### PR TITLE
Fix ComfyUI custom-node package import

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
-# Spectrum MiniMax H3 v0.1.0
+# Spectrum MiniMax H3 v0.1.1
 
-Initial alpha release of the standalone Spectrum-style acceleration node for ComfyUI's native MiniMax H3 audio-video model.
+Corrective release for the ComfyUI custom-node entry point.
+
+## Fixed
+
+- Load the bundled `comfyui_spectrum_h3` implementation through the custom-node package itself, matching ComfyUI's isolated directory loader.
+- Preserve direct source-checkout imports used by development and packaging checks.
+- Add a regression test that loads the node from an isolated, hyphenated custom-node directory without placing that directory on `sys.path`.
 
 ## Highlights
 
@@ -13,7 +19,7 @@ Initial alpha release of the standalone Spectrum-style acceleration node for Com
 ## Validation
 
 - GitHub Actions passes against native ComfyUI commit `e377e263049f9338b4d12a3dd417b36ae62948ff`.
-- 37 automated tests cover forecasting mathematics, scheduling, rollback, clone isolation, native-path equivalence, and zero transformer-block execution on forecast steps.
+- Automated tests cover forecasting mathematics, scheduling, rollback, clone isolation, the actual ComfyUI loader shape, native-path equivalence, and zero transformer-block execution on forecast steps.
 - CodeRabbit review feedback was evaluated and all review threads were resolved.
 
 ## Current limits

--- a/nodes.py
+++ b/nodes.py
@@ -1,8 +1,15 @@
-from comfyui_spectrum_h3.nodes import (
-    NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS,
-    SpectrumApplyMiniMaxH3,
-)
+if __package__:
+    from .comfyui_spectrum_h3.nodes import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+        SpectrumApplyMiniMaxH3,
+    )
+else:
+    from comfyui_spectrum_h3.nodes import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+        SpectrumApplyMiniMaxH3,
+    )
 
 __all__ = [
     "NODE_CLASS_MAPPINGS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-spectrum-minimax-h3"
-version = "0.1.0"
+version = "0.1.1"
 description = "Spectrum-style spectral feature forecasting for native ComfyUI MiniMax H3"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_comfyui_directory_loader_resolves_bundled_package(tmp_path):
+    repository = Path(__file__).resolve().parents[1]
+    custom_node = tmp_path / "comfyui-spectrum-minimax-h3"
+    bundled_package = custom_node / "comfyui_spectrum_h3"
+    bundled_package.mkdir(parents=True)
+
+    shutil.copy(repository / "__init__.py", custom_node / "__init__.py")
+    shutil.copy(repository / "nodes.py", custom_node / "nodes.py")
+    (bundled_package / "__init__.py").write_text("", encoding="utf-8")
+    (bundled_package / "nodes.py").write_text(
+        "class SpectrumApplyMiniMaxH3:\n"
+        "    pass\n"
+        "NODE_CLASS_MAPPINGS = {'SpectrumApplyMiniMaxH3': SpectrumApplyMiniMaxH3}\n"
+        "NODE_DISPLAY_NAME_MAPPINGS = {'SpectrumApplyMiniMaxH3': 'Spectrum Apply MiniMax H3'}\n",
+        encoding="utf-8",
+    )
+
+    loader_script = """
+import importlib.util
+import pathlib
+import sys
+
+module_path = pathlib.Path(sys.argv[1]).resolve()
+module_name = str(module_path).replace('.', '_x_')
+spec = importlib.util.spec_from_file_location(module_name, module_path / '__init__.py')
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)
+assert 'SpectrumApplyMiniMaxH3' in module.NODE_CLASS_MAPPINGS
+"""
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", loader_script, str(custom_node)],
+        cwd=tmp_path,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What changed

- resolve the bundled `comfyui_spectrum_h3` package through the custom-node package when loaded by ComfyUI
- retain the direct source-checkout import path used by development tooling
- add an isolated regression test matching ComfyUI's `spec_from_file_location` directory loader
- bump the corrective release to `v0.1.1`

## Root cause

ComfyUI loads each custom-node directory as an isolated package without adding that directory to `sys.path`. The root `nodes.py` shim used an absolute `comfyui_spectrum_h3` import, so the bundled package could not be resolved in a normal ComfyUI installation even though it was present in the release ZIP.

## Validation

- exact ComfyUI loader import from an isolated, hyphenated directory
- Ruff clean
- `38 passed` against attached native ComfyUI H3 source
- wheel built successfully
- exact `v0.1.1` release archive extracted and loaded successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed custom-node loading in ComfyUI environments.
  - Restored reliable imports when running directly from a source checkout.
  - Resolved a loader regression so the Spectrum Apply node is recognized correctly.

- **Tests**
  - Added automated coverage for isolated custom-node loading and node registration.

- **Documentation**
  - Updated release notes with details for the v0.1.1 corrective release.

- **Chores**
  - Incremented the application version to v0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->