### PR TITLE
Support the post-ModelSamplingAV native audio velocity contract

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -17,12 +17,12 @@ The separate `ComfyUI-Spectrum-Proper` repository was inspected only for ComfyUI
 3. A stock k-diffusion sampler calls `KSamplerX0Inpaint`, then `CFGGuider.outer_predict_noise` invokes `PREDICT_NOISE` wrappers around `CFGGuider.predict_noise`.
 4. `sampling_function` and `calc_cond_batch` form conditional/unconditional model calls. Each call receives copied/merged transformer options containing `cond_or_uncond`, `uuids`, the current `sigmas`, the full `sample_sigmas`, user patches, replacement patches, hooks, and model-management data.
 5. `comfy.model_base.MiniMaxH3._apply_model` converts the flat sampler latent back to the native pair `[video, audio]`, maps sampler sigma through `model_sampling.timestep`, copies transformer options, and calls `MiniMaxH3Model.forward`.
-6. `MiniMaxH3Model.forward` invokes ComfyUI `DIFFUSION_MODEL` wrappers around `MiniMaxH3Model._forward`.
+6. `MiniMaxH3Model.forward` invokes ComfyUI `DIFFUSION_MODEL` wrappers around `MiniMaxH3Model._forward`. On cores with `ModelSamplingAV` the sampler carries the audio stream scaled onto the video schedule; `forward` removes that scale before the wrappers run and restores it after, so wrappers always observe the stream's own latent and velocity.
 7. `_forward` pads video to the model patch geometry, resolves or constructs `PackedLayout`, derives video and audio timesteps from the current video sigma and both sigma shifts, builds modality/timestep modulation segments, embeds target and conditioning rows, builds RoPE, and runs every transformer block. Per-block replacement patches and the native prefetch queue are applied inside this loop.
 8. The packed sequence is `[text | optional keyframe/reference segments | target audio | target video]`. `PackedLayout.segments` proves that the target audio and target video spans are the final two contiguous segments, in that order.
 9. Immediately after the final transformer block, the packed hidden tensor contains the desired forecast target. Only the target audio and target video rows are cached, as a compact tensor ordered `[target audio rows | target video rows]`. Text, keyframe, image-reference, video-reference, and audio-reference rows are excluded.
 10. `FinalLayer.forward` consumes the current hidden rows plus the current exact timestep embeddings. It independently normalizes/modulates target video and target audio rows, then executes the checkpoint's FP32 output heads.
-11. Native reconstruction unpatchifies video, unpacks stereo channel-major audio, applies the video-to-audio sigma-map derivative, and returns `[-video_velocity, -audio_slope * audio_velocity]`. `BaseModel._apply_model` packs this native pair again for the sampler and applies the native denoised conversion.
+11. Native reconstruction unpatchifies video and unpacks stereo channel-major audio. The audio velocity convention is core-dependent and is detected from the presence of `time_shift_slope` in `comfy.ldm.minimax.model`: cores that expose it expect `_forward` to apply the video-to-audio sigma-map derivative and return `[-video_velocity, -audio_slope * audio_velocity]`; cores that removed it perform the schedule conversion in `forward` instead, so `_forward` returns the unscaled `[-video_velocity, -audio_velocity]`. `BaseModel._apply_model` packs this native pair again for the sampler and applies the native denoised conversion.
 
 ## Integration invariant
 
@@ -31,7 +31,7 @@ The acceleration boundary is the post-final-block hidden feature immediately bef
 This preserves:
 
 - current video and audio timestep conditioning;
-- sigma-shift mapping and audio derivative scaling;
+- sigma-shift mapping, and whichever audio velocity convention the installed core uses;
 - output-head weights and FP32 islands;
 - video unpatchification and audio unpacking;
 - native return structure;

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -100,7 +100,9 @@ def target_segments(layout: Any) -> tuple[tuple[int, int], tuple[int, int]]:
 
 def _native_module(inner: Any):
     module = importlib.import_module(type(inner).__module__)
-    required = ("PackedLayout", "unpatchify_video", "unpack_audio", "time_shift_sigma", "time_shift_slope")
+    # time_shift_slope is deliberately absent: cores that still expose it want the
+    # audio velocity pre-scaled here, newer ones convert outside this wrapper.
+    required = ("PackedLayout", "unpatchify_video", "unpack_audio", "time_shift_sigma")
     missing = [name for name in required if not hasattr(module, name)]
     if missing:
         raise RuntimeError(f"native MiniMax H3 module is missing required helpers: {', '.join(missing)}")
