### PR TITLE
Fix Apple MPS tensor conversion and release v0.1.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,35 +1,26 @@
-# Spectrum MiniMax H3 v0.1.4
+# Spectrum MiniMax H3 v0.1.5
 
-Adds optional device-resident history storage for systems with spare VRAM.
+Fixes MiniMax H3 sampling on Apple MPS and includes the documentation and licensing corrections made since v0.1.4.
 
-## Added
+## Fixed
 
-- Add `history_storage=system_ram|vram` to the Spectrum node, defaulting to the existing system-RAM behavior.
-- Keep model-dtype history on the producing device in VRAM mode, avoiding actual-step device-to-host copies and repeated forecast-time host-to-device reads.
-- Clone the target view into compact owned device storage so cached history does not retain the complete final-block hidden tensor.
-- Report the configured storage and resolved history device in debug summaries.
-
-## Highlights
-
-- System-RAM mode remains the default and preserves existing saved-workflow behavior.
-- VRAM mode preserves the forecasting math, model dtype, FP32 accumulation order, scheduler, and fallback semantics.
-- History is still bounded by `max_history` and released at run teardown.
-
-## Memory guidance
-
-- The supplied 0.5 MP single-branch workflow retained about 2.22-2.27 GiB at `max_history=8`; a two-branch topology at the same shape would use roughly twice that amount.
-- At the native 1344x768, 124-frame example, eight two-branch snapshots approach 6.1 GiB.
-- VRAM mode also needs headroom for native model execution, the current snapshot, the prediction result, an FP32 accumulation chunk, and allocator fragmentation.
-
-## Measured 0.5 MP A/B results
-
-Three supplied full-checkpoint Euler pairs measured total times of 112.43/105.55 s, 115.60/116.08 s, and 109.80/107.26 s for system RAM/VRAM respectively. The combined means were 112.61 s and 109.63 s, a 2.6% advantage for VRAM mode. Individual pairs ranged from 6.1% faster to 0.4% slower, so the performance benefit is workload- and system-dependent.
+- Move detached solver timestep tensors to CPU before converting them to `float64`, avoiding the unsupported MPS `float64` conversion that stopped sampling at step 0.
+- Apply the same transfer-before-cast ordering to sigma-schedule normalization, which contained the same latent defect.
+- Centralize the conversion path so run initialization and per-step coordinate calculation cannot diverge.
+- Correct the repository's GPL-3.0-or-later licensing files and package metadata.
 
 ## Validation
 
-- Automated tests cover setting validation, default compatibility, compact owned storage, storage-device tracking, and CPU/CUDA prediction equivalence.
-- Existing native-path equivalence, transaction, sampler-contract, scheduler, and bounded-memory tests remain in place.
+- Add regression coverage that explicitly enforces `detach -> CPU transfer -> float64 cast -> flatten`.
+- Preserve CPU values, output shape, device, and dtype through the shared conversion helper.
+- Confirm the fix on a physical Apple M4 Max system with a complete 20-step RES multistep run: 14 actual H3 transformer evaluations, 6 forecasted evaluations, and zero fallbacks.
+- Retain the existing native MiniMax H3 fixture, scheduler, transaction, fallback, and forecasting test coverage.
 
-## Current limits
+## Documentation
 
-The supplied 0.5 MP tests verify the expected additional allocation and show a small, variable timing benefit. Other resolutions, durations, CFG topologies, reference modes, and hardware remain unverified. Selecting VRAM storage with insufficient headroom can raise an out-of-memory error.
+- Clarify that Spectrum can produce trajectory deviations and localized degradation during fast or brief motion.
+- Record the community-tested Radeon AI PRO R9700 / ROCm configuration and its measured warm-run result as a scoped compatibility datapoint.
+
+## Scope
+
+The MPS hardware confirmation covers the reported Apple M4 Max, PyTorch 2.10.0, ComfyUI 0.30.0, RES multistep configuration. It does not establish compatibility for every Apple Silicon model, PyTorch release, sampler, workflow topology, or MiniMax H3 configuration.

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -14,6 +14,17 @@ from .forecast import HistoryWeightForecaster
 LOG = logging.getLogger(__name__)
 
 
+def _as_cpu_float64_vector(value: Any) -> torch.Tensor:
+    """Detach a tensor-like value, move it to CPU, then cast to float64."""
+    return (
+        torch.as_tensor(value)
+        .detach()
+        .to(device="cpu")
+        .to(dtype=torch.float64)
+        .reshape(-1)
+    )
+
+
 class ForecastRetryActual(RuntimeError):
     """Internal signal used to discard a partial forecast attempt transactionally."""
 
@@ -144,7 +155,7 @@ class SpectrumH3Runtime:
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{name} must be an integer >= 0")
-        sigma_values = torch.as_tensor(sigmas).detach().to(device="cpu", dtype=torch.float64).reshape(-1)
+        sigma_values = _as_cpu_float64_vector(sigmas)
         total_steps = max(0, sigma_values.numel() - 1)
         evaluated = sigma_values[:-1]
         finite_schedule = bool(evaluated.numel()) and bool(torch.isfinite(evaluated).all().item())
