### PR TITLE
Add optional VRAM history storage

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -47,10 +47,10 @@ Coordinates are derived from the actual supplied sigma sequence. Evaluated sigma
 
 ## Forecast memory model
 
-The forecaster stores at most `max_history` detached model-dtype snapshots on CPU. It solves only for history weights:
+The forecaster stores at most `max_history` detached model-dtype snapshots in the configured history storage: system RAM by default, or the producing model device when the opt-in VRAM mode is selected. It solves only for history weights:
 
 `w(t*) = phi(t*) (Phi^T Phi + lambda I)^-1 Phi^T`
 
 Spectral and two-point linear weights are combined before feature streaming. Prediction reads one bounded chunk from one history snapshot at a time, accumulates that chunk in FP32 on the output device, and writes the final model-dtype feature. No persistent full-feature FP32 right-hand side or coefficient tensor is created.
 
-Native H3 lays out target rows as one contiguous `[audio | video]` packed tail. Actual capture archives a view of that tail instead of materializing a same-size GPU concatenation. When one model call contains the complete canonical branch set, the archived tensor is transferred directly into forecaster history; split conditional calls retain the transactional canonicalization path and assemble rows only after all calls complete. Debug summaries expose wall-clock archive, history-update, and forecast-prediction counters. Because the device-to-host archive synchronizes outstanding CUDA work, archive time can include the wait for preceding transformer kernels.
+Native H3 lays out target rows as one contiguous `[audio | video]` packed tail. Actual capture archives that tail without materializing an audio/video concatenation. System-RAM mode copies the view directly to CPU. VRAM mode must clone it into compact owned device storage, because retaining the view would pin the complete final-block hidden tensor. When one model call contains the complete canonical branch set, the archived tensor transfers directly into forecaster history; split conditional calls retain the transactional canonicalization path and assemble rows only after all calls complete. Debug summaries expose the storage location and wall-clock archive, history-update, and forecast-prediction counters. Device-to-host archiving can synchronize outstanding CUDA work, while device cloning can be asynchronously enqueued.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ The node accepts and returns `MODEL`. Disabled mode returns the original model o
 | `flex_window` | `0.75` | Amount added to the interval after a scheduled post-warmup actual step. |
 | `warmup_steps` | `5` | Initial solver steps forced to native transformer evaluation. |
 | `tail_actual_steps` | `1` | Requested final native tail. Deterministic RES enforces a sampler-safe minimum of `3`. |
-| `max_history` | `8` | Maximum model-dtype actual feature snapshots retained on CPU. |
+| `max_history` | `8` | Maximum model-dtype actual feature snapshots retained. |
 | `debug` | `false` | Enables concise run, step, topology, fallback, sanitization, chunk, and teardown logs. |
+| `history_storage` | `system_ram` | Stores history in `system_ram`, or in `vram` to avoid transfer overhead when sufficient accelerator memory is free. |
 
 Every value is validated. `max_history` must be at least `degree + 1`.
 
@@ -73,6 +74,7 @@ flex_window = 0.75
 warmup_steps = 5
 tail_actual_steps = 1
 max_history = 8
+history_storage = system_ram
 ```
 
 ### Provisional aggressive preset
@@ -86,6 +88,7 @@ flex_window = 3.0
 warmup_steps = 5
 tail_actual_steps = 1
 max_history = 8
+history_storage = system_ram
 ```
 
 Both presets remain provisional pending broader prompt, sampler, and quality coverage.
