### PR TITLE
Release v0.1.6 for current ComfyUI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,12 @@ permissions:
 
 jobs:
   unit-and-native-fixture:
+    strategy:
+      fail-fast: false
+      matrix:
+        comfy_ref:
+          - e377e263049f9338b4d12a3dd417b36ae62948ff
+          - 0dd9b154a1654fc699dcdc3af066c7cce096045a
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -22,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
           repository: comfyanonymous/ComfyUI
-          ref: e377e263049f9338b4d12a3dd417b36ae62948ff
+          ref: ${{ matrix.comfy_ref }}
           path: ComfyUI
 
       - name: Set up Python
@@ -35,7 +41,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging comfy-kitchen==0.2.26 comfy-aimdo==0.4.11
+          python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
           python -m pip wheel --no-deps --wheel-dir /tmp/spectrum-h3-wheel .
 
       - name: Run forecaster smoke test

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,8 +1,8 @@
 # MiniMax H3 integration notes
 
-Source review date: 2026-08-03
+Source review date: 2026-08-07
 
-Reviewed native ComfyUI commit: `e377e263049f9338b4d12a3dd417b36ae62948ff`
+Reviewed native ComfyUI commits: `e377e263049f9338b4d12a3dd417b36ae62948ff` and `0dd9b154a1654fc699dcdc3af066c7cce096045a`
 
 Reviewed Spectrum paper: arXiv `2603.01623v1`
 
@@ -44,6 +44,8 @@ This preserves:
 Solver-step IDs are assigned by a `PREDICT_NOISE` wrapper inside an `OUTER_SAMPLE` run transaction. Forecasting is allowlisted only for deterministic native `sample_euler`, `sample_res_multistep`, and `sample_res_multistep_cfg_pp`, whose reviewed implementations perform exactly one `predict_noise` call per solver iteration. Euler requires one completed actual H3 evaluation after every forecast. RES stores each current denoised result for the following second-order update. The actual step after a forecast consumes that forecast-derived value, then replaces `old_denoised` with its native result; one completed actual evaluation therefore clears the retained forecast before forecasting resumes. RES also enforces a three-step actual tail. These sampler floors are applied at run time and cannot be weakened by an older saved workflow. Ancestral variants remain native because they inject noise between model evaluations. Other samplers remain native and report a debug fallback reason.
 
 Coordinates are derived from the actual supplied sigma sequence. Evaluated sigma values are affinely normalized between the run's evaluated minimum and maximum into `[-1, 1]`; no fixed step count is assumed.
+
+Native EasyCache and LazyCache may terminate a diffusion-model wrapper chain without an H3 call. Their shared `transformer_options["easycache"]` holder is therefore detected before Spectrum opens a run transaction. Spectrum remains inactive for that run and the cache owns the acceleration path.
 
 ## Forecast memory model
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use Spectrum when the speed benefit is worth possible output differences. Disabl
 
 ## Supported native path
 
-The integration targets `comfy.ldm.minimax.model.MiniMaxH3Model` in native ComfyUI. It requires the MiniMax H3 and packed-latent sampler APIs present at ComfyUI commit `e377e263049f9338b4d12a3dd417b36ae62948ff` from August 3, 2026, including the `latent_shapes` argument on `outer_sample`. Older ComfyUI revisions are unsupported. Development and native-equivalence tests are pinned to that commit. Later revisions are unverified; required H3 attributes are checked when the node is applied, and replacement output shape is checked on actual steps so incompatible native changes fail with an explicit contract error.
+The integration targets `comfy.ldm.minimax.model.MiniMaxH3Model` in native ComfyUI. It requires the MiniMax H3 and packed-latent sampler APIs introduced by ComfyUI commit `e377e263049f9338b4d12a3dd417b36ae62948ff`, including the `latent_shapes` argument on `outer_sample`. Older ComfyUI revisions are unsupported. Native-equivalence CI covers that original integration and current ComfyUI commit `0dd9b154a1654fc699dcdc3af066c7cce096045a`, including the `ModelSamplingAV` audio-schedule contract introduced in `bdcb886a4705a03cf40f4a7226de9fc7c059fc90`. Required H3 attributes are checked when the node is applied, and replacement output shape is checked on actual steps so incompatible native changes fail with an explicit contract error.
 
 The forecast target is the packed hidden feature immediately after the final H3 transformer block and before `FinalLayer`, ordered as:
 