@@ -349,9 +351,14 @@ def _execute_forecast(
     )
     original_t, original_h, original_w = state.original_video_shape
     video_out = video_out[:, :, :original_t, :original_h, :original_w]
-    audio_out = module.unpack_audio(audio_projected)
-    slope = module.time_shift_slope(state.sigma_v, state.shift_v, state.shift_a).to(audio_out.dtype)
-    return [-video_out.to(video_x.dtype), (-slope) * audio_out.to(audio_x.dtype)]
+    audio_out = -module.unpack_audio(audio_projected).to(audio_x.dtype)
+    # Older cores return the audio velocity scaled by d(sigma_a)/d(sigma_v) from
+    # _forward; newer ones carry the audio on the video schedule and undo the
+    # scale in forward(), outside this wrapper, so _forward stays unscaled.
+    slope_fn = getattr(module, "time_shift_slope", None)
+    if slope_fn is not None:
+        audio_out = audio_out * slope_fn(state.sigma_v, state.shift_v, state.shift_a).to(audio_out.dtype)
+    return [-video_out.to(video_x.dtype), audio_out]
 
 
 def diffusion_model_wrapper(

--- a/tests/test_native_equivalence.py
+++ b/tests/test_native_equivalence.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.forecast import HistoryWeightForecaster
 from comfyui_spectrum_h3.minimax_h3 import diffusion_model_wrapper
 from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
 from comfyui_spectrum_h3.sampling import (
@@ -139,6 +140,59 @@ def test_actual_capture_avoids_full_audio_video_concatenation(monkeypatch):
 
     assert isinstance(wrapped, list) and len(wrapped) == 2
     assert runtime.stats.direct_history_updates == 1
+    runtime.end_run(run_id)
+
+
+def test_exact_forecast_reproduces_the_native_audio_video_velocity(monkeypatch):
+    """A forecast that recovers the true final-block feature must equal native _forward.
+
+    This pins the audio-velocity convention: cores that expose time_shift_slope want
+    the forecast pre-scaled by d(sigma_a)/d(sigma_v), newer cores convert outside the
+    wrapper and want it unscaled. Getting it wrong only shows up as audio drift.
+    """
+    _, _, PackedLayout = _native_imports()
+    model, _ = _tiny_model()
+    x, context, payload = _inputs(PackedLayout)
+    native = model._forward(x, torch.tensor([500.0]), context, {}, minimax_payload=payload)
+
+    captured = {}
+    original_observe = SpectrumH3Runtime.observe_actual
+
+    def recording_observe(self, run_id, step_id, call_id, target):
+        captured["target"] = target.detach().clone()
+        return original_observe(self, run_id, step_id, call_id, target)
+
+    monkeypatch.setattr(SpectrumH3Runtime, "observe_actual", recording_observe)
+    capture_runtime = SpectrumH3Runtime(
+        SpectrumH3Config(degree=1, max_history=4, force_actual=True, warmup_steps=0, tail_actual_steps=0)
+    )
+    capture_run = capture_runtime.start_run(torch.tensor([1.0, 0.0]), "sample_euler", supported_sampler=True)
+    _wrapped_call(model, capture_runtime, 1.0, 500.0, x, context, payload)
+    capture_runtime.end_run(capture_run)
+    monkeypatch.setattr(SpectrumH3Runtime, "observe_actual", original_observe)
+    assert "target" in captured
+
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(degree=1, max_history=4, warmup_steps=2, tail_actual_steps=0, window_size=2.0)
+    )
+    run_id = runtime.start_run(torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]), "sample_euler", supported_sampler=True)
+    _wrapped_call(model, runtime, 1.0, 1000.0, x, context, payload)
+    _wrapped_call(model, runtime, 0.75, 750.0, x, context, payload)
+
+    # Patch the forecaster, not the runtime, so all step bookkeeping still runs.
+    monkeypatch.setattr(
+        HistoryWeightForecaster,
+        "predict",
+        lambda self, coordinate, blend_weight, *, rows, device, dtype: captured["target"].to(
+            device=device, dtype=dtype
+        ),
+    )
+    forecast, forecast_decision = _wrapped_call(model, runtime, 0.5, 500.0, x, context, payload)
+    assert not forecast_decision["actual"]
+    for native_part, forecast_part in zip(native, forecast, strict=True):
+        assert native_part.shape == forecast_part.shape
+        assert native_part.dtype == forecast_part.dtype
+        torch.testing.assert_close(native_part, forecast_part, rtol=1e-5, atol=1e-5)
     runtime.end_run(run_id)
 
 