@@ -207,7 +218,7 @@ class SpectrumH3Runtime:
     def coordinate_for_timestep(self, timestep: torch.Tensor | float) -> float:
         if self._run is None:
             raise RuntimeError("Spectrum H3 runtime is outside a sampling run")
-        value_tensor = torch.as_tensor(timestep).detach().to(device="cpu", dtype=torch.float64).reshape(-1)
+        value_tensor = _as_cpu_float64_vector(timestep)
         if value_tensor.numel() == 0 or not bool(torch.isfinite(value_tensor).all().item()):
             raise RuntimeError("current solver timestep is empty or nonfinite")
         if not bool(torch.allclose(value_tensor, value_tensor[0].expand_as(value_tensor))):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.1.4"
+version = "0.1.5"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_mps_runtime.py
+++ b/tests/test_mps_runtime.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import torch
+
+import comfyui_spectrum_h3.runtime as runtime_module
+
+
+class _MpsLikeTensor:
+    def __init__(self):
+        self.device = torch.device("mps")
+        self.calls = []
+
+    def detach(self):
+        return self
+
+    def to(self, *args, **kwargs):
+        device = kwargs.get("device")
+        dtype = kwargs.get("dtype")
+        if args:
+            if len(args) != 1:
+                raise AssertionError(f"unexpected to() arguments: {args!r}")
+            if isinstance(args[0], torch.dtype):
+                dtype = args[0]
+            else:
+                device = args[0]
+        if device is not None and dtype is not None:
+            raise TypeError("MPS cannot transfer to CPU and cast to float64 in one operation")
+        if dtype is torch.float64 and self.device.type == "mps":
+            raise TypeError("MPS does not support float64")
+        if device is not None:
+            self.device = torch.device(device)
+            self.calls.append(("device", self.device.type))
+        if dtype is not None:
+            self.calls.append(("dtype", dtype))
+        return self
+
+    def reshape(self, *shape):
+        self.calls.append(("reshape", shape))
+        return self
+
+
+def test_cpu_float64_conversion_moves_off_mps_before_casting(monkeypatch):
+    source = _MpsLikeTensor()
+    monkeypatch.setattr(runtime_module.torch, "as_tensor", lambda _value: source)
+
+    result = runtime_module._as_cpu_float64_vector(object())
+
+    assert result is source
+    assert source.calls == [
+        ("device", "cpu"),
+        ("dtype", torch.float64),
+        ("reshape", (-1,)),
+    ]
+
+
+def test_cpu_float64_conversion_preserves_values_and_flattens():
+    source = torch.tensor([[1.5, -2.0]], dtype=torch.float16)
+
+    result = runtime_module._as_cpu_float64_vector(source)
+
+    assert result.device.type == "cpu"
+    assert result.dtype is torch.float64
+    assert result.shape == (2,)
+    torch.testing.assert_close(result, torch.tensor([1.5, -2.0], dtype=torch.float64))

--- a/tests/test_mps_runtime.py
+++ b/tests/test_mps_runtime.py
@@ -11,6 +11,7 @@ class _MpsLikeTensor:
         self.calls = []
 
     def detach(self):
+        self.calls.append(("detach",))
         return self
 
     def to(self, *args, **kwargs):
@@ -47,6 +48,7 @@ def test_cpu_float64_conversion_moves_off_mps_before_casting(monkeypatch):
 
     assert result is source
     assert source.calls == [
+        ("detach",),
         ("device", "cpu"),
         ("dtype", torch.float64),
         ("reshape", (-1,)),


### PR DESCRIPTION
## Root cause

Spectrum converted solver tensors with a single `to(device="cpu", dtype=torch.float64)` operation. For an MPS-resident timestep, PyTorch attempted an unsupported `float64` conversion through the MPS path before the value was safely resident on CPU.

The same latent defect also existed in sigma-schedule normalization, even though the reported run reached the timestep path first.

## Fix

- move detached schedule and timestep tensors to CPU while preserving their source dtype;
- cast to `float64` only after the CPU transfer completes;
- centralize the ordering in one helper used by run initialization and per-step coordinate calculation;
- preserve the existing CPU `float64` coordinate calculations and scheduler behavior.

## Regression coverage

- add an MPS-like test double that rejects combined transfer/cast operations and rejects `float64` while still on MPS;
- explicitly enforce `detach -> CPU transfer -> float64 cast -> flatten`;
- verify CPU device, `float64` dtype, flattened shape, and preserved values.

## Hardware confirmation

The issue reporter completed a full run on an Apple M4 Max after switching to this branch:

```text
sampler: sample_res_multistep
steps: 20
actual steps: 14
forecast steps: 6
fallbacks: 0
run completed successfully
```

This confirms the reported step-0 failure is fixed on the supplied M4 Max / PyTorch 2.10.0 / ComfyUI 0.30.0 configuration.

## Release

- bump the package to `0.1.5`;
- update release notes for the MPS fix and the documentation/licensing changes merged since v0.1.4;
- allow the existing main-branch workflows to publish the Comfy Registry package and GitHub release after merge and successful CI.

Closes #8