@@ -134,6 +134,8 @@ Forecasting is currently allowlisted for:
 - RES multistep CFG++ (`sample_res_multistep_cfg_pp`)
 
 The reviewed implementations make one `predict_noise` call per solver iteration. Euler feeds each approximate denoised result into the latent used by the next evaluation, so it requires one completed actual H3 evaluation after every forecast. RES multistep stores each current denoised result as `old_denoised` for the following second-order update. The actual evaluation immediately after a forecast still consumes forecast-derived history, then replaces `old_denoised` with its native result before another forecast is allowed. This prevents any RES update from combining two forecasted denoised results. RES also keeps its final three solver steps native; this tail floor applies even when a saved workflow supplies a smaller `tail_actual_steps` value. Ancestral samplers execute native MiniMax H3 because injected noise invalidates the smooth deterministic feature trajectory used by the forecaster. Debug mode logs the exact fallback, tail, or post-forecast refresh reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
+
+Native EasyCache and LazyCache must not accelerate the same model branch as Spectrum. Either cache can return an approximate diffusion result without invoking MiniMax H3, so Spectrum cannot capture the actual post-transformer feature required by its solver-step transaction. If both are attached, Spectrum now logs one warning and remains inactive for that run while the cache continues normally. Use one of these accelerators on a model branch.
 
 ## Memory design
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,26 +1,24 @@
-# Spectrum MiniMax H3 v0.1.5
+# Spectrum MiniMax H3 v0.1.6
 
-Fixes MiniMax H3 sampling on Apple MPS and includes the documentation and licensing corrections made since v0.1.4.
+Restores Spectrum on current ComfyUI after the native MiniMax H3 `ModelSamplingAV` update and makes native cache conflicts fail safe.
 
 ## Fixed
 
-- Move detached solver timestep tensors to CPU before converting them to `float64`, avoiding the unsupported MPS `float64` conversion that stopped sampling at step 0.
-- Apply the same transfer-before-cast ordering to sigma-schedule normalization, which contained the same latent defect.
-- Centralize the conversion path so run initialization and per-step coordinate calculation cannot diverge.
-- Correct the repository's GPL-3.0-or-later licensing files and package metadata.
+- Remove `time_shift_slope` from the unconditional native-helper requirement after ComfyUI removed it in `bdcb886a`.
+- Match both native MiniMax H3 audio-velocity contracts: derivative-scaled output on the original core and raw `_forward` output when `ModelSamplingAV` performs the schedule conversion outside Spectrum's wrapper boundary.
+- Detect native EasyCache or LazyCache on the same model branch before opening a Spectrum transaction. Spectrum remains inactive for that run and the cache continues normally, avoiding `Spectrum H3 solver step completed without an H3 model call`.
 
 ## Validation
 
-- Add regression coverage that explicitly enforces `detach -> CPU transfer -> float64 cast -> flatten`.
-- Preserve CPU values, output shape, device, and dtype through the shared conversion helper.
-- Confirm the fix on a physical Apple M4 Max system with a complete 20-step RES multistep run: 14 actual H3 transformer evaluations, 6 forecasted evaluations, and zero fallbacks.
-- Retain the existing native MiniMax H3 fixture, scheduler, transaction, fallback, and forecasting test coverage.
+- Add an exact reconstruction test that feeds a captured native final-block feature through the forecast output path and compares both video and audio velocity with native `_forward`.
+- Run native-equivalence CI against the original H3 integration commit and current ComfyUI commit `0dd9b154a1654fc699dcdc3af066c7cce096045a`.
+- Add regression coverage proving EasyCache/LazyCache presence bypasses Spectrum without starting or advancing runtime state.
+- Validate the full CPU suite locally on both sides of the upstream `ModelSamplingAV` change: 80 passed and one CUDA-only equivalence test skipped on each core.
 
 ## Documentation
 
-- Clarify that Spectrum can produce trajectory deviations and localized degradation during fast or brief motion.
-- Record the community-tested Radeon AI PRO R9700 / ROCm configuration and its measured warm-run result as a scoped compatibility datapoint.
+- Document the supported native contract range and the mutual exclusion between Spectrum and native EasyCache/LazyCache on one model branch.
 
 ## Scope
 