@@ -128,18 +131,22 @@ w(t*) = phi(t*) (Phi^T Phi + lambda I)^-1 Phi^T
 H_hat(t*) = w(t*) H
 ```
 
-Spectral and linear history weights are combined before reading feature history. Persistent large tensors are limited to `max_history` detached model-dtype snapshots on CPU. Design, Gram, Cholesky, and history-weight tensors are small FP32 matrices. Prediction streams one bounded slice from one history snapshot at a time, accumulates that slice in FP32 on the prediction device, then writes model dtype. There is no persistent full-feature FP32 regression right-hand side or coefficient tensor.
+Spectral and linear history weights are combined before reading feature history. Persistent large tensors are limited to `max_history` detached model-dtype snapshots in the selected `history_storage`. Design, Gram, Cholesky, and history-weight tensors remain small FP32 CPU matrices. Prediction streams one bounded slice from one history snapshot at a time, accumulates that slice in FP32 on the prediction device, then writes model dtype. There is no persistent full-feature FP32 regression right-hand side or coefficient tensor.
 
-CPU history cost is approximately:
+History storage cost is approximately:
 
 ```text
 branch_count * max_history * (target_audio_rows + target_video_rows)
 * hidden_width * model_dtype_bytes
 ```
 
-At the native 1344x768, 124-frame example, the reviewed layout has about 37,710 target rows. With hidden width 5,376 and BF16/FP16 history, one snapshot is roughly 387 MiB per branch. Eight conditional/unconditional snapshots can therefore approach 6.1 GiB of CPU RAM. Reference tokens do not enter the cached target, while longer duration and larger target geometry increase the cost. Lower `max_history` is valid only while it remains at least `degree + 1`.
+At the native 1344x768, 124-frame example, the reviewed layout has about 37,710 target rows. With hidden width 5,376 and BF16/FP16 history, one snapshot is roughly 387 MiB per branch. Eight conditional/unconditional snapshots can therefore approach 6.1 GiB in the selected storage. Reference tokens do not enter the cached target, while longer duration and larger target geometry increase the cost. Lower `max_history` is valid only while it remains at least `degree + 1`.
 
-Forecast VRAM includes one model-dtype target feature for the current model call plus a bounded FP32 accumulation chunk. Cached history does not remain on the GPU. Actual-step device-to-CPU history transfers can reduce the theoretical speedup. The native single-call path archives the already-contiguous audio/video target view directly and transfers ownership of that snapshot into history without assembling a second full CPU tensor. Debug run summaries report archive, history-update, and forecast-prediction wall time separately; CUDA synchronization can be charged to the archive counter, so these counters diagnose the runtime path rather than serving as isolated kernel benchmarks.
+With `history_storage=system_ram`, forecast VRAM includes one model-dtype target feature for the current model call plus a bounded FP32 accumulation chunk. Actual steps copy each new snapshot to CPU, and forecasts stream the retained snapshots back to the prediction device. These transfers can reduce the theoretical speedup.
+
+With `history_storage=vram`, the same model-dtype history remains on the device that produced it. This avoids the device-to-host archive and repeated host-to-device forecast reads. The captured target is cloned into compact owned storage; retaining its native view would keep the complete final-block hidden tensor alive. The mode needs the full history allocation plus transient headroom for the current snapshot, prediction result, FP32 chunk, allocator fragmentation, and native H3 execution. At the native example above, use it only with materially more than 6.1 GiB of VRAM free at the native generation peak. An explicit VRAM selection can raise an out-of-memory error when that headroom is unavailable.
+
+Debug run summaries report the selected storage and resolved history device together with archive, history-update, and forecast-prediction wall time. CPU archiving can synchronize preceding CUDA work, while GPU cloning can be asynchronously enqueued, so the component counters diagnose the runtime path rather than serving as isolated kernel benchmarks. End-to-end wall time and peak allocated VRAM are the authoritative comparison.
 
 ## Fallback and transaction behavior
 

--- a/README.md
+++ b/README.md
@@ -140,13 +140,26 @@ branch_count * max_history * (target_audio_rows + target_video_rows)
 * hidden_width * model_dtype_bytes
 ```
 
