### PR TITLE
Add RES multistep sampler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,12 @@ Forecasting is currently allowlisted for:
 
 - Euler (`sample_euler`)
 - Euler ancestral (`sample_euler_ancestral`, including ComfyUI's flow-model path)
+- RES multistep (`sample_res_multistep`)
+- RES multistep CFG++ (`sample_res_multistep_cfg_pp`)
+- RES multistep ancestral (`sample_res_multistep_ancestral`)
+- RES multistep ancestral CFG++ (`sample_res_multistep_ancestral_cfg_pp`)
 
-The reviewed implementations make one `predict_noise` call per solver iteration. Other samplers execute native MiniMax H3. Debug mode logs the exact fallback reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
+The reviewed implementations make one `predict_noise` call per solver iteration. RES multistep reuses the previous denoised result in its solver update without making an additional model call. Other samplers execute native MiniMax H3. Debug mode logs the exact fallback reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
 
 ## Memory design
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,18 @@
-# Spectrum MiniMax H3 v0.1.1
+# Spectrum MiniMax H3 v0.1.2
 
-Corrective release for the ComfyUI custom-node entry point.
+Adds Spectrum forecasting support for ComfyUI's RES multistep sampler family.
 
-## Fixed
+## Added
 
-- Load the bundled `comfyui_spectrum_h3` implementation through the custom-node package itself, matching ComfyUI's isolated directory loader.
-- Preserve direct source-checkout imports used by development and packaging checks.
-- Add a regression test that loads the node from an isolated, hyphenated custom-node directory without placing that directory on `sys.path`.
+- Support `sample_res_multistep`.
+- Support the CFG++, ancestral, and ancestral CFG++ RES multistep variants.
+- Cover the sampler allowlist with focused regression tests.
 
 ## Highlights
 
 - Forecasts selected post-transformer H3 features while preserving the native current-step output heads, reconstruction, sigma mapping, and return structure.
 - Keeps runtime and history state isolated per model clone and rolls incomplete split-branch transactions back to a complete native step.
-- Supports native Euler and Euler ancestral sampling, with explicit native fallback for unsupported samplers, incompatible topology, invalid forecasts, and multi-GPU parallel sampling.
+- Supports native Euler, Euler ancestral, and RES multistep sampling, with explicit native fallback for unsupported samplers, incompatible topology, invalid forecasts, and multi-GPU parallel sampling.
 - Bounds retained history on CPU and streams forecast accumulation in chunks to avoid persistent full-feature FP32 coefficient or right-hand-side tensors.
 - Leaves the separate FLUX-focused ComfyUI-Spectrum-Proper repository unchanged.
 

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -17,7 +17,16 @@ ACTUAL_KEY = "spectrum_h3_actual"
 REASON_KEY = "spectrum_h3_reason"
 WRAPPER_KEY = "spectrum_minimax_h3"
 
-SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset({"sample_euler", "sample_euler_ancestral"})
+SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset(
+    {
+        "sample_euler",
+        "sample_euler_ancestral",
+        "sample_res_multistep",
+        "sample_res_multistep_cfg_pp",
+        "sample_res_multistep_ancestral",
+        "sample_res_multistep_ancestral_cfg_pp",
+    }
+)
 
 
 @dataclass(slots=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-spectrum-minimax-h3"
-version = "0.1.1"
+version = "0.1.2"
 description = "Spectrum-style spectral feature forecasting for native ComfyUI MiniMax H3"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_sampler_contract.py
+++ b/tests/test_sampler_contract.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+RES_VARIANTS = (
+    "sample_res_multistep",
+    "sample_res_multistep_cfg_pp",
+    "sample_res_multistep_ancestral",
+    "sample_res_multistep_ancestral_cfg_pp",
+)
+
+
+def _native_sampling_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    comfyui_path = os.environ.get("COMFYUI_PATH")
+    if not comfyui_path:
+        pytest.skip("COMFYUI_PATH is required for native sampler contract tests")
+    source_path = Path(comfyui_path) / "comfy" / "k_diffusion" / "sampling.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _named_calls(node: ast.AST, name: str) -> list[ast.Call]:
+    return [
+        call
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == name
+    ]
+
+
+def test_native_res_multistep_makes_one_model_call_per_solver_iteration():
+    function = _native_sampling_functions()["res_multistep"]
+    loops = [node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor))]
+
+    assert len(loops) == 1
+    assert len(_named_calls(loops[0], "model")) == 1
+    assert len(_named_calls(function, "model")) == 1
+
+
+@pytest.mark.parametrize("function_name", RES_VARIANTS)
+def test_native_res_variant_delegates_once_to_reviewed_core(function_name):
+    function = _native_sampling_functions()[function_name]
+
+    assert len(_named_calls(function, "res_multistep")) == 1
+    assert not _named_calls(function, "model")

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from comfyui_spectrum_h3.sampling import sampler_is_supported, sampler_name
+
+
+def _sampler(function_name: str) -> SimpleNamespace:
+    def sampler_function():
+        pass
+
+    sampler_function.__name__ = function_name
+    return SimpleNamespace(sampler_function=sampler_function)
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    (
+        "sample_euler",
+        "sample_euler_ancestral",
+        "sample_res_multistep",
+        "sample_res_multistep_cfg_pp",
+        "sample_res_multistep_ancestral",
+        "sample_res_multistep_ancestral_cfg_pp",
+    ),
+)
+def test_reviewed_single_call_samplers_are_supported(function_name):
+    sampler = _sampler(function_name)
+
+    assert sampler_name(sampler) == function_name
+    assert sampler_is_supported(sampler)
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    (
+        "res_multistep",
+        "sample_res_multistep_experimental",
+        "sample_heun",
+    ),
+)
+def test_unreviewed_sampler_names_do_not_match_by_prefix(function_name):
+    assert not sampler_is_supported(_sampler(function_name))


### PR DESCRIPTION
## What changed

- Allow Spectrum solver-step tracking for `sample_res_multistep` and its CFG++, ancestral, and ancestral CFG++ variants.
- Document the supported RES sampler family.
- Add focused allowlist tests and a native-source contract test proving the reviewed RES core makes one model call per sigma interval.
- Bump the package and release metadata to `0.1.2`.

## Root cause

Spectrum rejected `sample_res_multistep` solely because the sampler was absent from the audited one-call allowlist. The reviewed ComfyUI implementation performs one `model(...)` call per solver iteration and reuses the previous denoised result algebraically for its multistep update, so it satisfies Spectrum's existing transaction model.

## Validation

- Ruff clean
- Forecaster smoke test passed
- `52 passed` against the attached native ComfyUI source matching commit `e377e263049f9338b4d12a3dd417b36ae62948ff`
- Wheel build succeeded and contains the updated integration

Full-checkpoint output quality, audiovisual synchronization, memory, and end-to-end performance remain unverified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for four ComfyUI RES multistep samplers, including CFG++ and ancestral variants.
  * Expanded native fallback support for additional sampler scenarios.

* **Documentation**
  * Documented RES multistep sampler behavior and updated release information for version 0.1.2.

* **Tests**
  * Added coverage validating supported sampler names and RES multistep model-call behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->