### PR DESCRIPTION
## Problem

ComfyUI [`bdcb886a`](https://github.com/comfyanonymous/ComfyUI/commit/bdcb886a4705a03cf40f4a7226de9fc7c059fc90) ("Fix sampler issues for audio with minimax, support more samplers", #15243) removed `time_shift_slope` from `comfy/ldm/minimax/model.py`.

Spectrum lists that function as a required native helper, so on any current ComfyUI every sampling run aborts at the first model call:

```
RuntimeError: native MiniMax H3 module is missing required helpers: time_shift_slope
```

Raised from `_native_module` via `_resolve_layout`, inside `diffusion_model_wrapper`. The node is unusable on current master.

## What changed upstream

The audio schedule conversion moved out of `MiniMaxH3Model._forward` and into `MiniMaxH3Model.forward`. With the new `ModelSamplingAV`, the sampler carries the audio latent scaled onto the video schedule; `forward` now undoes that scale *before* running `DIFFUSION_MODEL` wrappers and reapplies it after. `_forward` therefore returns the **unscaled** audio velocity, where it previously returned it multiplied by `d(sigma_a)/d(sigma_v)`.

This matters to Spectrum specifically because its forecast reconstruction stands in for `_forward` and sits inside that same wrapper boundary, so it has to honour the same convention.

## Fix

Drop `time_shift_slope` from the required-helper tuple and use its presence as the discriminator in `_execute_forecast`:

- core still exposes it → apply the derivative scaling, as before
- core removed it → return the raw velocity

This keeps the node working on both old and new cores rather than pinning a minimum ComfyUI version. No behaviour change on cores that predate the upstream commit.

## Why the added test

The failure mode on newer cores is silent. Output shapes, dtypes and devices all remain valid — only the forecasted audio velocity is wrong — so the existing shape-based coverage cannot catch it. Getting this backwards would ship as audio drift on forecasted steps, not a crash.

`test_exact_forecast_reproduces_the_native_audio_video_velocity` captures the true final-block hidden feature from an actual step, feeds it back through the forecast path, and asserts the wrapper output matches native `_forward` exactly. If the forecaster recovers the true feature, the reconstruction must be indistinguishable from native.

I checked the test is not vacuous: re-adding a `time_shift_slope` to the module to simulate an old core makes it fail with up to 56% relative error on the audio stream, confirming both that the compatibility branch is exercised and that the assertion is sensitive to exactly this defect.

## Validation

- Full suite: **80 passed**, run with `COMFYUI_PATH` and `PYTHONPATH` set so the native-equivalence and sampler-contract tests actually execute against real ComfyUI rather than skipping.
- Verified against ComfyUI at `bdcb886a` (the commit that removed the helper).

```
COMFYUI_PATH=/path/to/ComfyUI PYTHONPATH=/path/to/ComfyUI python -m pytest tests/ -q
```

Worth noting: without those two environment variables 13 tests skip, including every test that checks the node against real ComfyUI — which is exactly where core drift like this surfaces. Might be worth failing loudly, or documenting them in the README, so this class of breakage is caught by a default test run.

## Docs

`IMPLEMENTATION_NOTES.md` steps 6 and 11 and the integration invariant described the old single convention; updated to describe both and the detection rule.

## Scope / limitations

- Four complete end-to-end audio-video generations on this branch, no errors and no fallbacks, on an AMD Radeon AI PRO R9700 (gfx1201) / ROCm, Python 3.13, against ComfyUI at `bdcb886a`.
- Those runs confirm the node is functional again and that the reconstruction holds at real model scale. They were not run as a formal A/B against a Spectrum-disabled baseline, so they establish correctness qualitatively rather than measuring audio deviation numerically.
- The detection is structural — presence of a module-level function — not a version check. If a future core removes `time_shift_slope` *without* moving the conversion into `forward`, this heuristic would be wrong. An explicit capability flag on the native module would be more robust if you'd prefer that shape.
- No version bump or `RELEASE_NOTES.md` entry included; happy to add either if you want this cut as a release.