-At the native 1344x768, 124-frame example, the reviewed layout has about 37,710 target rows. With hidden width 5,376 and BF16/FP16 history, one snapshot is roughly 387 MiB per branch. Eight conditional/unconditional snapshots can therefore approach 6.1 GiB in the selected storage. Reference tokens do not enter the cached target, while longer duration and larger target geometry increase the cost. Lower `max_history` is valid only while it remains at least `degree + 1`.
+In the supplied 0.5 MP workflow, the effective single-branch topology had 27,075-27,702 target rows, hidden width 5,376, and 16-bit history. At `max_history=8`, it retained 2,273.5-2,324.9 MiB (about 2.22-2.27 GiB). A two-branch topology at the same shape would use roughly twice that amount. At the native 1344x768, 124-frame example, the reviewed layout has about 37,710 target rows; eight conditional/unconditional snapshots can approach 6.1 GiB. Reference tokens do not enter the cached target, while longer duration and larger target geometry increase the cost. Lower `max_history` is valid only while it remains at least `degree + 1`.
 
 With `history_storage=system_ram`, forecast VRAM includes one model-dtype target feature for the current model call plus a bounded FP32 accumulation chunk. Actual steps copy each new snapshot to CPU, and forecasts stream the retained snapshots back to the prediction device. These transfers can reduce the theoretical speedup.
 
 With `history_storage=vram`, the same model-dtype history remains on the device that produced it. This avoids the device-to-host archive and repeated host-to-device forecast reads. The captured target is cloned into compact owned storage; retaining its native view would keep the complete final-block hidden tensor alive. The mode needs the full history allocation plus transient headroom for the current snapshot, prediction result, FP32 chunk, allocator fragmentation, and native H3 execution. At the native example above, use it only with materially more than 6.1 GiB of VRAM free at the native generation peak. An explicit VRAM selection can raise an out-of-memory error when that headroom is unavailable.
 
 Debug run summaries report the selected storage and resolved history device together with archive, history-update, and forecast-prediction wall time. CPU archiving can synchronize preceding CUDA work, while GPU cloning can be asynchronously enqueued, so the component counters diagnose the runtime path rather than serving as isolated kernel benchmarks. End-to-end wall time and peak allocated VRAM are the authoritative comparison.
+
+### Measured VRAM-history results
+
+Three supplied full-checkpoint, 20-step Euler A/B pairs at approximately 0.5 MP compared otherwise identical `system_ram` and `vram` runs:
+
+| Pair | System RAM | VRAM | VRAM difference |
+|---|---:|---:|---:|
+| 1 | 112.43 s | 105.55 s | -6.1% |
+| 2 | 115.60 s | 116.08 s | +0.4% |
+| 3 | 109.80 s | 107.26 s | -2.3% |
+| Mean | 112.61 s | 109.63 s | -2.6% |
+
+The VRAM runs used about 2.22-2.27 GiB more peak memory, matching the retained history reported by Spectrum. The timing benefit was small and variable, so VRAM history should be treated as an optional optimization for systems with spare VRAM rather than a guaranteed speedup. OS-level GPU monitors can hide the live-allocation increase when PyTorch satisfies it from an already-reserved CUDA memory pool.
 
 ## Fallback and transaction behavior
 
@@ -171,7 +184,7 @@ Automated tests cover:
 - exact native versus wrapped forced-actual video/audio output on a deterministic tiny native H3 fixture;
 - proof that a forecast fixture invokes zero H3 transformer blocks.
 
-No full MiniMax H3 checkpoint is available in the automated environment. Real text-to-video/audio generation, reference modes, long-duration memory behavior, wall-clock speedup, VRAM/RSS peaks, decoded video metrics, audio metrics, and audiovisual synchronization remain unverified by the automated suite. No claim of lossless quality is made.
+No full MiniMax H3 checkpoint is available in the automated environment. The supplied real-checkpoint A/B runs validate the 0.5 MP VRAM allocation and show a small, variable timing benefit. Other resolutions, durations, CFG topologies, reference modes, hardware, decoded video metrics, audio metrics, and audiovisual synchronization remain unverified. No claim of lossless quality is made.
 
 ## Tests
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,42 +1,31 @@
-# Spectrum MiniMax H3 v0.1.3
+# Spectrum MiniMax H3 v0.1.4
 
-Stabilizes deterministic Euler and RES multistep audio-video forecasting and adds Comfy Registry publishing metadata.
+Adds optional device-resident history storage for systems with spare VRAM.
 
-## Changed
+## Added
 
