### PR TITLE
Document tested AMD ROCm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Automated tests cover:
 - exact native versus wrapped forced-actual video/audio output on a deterministic tiny native H3 fixture;
 - proof that a forecast fixture invokes zero H3 transformer blocks.
 
+A community compatibility report confirmed that revision `dc6291525112cb4246f864738e5bb4e2b85446da` ran without source changes on Windows 11 with a Radeon AI PRO R9700 32 GB, PyTorch 2.9.1 + ROCm 7.2.1, and ComfyUI 0.30.0. In the reported 20-step RES multistep, 864x480, 107-frame `system_ram` workflow, the expected 14 actual and 6 forecasted evaluations reduced warm elapsed time from 212.73 s to 160.97 s (24.33% lower time; about 1.32x throughput). This validates only that exact configuration; other AMD GPUs, ROCm builds, workflows, and quality cases remain unverified. See [issue #6](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/issues/6).
+
 No full MiniMax H3 checkpoint is available in the automated environment. The supplied real-checkpoint A/B runs validate the 0.5 MP VRAM allocation and show a small, variable timing benefit. Exact-seed full-checkpoint comparisons have also shown both trajectory deviations during fast or brief actions and localized degradation in rapidly moving or briefly visible details such as eyes, fingers, and fingernails. These effects can occur separately or together. Other resolutions, durations, CFG topologies, reference modes, hardware, decoded video metrics, audio metrics, and audiovisual synchronization remain unverified. Spectrum must not be treated as lossless or output-identical to native sampling.
 
 ## Tests


### PR DESCRIPTION
## Summary

Add a concise validation note for the community-tested Radeon AI PRO R9700 configuration reported in issue #6.

The README records:

- the exact Windows, GPU, PyTorch/ROCm, ComfyUI, and Spectrum revision;
- the expected 14-actual / 6-forecast RES schedule;
- the measured warm-run change from 212.73 s to 160.97 s;
- the equivalent 24.33% lower elapsed time and approximately 1.32x throughput;
- an explicit limit that this is a datapoint for the reported configuration, not a blanket ROCm compatibility claim.

Docs-only change. No runtime behavior is modified.

Related: #6