-The MPS hardware confirmation covers the reported Apple M4 Max, PyTorch 2.10.0, ComfyUI 0.30.0, RES multistep configuration. It does not establish compatibility for every Apple Silicon model, PyTorch release, sampler, workflow topology, or MiniMax H3 configuration.
+The automated native tests use tiny CPU fixtures. Contributor testing reported four successful full MiniMax H3 generations with the ComfyUI compatibility patch on an AMD Radeon AI PRO R9700 / ROCm system. Exact-seed full-checkpoint A/B validation of the new ComfyUI audio path remains outstanding.

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -109,6 +109,23 @@ def outer_sample_wrapper(
             latent_shapes=latent_shapes,
         )
 
+    transformer_options = (getattr(guider, "model_options", None) or {}).get("transformer_options") or {}
+    if transformer_options.get("easycache") is not None:
+        LOG.warning(
+            "Spectrum H3 disabled for this run because EasyCache or LazyCache is active on the same model"
+        )
+        return executor(
+            noise,
+            latent_image,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+
     runtime = binding.runtime
     name = sampler_name(sampler)
     run_id = runtime.start_run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.1.5"
+version = "0.1.6"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -4,10 +4,15 @@ from types import SimpleNamespace
 
 import pytest
 
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
 from comfyui_spectrum_h3.sampling import (
+    BINDING_KEY,
+    SpectrumH3Binding,
     max_consecutive_forecasts,
     min_actual_steps_after_forecast,
     min_tail_actual_steps,
+    outer_sample_wrapper,
     sampler_is_supported,
     sampler_name,
 )
@@ -84,3 +89,40 @@ def test_unsupported_sampler_has_no_forecast_streak_policy():
     assert max_consecutive_forecasts(sampler) is None
     assert min_actual_steps_after_forecast(sampler) == 0
     assert min_tail_actual_steps(sampler) == 0
+
+
+def test_easycache_on_same_model_bypasses_spectrum_run(caplog):
+    runtime = SpectrumH3Runtime(SpectrumH3Config())
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {"easycache": object()},
+        }
+    )
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            calls.append((args, kwargs))
+            return "native-cache-result"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            "noise",
+            "latent",
+            _sampler("sample_euler"),
+            "sigmas",
+            denoise_mask="mask",
+            callback="callback",
+            disable_pbar=True,
+            seed=7,
+            latent_shapes=("video", "audio"),
+        )
+
+    assert result == "native-cache-result"
+    assert len(calls) == 1
+    assert runtime.active_run_id is None
+    assert "EasyCache or LazyCache is active" in caplog.text


### PR DESCRIPTION
## Summary

- publish the merged MiniMax H3 `ModelSamplingAV` compatibility fix as v0.1.6;
- make native EasyCache/LazyCache on the same model branch bypass Spectrum before a run transaction starts;
- test the native integration against both the original supported ComfyUI core and current ComfyUI;
- document the changed audio-velocity contract and cache mutual exclusion.

## Root cause

ComfyUI commit `bdcb886a` moved MiniMax H3 audio schedule conversion outside the `DIFFUSION_MODEL` wrapper boundary and removed `time_shift_slope`. Spectrum required that helper and its forecast reconstruction still used the old derivative-scaled return contract.

A separate failure in #12 occurs when native EasyCache or LazyCache returns a cached diffusion result without invoking H3. Spectrum previously opened a solver-step transaction first and then raised because no actual post-transformer feature existed to record.

## Fix

PR #13 now reconstructs the audio output according to the installed native core contract and includes an exact hidden-feature-to-output equivalence test.

This follow-up detects the native cache holder before Spectrum starts a run. Spectrum logs one warning and remains inactive while the cache continues normally. The two accelerators therefore cannot silently corrupt each other's history.

## Validation

- current ComfyUI `0dd9b154a1654fc699dcdc3af066c7cce096045a`: 80 passed, 1 CUDA-only skip;
- original supported ComfyUI `e377e263049f9338b4d12a3dd417b36ae62948ff`: 80 passed, 1 CUDA-only skip;
- forecaster smoke test passed;
- Ruff substantive checks passed;
- wheel and sdist built successfully; v0.1.6 wheel contents inspected;
- `git diff --check` passed.

The CUDA exact-equivalence test and exact-seed full-checkpoint A/B output comparison were not run in this CPU-only environment.

Related: #12, #14, #15, #13