-- Require one completed actual H3 evaluation after every RES multistep forecast so its retained `old_denoised` state is native before forecasting resumes.
-- Enforce a three-step actual tail for deterministic RES, including saved workflows that request a smaller tail.
-- Require one completed actual H3 evaluation after every Euler forecast to prevent late forecast streaks from accumulating temporal audio/video errors on short schedules.
-- Keep ancestral Euler and RES variants on the native path because their injected noise breaks the forecaster's smooth deterministic trajectory assumption.
-- Keep `tail_actual_steps=1` as the configurable Euler default while applying the sampler-specific RES floor internally.
-- Add the xmarre Comfy Registry publisher metadata and publishing workflow.
+- Add `history_storage=system_ram|vram` to the Spectrum node, defaulting to the existing system-RAM behavior.
+- Keep model-dtype history on the producing device in VRAM mode, avoiding actual-step device-to-host copies and repeated forecast-time host-to-device reads.
+- Clone the target view into compact owned device storage so cached history does not retain the complete final-block hidden tensor.
+- Report the configured storage and resolved history device in debug summaries.
 
 ## Highlights
 
-- Forecasts selected post-transformer H3 features while preserving the native current-step output heads, reconstruction, sigma mapping, and return structure.
-- Keeps runtime and history state isolated per model clone and rolls incomplete split-branch transactions back to a complete native step.
-- Supports deterministic Euler and RES multistep sampling with sampler-specific post-forecast refresh and tail policies, plus explicit native fallback for stochastic samplers, unsupported samplers, incompatible topology, invalid forecasts, and multi-GPU parallel sampling.
-- Bounds retained history on CPU and streams forecast accumulation in chunks to avoid persistent full-feature FP32 coefficient or right-hand-side tensors.
-- Avoids redundant full-target GPU concatenation and CPU restacking on native single-call actual steps, and reports history/forecast timing counters in debug summaries.
-- Leaves the separate FLUX-focused ComfyUI-Spectrum-Proper repository unchanged.
+- System-RAM mode remains the default and preserves existing saved-workflow behavior.
+- VRAM mode preserves the forecasting math, model dtype, FP32 accumulation order, scheduler, and fallback semantics.
+- History is still bounded by `max_history` and released at run teardown.
 
-## Measured 0.5 MP results
+## Memory guidance
 
-Supplied full-checkpoint, 20-step runs:
-
-| Sampler | Native | Spectrum | Schedule | Time saved | Wall-time reduction | Speedup |
-|---|---:|---:|---:|---:|---:|---:|
-| RES multistep | `2:42` | `1:54` | 14 actual / 6 forecast | `48 s` | `29.6%` | `1.42x` |
-| Euler | `2:38` | `1:59` | 13 actual / 7 forecast | `39 s` | `24.7%` | `1.33x` |
-
-The tested Euler artifacts appeared fixed. The remaining slight RES artifacts appeared gone after enforcing the three-step actual tail.
+- At the supplied 0.5 MP layout, one two-branch history point is about 568 MiB: roughly 2.78 GiB at `max_history=5` or 4.44 GiB at `max_history=8`.
+- At the native 1344x768, 124-frame example, eight two-branch snapshots approach 6.1 GiB.
+- VRAM mode also needs headroom for native model execution, the current snapshot, the prediction result, an FP32 accumulation chunk, and allocator fragmentation.
 
 ## Validation
 
-- The local suite passes against native ComfyUI commit `e377e263049f9338b4d12a3dd417b36ae62948ff`.
-- Automated tests cover forecasting mathematics, scheduling, rollback, clone isolation, the actual ComfyUI loader shape, native-path equivalence, and zero transformer-block execution on forecast steps.
-- Sampler contract tests verify one model call per deterministic solver step, RES's current/previous-denoised recurrence and update ordering, ancestral noise injection, rollback-safe refresh state, and sampler-specific forecast spacing and tails.
+- Automated tests cover setting validation, default compatibility, compact owned storage, storage-device tracking, and CPU/CUDA prediction equivalence.
+- Existing native-path equivalence, transaction, sampler-contract, scheduler, and bounded-memory tests remain in place.
 
 ## Current limits
 
-The automated environment cannot decode a full MiniMax H3 generation. Broader prompts, durations, resolutions, CFG settings, reference modes, memory peaks, and audiovisual synchronization remain real-generation validation items. Timings can vary with model warmup and GPU state.
+End-to-end speedup and real-checkpoint peak VRAM remain hardware-dependent validation items. Selecting VRAM storage with insufficient headroom can raise an out-of-memory error.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,9 +17,13 @@ Adds optional device-resident history storage for systems with spare VRAM.
 
 ## Memory guidance
 
-- At the supplied 0.5 MP layout, one two-branch history point is about 568 MiB: roughly 2.78 GiB at `max_history=5` or 4.44 GiB at `max_history=8`.
+- The supplied 0.5 MP single-branch workflow retained about 2.22-2.27 GiB at `max_history=8`; a two-branch topology at the same shape would use roughly twice that amount.
 - At the native 1344x768, 124-frame example, eight two-branch snapshots approach 6.1 GiB.
 - VRAM mode also needs headroom for native model execution, the current snapshot, the prediction result, an FP32 accumulation chunk, and allocator fragmentation.
+
+## Measured 0.5 MP A/B results
+
+Three supplied full-checkpoint Euler pairs measured total times of 112.43/105.55 s, 115.60/116.08 s, and 109.80/107.26 s for system RAM/VRAM respectively. The combined means were 112.61 s and 109.63 s, a 2.6% advantage for VRAM mode. Individual pairs ranged from 6.1% faster to 0.4% slower, so the performance benefit is workload- and system-dependent.
 
 ## Validation
 
@@ -28,4 +32,4 @@ Adds optional device-resident history storage for systems with spare VRAM.
 
 ## Current limits
 
-End-to-end speedup and real-checkpoint peak VRAM remain hardware-dependent validation items. Selecting VRAM storage with insufficient headroom can raise an out-of-memory error.
+The supplied 0.5 MP tests verify the expected additional allocation and show a small, variable timing benefit. Other resolutions, durations, CFG topologies, reference modes, and hardware remain unverified. Selecting VRAM storage with insufficient headroom can raise an out-of-memory error.

--- a/comfyui_spectrum_h3/config.py
+++ b/comfyui_spectrum_h3/config.py
@@ -15,6 +15,7 @@ class SpectrumH3Config:
     warmup_steps: int = 5
     tail_actual_steps: int = 1
     max_history: int = 8
+    history_storage: str = "system_ram"
     debug: bool = False
     force_actual: bool = False
 
@@ -59,6 +60,11 @@ class SpectrumH3Config:
             raise ValueError(
                 f"max_history must be an integer >= {self.min_fit_points} for degree {self.degree}"
             )
+        if not isinstance(self.history_storage, str) or self.history_storage not in {
+            "system_ram",
+            "vram",
+        }:
+            raise ValueError("history_storage must be 'system_ram' or 'vram'")
         return self
 
 

--- a/comfyui_spectrum_h3/forecast.py
+++ b/comfyui_spectrum_h3/forecast.py
@@ -15,8 +15,9 @@ class _HistoryEntry:
 class HistoryWeightForecaster:
     """Chebyshev ridge forecasting without full-feature FP32 coefficients.
 
-    Persistent large tensors are model-dtype CPU history snapshots. Regression
-    work is limited to K x (M + 1) design data and a (M + 1)^2 factorization.
+    Persistent large tensors are model-dtype history snapshots on the configured
+    storage device. Regression work is limited to K x (M + 1) design data and a
+    (M + 1)^2 factorization.
     """
 
     def __init__(
@@ -25,11 +26,13 @@ class HistoryWeightForecaster:
         ridge_lambda: float = 0.1,
         max_history: int = 8,
         chunk_bytes: int = 32 * 1024 * 1024,
+        history_storage: str = "system_ram",
     ) -> None:
         self.degree = int(degree)
         self.ridge_lambda = float(ridge_lambda)
         self.max_history = int(max_history)
         self.chunk_bytes = int(chunk_bytes)
+        self.history_storage = str(history_storage)
         if self.degree < 1:
             raise ValueError("degree must be >= 1")
         if self.ridge_lambda < 0.0:
@@ -38,12 +41,15 @@ class HistoryWeightForecaster:
             raise ValueError("max_history is too small for the requested polynomial degree")
         if self.chunk_bytes < 4096:
             raise ValueError("chunk_bytes must be >= 4096")
+        if self.history_storage not in {"system_ram", "vram"}:
+            raise ValueError("history_storage must be 'system_ram' or 'vram'")
         self.reset()
 
     def reset(self) -> None:
         self._history: list[_HistoryEntry] = []
         self._feature_shape: tuple[int, ...] | None = None
         self._feature_dtype: torch.dtype | None = None
+        self._history_device: torch.device | None = None
         self._generation = 0
         self._factor_generation = -1
         self._design: torch.Tensor | None = None
@@ -64,6 +70,10 @@ class HistoryWeightForecaster:
     @property
     def feature_dtype(self) -> torch.dtype | None:
         return self._feature_dtype
+
+    @property
+    def history_device(self) -> torch.device | None:
+        return self._history_device
 
     @property
     def factorization_count(self) -> int:
@@ -112,10 +122,20 @@ class HistoryWeightForecaster:
             raise ValueError(f"feature dtype changed from {self._feature_dtype} to {feature.dtype}")
 
         detached = feature.detach()
-        if take_ownership and detached.device.type == "cpu" and detached.is_contiguous():
+        storage_device = torch.device("cpu") if self.history_storage == "system_ram" else detached.device
+        if self._history_device is None:
+            self._history_device = storage_device
+        elif storage_device != self._history_device:
+            raise ValueError(f"history device changed from {self._history_device} to {storage_device}")
+
+        if take_ownership and detached.device == storage_device and detached.is_contiguous():
             archived = detached.reshape(-1)
         else:
-            archived = detached.to(device="cpu", dtype=self._feature_dtype, copy=True).contiguous().reshape(-1)
+            archived = (
+                detached.to(device=storage_device, dtype=self._feature_dtype, copy=True)
+                .contiguous()
+                .reshape(-1)
+            )
         self._history.append(_HistoryEntry(float(coordinate), archived))
         if len(self._history) > self.max_history:
             self._history.pop(0)

--- a/comfyui_spectrum_h3/nodes.py
+++ b/comfyui_spectrum_h3/nodes.py
@@ -22,7 +22,10 @@ class SpectrumApplyMiniMaxH3:
                 "tail_actual_steps": ("INT", {"default": 1, "min": 0, "max": 64, "step": 1}),
                 "max_history": ("INT", {"default": 8, "min": 2, "max": 64, "step": 1}),
                 "debug": ("BOOLEAN", {"default": False}),
-            }
+            },
+            "optional": {
+                "history_storage": (["system_ram", "vram"], {"default": "system_ram"}),
+            },
         }
 
     RETURN_TYPES = ("MODEL",)
@@ -43,6 +46,7 @@ class SpectrumApplyMiniMaxH3:
         tail_actual_steps,
         max_history,
         debug,
+        history_storage="system_ram",
     ):
         if not enabled:
             return (model,)
@@ -57,6 +61,7 @@ class SpectrumApplyMiniMaxH3:
             warmup_steps=int(warmup_steps),
             tail_actual_steps=int(tail_actual_steps),
             max_history=int(max_history),
+            history_storage=str(history_storage),
             debug=bool(debug),
         ).validate()
         patched = model.clone()

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -86,6 +86,7 @@ class SpectrumH3Runtime:
             degree=self.config.degree,
             ridge_lambda=self.config.ridge_lambda,
             max_history=self.config.max_history,
+            history_storage=self.config.history_storage,
         )
         self.stats = RuntimeStats(current_window=self.config.window_size)
         self._run_counter = 0
@@ -340,7 +341,14 @@ class SpectrumH3Runtime:
             )
         started = time.perf_counter()
         try:
-            archived = feature.detach().to(device="cpu", dtype=feature.dtype, copy=True).contiguous()
+            detached = feature.detach()
+            if self.config.history_storage == "vram":
+                # The observed target is a view into the complete final-block
+                # hidden state. A forced clone keeps only the compact target
+                # storage alive and prevents later reuse of the backing tensor.
+                archived = detached.clone(memory_format=torch.contiguous_format)
+            else:
+                archived = detached.to(device="cpu", dtype=feature.dtype, copy=True).contiguous()
         finally:
             self.stats.history_archive_seconds += time.perf_counter() - started
         call.observed_actual = True
@@ -532,6 +540,8 @@ class SpectrumH3Runtime:
             f"history_update_s={self.stats.history_update_seconds:.3f} "
             f"forecast_predict_s={self.stats.forecast_prediction_seconds:.3f} "
             f"direct_history_updates={self.stats.direct_history_updates} "
+            f"history_storage={self.config.history_storage} "
+            f"history_device={str(self.forecaster.history_device)!r} "
             f"history_mib={self.forecaster.history_tensor_bytes / (1024 * 1024):.1f} "
             f"reason={self.stats.disable_reason!r}"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.1.3"
+version = "0.1.4"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,3 +17,8 @@ from comfyui_spectrum_h3.config import SpectrumH3Config
 def test_count_fields_reject_fractional_values(field, value):
     with pytest.raises(ValueError, match="integer"):
         SpectrumH3Config(**{field: value}).validate()
+
+
+def test_history_storage_rejects_unknown_locations():
+    with pytest.raises(ValueError, match="history_storage"):
+        SpectrumH3Config(history_storage="automatic").validate()

--- a/tests/test_forecast_equivalence.py
+++ b/tests/test_forecast_equivalence.py
@@ -97,3 +97,50 @@ def test_persistent_storage_has_no_full_fp32_rhs_or_coefficients():
     assert forecaster.persistent_tensor_bytes <= forecaster.history_tensor_bytes + small_matrix_ceiling
     assert not hasattr(forecaster, "_rhs")
     assert not hasattr(forecaster, "_coeff")
+
+
+def test_vram_storage_uses_the_feature_device_and_can_take_ownership():
+    forecaster = HistoryWeightForecaster(
+        degree=1,
+        ridge_lambda=0.1,
+        max_history=2,
+        history_storage="vram",
+    )
+    first = torch.zeros(1, 2, 3).contiguous()
+    forecaster.update(-1.0, first, take_ownership=True)
+    forecaster.update(0.0, torch.ones(1, 2, 3).contiguous(), take_ownership=True)
+
+    assert forecaster.history_device == first.device
+    assert forecaster._history[0].feature_flat.data_ptr() == first.data_ptr()
+    assert torch.isfinite(forecaster.predict(0.5, blend_weight=0.5)).all()
+
+
+def test_vram_storage_rejects_a_device_change_within_history():
+    forecaster = HistoryWeightForecaster(
+        degree=1,
+        ridge_lambda=0.1,
+        max_history=2,
+        history_storage="vram",
+    )
+    forecaster.update(-1.0, torch.zeros(1, 2, 3), take_ownership=True)
+
+    with pytest.raises(ValueError, match="history device changed"):
+        forecaster.update(0.0, torch.empty(1, 2, 3, device="meta"), take_ownership=True)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_vram_and_system_ram_predictions_match_on_cuda():
+    torch.manual_seed(31)
+    features = [torch.randn(2, 7, 11, device="cuda", dtype=torch.float16) for _ in range(3)]
+    system_ram = HistoryWeightForecaster(degree=2, max_history=3, history_storage="system_ram")
+    vram = HistoryWeightForecaster(degree=2, max_history=3, history_storage="vram")
+    for coordinate, feature in zip((-1.0, -0.25, 0.5), features, strict=True):
+        system_ram.update(coordinate, feature)
+        vram.update(coordinate, feature)
+
+    cpu_cached = system_ram.predict(0.75, blend_weight=0.5, device="cuda", dtype=torch.float16)
+    gpu_cached = vram.predict(0.75, blend_weight=0.5, device="cuda", dtype=torch.float16)
+    torch.testing.assert_close(gpu_cached, cpu_cached, rtol=0.0, atol=0.0)
+    assert system_ram.history_device == torch.device("cpu")
+    assert vram.history_device is not None
+    assert vram.history_device.type == "cuda"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -61,6 +61,7 @@ def _forecast_step(runtime, timestep, labels=LABEL):
 
 def test_default_tail_actual_steps_is_one():
     assert SpectrumH3Config().tail_actual_steps == 1
+    assert SpectrumH3Config().history_storage == "system_ram"
 
 
 def test_scheduler_counts_warmup_forecasts_recomputes_and_window_growth():
@@ -123,6 +124,31 @@ def test_single_call_actual_history_takes_ownership_without_restaking_rows():
     assert runtime.stats.direct_history_updates == 1
     assert runtime.forecaster._history[-1].feature_flat.data_ptr() == archived_ptr
     torch.testing.assert_close(runtime.forecaster._history[-1].feature_flat.reshape_as(feature), feature)
+
+
+def test_vram_archive_is_compact_owned_storage():
+    runtime = _runtime(force_actual=True, history_storage="vram")
+    runtime.start_run(torch.linspace(1.0, 0.0, 3), "sample_euler", supported_sampler=True)
+    decision = runtime.begin_step(torch.tensor([1.0]))
+    backing = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    feature = backing[1:].unsqueeze(0).reshape(1, 3, 4)
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=TOPOLOGY,
+        labels=LABEL,
+        expected_shape=tuple(feature.shape),
+    )
+    assert actual
+    expected = feature.clone()
+    runtime.observe_actual(decision["run_id"], decision["step_id"], call_id, feature)
+    archived = runtime._step.actual_records[0].feature
+    backing.fill_(-1.0)
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    assert archived.data_ptr() != feature.data_ptr()
+    assert archived.untyped_storage().nbytes() == archived.numel() * archived.element_size()
+    torch.testing.assert_close(runtime.forecaster._history[-1].feature_flat.reshape_as(expected), expected)
 
 
 def test_split_call_actual_history_still_canonicalizes_rows():


### PR DESCRIPTION
## Summary

- add optional `history_storage=system_ram|vram`, with `system_ram` as the backward-compatible default
- retain compact model-dtype history on the producing device in VRAM mode
- avoid pinning the complete final-block hidden tensor by cloning only the packed target tail
- enforce a stable history device per run and expose storage/device diagnostics
- prepare v0.1.4 metadata, tests, README guidance, and release notes

## Runtime behavior

`system_ram` preserves the existing archive and prediction path. `vram` keeps bounded history on the model device and avoids actual-step device-to-host copies plus forecast-time host-to-device reads. Forecasting math, history order, FP32 accumulation order, scheduler behavior, fallback behavior, and teardown remain unchanged.

## Measured 0.5 MP results

The supplied single-branch workflow retained 2,273.5-2,324.9 MiB at `max_history=8`, matching the measured ~2.22-2.27 GiB increase in peak VRAM.

| Pair | System RAM | VRAM | VRAM difference |
|---|---:|---:|---:|
| 1 | 112.43 s | 105.55 s | -6.1% |
| 2 | 115.60 s | 116.08 s | +0.4% |
| 3 | 109.80 s | 107.26 s | -2.3% |
| Mean | 112.61 s | 109.63 s | -2.6% |

The timing benefit is small and variable. VRAM history is an optional optimization for systems with spare memory, not a guaranteed speedup. Two-branch layouts at the same shape use roughly twice the retained-history memory; the reviewed native 1344x768, 124-frame two-branch example approaches 6.1 GiB.

## Validation

- 76 tests passed locally; one CUDA-only exact-equivalence case was skipped on the CPU runner
- GitHub Actions passed for the implementation commit
- forecaster smoke test passed
- Ruff substantive checks passed
- v0.1.4 wheel and sdist built with the expected package contents
- CodeRabbit reported no actionable findings
- supplied real-checkpoint runs verified device residency and expected peak-memory growth

## Remaining limits

CUDA equivalence is covered by a skipped-when-unavailable test but was not executed on the CPU CI runner. Performance and memory requirements remain dependent on resolution, duration, CFG topology, reference mode, allocator state, and hardware. Explicit VRAM storage can raise an out-of-memory error when headroom is insufficient.