### PR TITLE
Enable one-point bootstrap by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The node accepts and returns `MODEL`. Disabled mode returns the original model o
 | `max_history` | `8` | Maximum model-dtype actual feature snapshots retained. |
 | `debug` | `false` | Enables concise run, step, topology, fallback, sanitization, chunk, and teardown logs. |
 | `history_storage` | `system_ram` | Stores history in `system_ram`, or in `vram` to avoid transfer overhead when sufficient accelerator memory is free. |
-| `bootstrap_first_forecast` | `false` | Experimental degree-1 one-point hold that can forecast solver step 1 from the actual step-0 hidden feature. |
+| `bootstrap_first_forecast` | `true` | Experimental degree-1 one-point hold that can forecast solver step 1 from the actual step-0 hidden feature. |
 
 Every value is validated. `max_history` must be at least `degree + 1`.
 
@@ -89,6 +89,7 @@ warmup_steps = 1
 tail_actual_steps = 1
 max_history = 8
 history_storage = system_ram
+bootstrap_first_forecast = true
 ```
 
 ### Provisional aggressive preset
@@ -103,9 +104,10 @@ warmup_steps = 5
 tail_actual_steps = 1
 max_history = 8
 history_storage = system_ram
+bootstrap_first_forecast = false
 ```
 
-The default degree, warmup, and tail are preliminary pending broader prompt, sampler, and quality coverage. Existing workflows retain their saved input values. The aggressive preset remains an explicit alternative.
+The default degree, warmup, tail, and one-point bootstrap are preliminary pending broader prompt, sampler, and quality coverage. Existing workflows retain their saved input values. The aggressive preset remains an explicit alternative and disables the degree-1-only bootstrap.
 
 ## Adaptive schedule
 
@@ -121,7 +123,7 @@ Schedule counts depend on the sampler safeguards and whether the experimental on
 
 ### Experimental one-point bootstrap
 
-`bootstrap_first_forecast=true` enables an H3-specific zero-order hold for solver step 1. It requires:
+`bootstrap_first_forecast=true` (the preliminary default) enables an H3-specific zero-order hold for solver step 1. It requires:
 
 ```text
 degree = 1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,42 +1,12 @@
-# Spectrum MiniMax H3 v0.1.7
+# Spectrum MiniMax H3 v0.1.8
 
-Adds an experimental one-point bootstrap forecast for degree-1 schedules and adopts the validated degree-1 setup as the preliminary default for new node instances.
+Corrects the preliminary one-point-bootstrap configuration introduced in v0.1.7.
 
-## Added
+## Fixed
 
-- Add optional `bootstrap_first_forecast`, disabled by default, which can forecast solver step 1 from the actual step-0 packed H3 hidden feature.
-- Route the explicit one-point `[1.0]` hold through the existing bounded prediction engine while preserving current-step timestep conditioning, output heads, branch mapping, shape checks, retry behavior, and accounting.
-- Keep ordinary degree-1 regression unchanged: it still requires two actual history samples, never factorizes a one-point system, and never inserts forecasts into actual history.
+- Set `bootstrap_first_forecast=true` for new node instances, alongside the existing preliminary defaults `degree=1`, `warmup_steps=1`, and `tail_actual_steps=1`.
+- Align the runtime configuration default, ComfyUI input metadata, and `apply()` fallback so every new or unserialized node path receives the same setting.
+- Keep the explicit degree-4 aggressive preset at `bootstrap_first_forecast=false`, because the one-point bootstrap is valid only for degree 1.
+- Add regression coverage for all four preliminary defaults and for validation of the aggressive preset.
 
-## Preliminary defaults
-
-- Set `degree=1` for new node instances.
-- Set `warmup_steps=1` for new node instances.
-- Keep `tail_actual_steps=1` as the requested native tail. Deterministic RES still enforces its sampler-safe three-step minimum.
-- Keep `bootstrap_first_forecast=false`; enable it explicitly to use the new step-1 hold.
-
-Existing workflows retain their saved input values.
-
-## Full-checkpoint validation
-
-A same-seed 20-step Euler run with `degree=1`, `warmup_steps=1`, `tail_actual_steps=1`, `bootstrap_first_forecast=true`, `window_size=2.0`, and `flex_window=0.75` completed with:
-
-```text
-A F A F A F A F A F A F A F A F A F A A
-```
-
-- 11 actual transformer calls and 9 forecasts.
-- Zero fallbacks.
-- 177.80 s sampler time, down from 324.98 s native: 45.29% reduction and 1.83x sampler throughput.
-- 200.32 s full-prompt time, down from 340.59 s native: 41.19% reduction. The Spectrum run also included 5.65 s of upstream `MiniMaxH3ImageToVideo` work, so the full-prompt comparison is less controlled than the sampler measurement.
-- 0.141 s total forecast prediction time and 3221.5 MiB of history in VRAM.
-
-The bootstrap run was 6.52 s faster than an earlier non-bootstrap Spectrum run with the same 11 actual calls and 9 forecasts. That 3.54% difference is treated as run variance and/or sigma-position cost, since bootstrap did not reduce the transformer-call count at 20 steps. Odd step counts such as 17 or 19 are where the shifted schedule can remove one additional actual call.
-
-## Automated validation
-
-- Exact 17-step and 20-step Euler bootstrap schedules.
-- Whole-step abort, retry, fallback, reordered-label, topology, shape, final-tail, refresh, and accounting invariants.
-- One-point prediction exactness with no regression factorization or history mutation.
-- Native H3 proof that the bootstrap skips transformer blocks while running the current step's output path.
-- 106 tests passed with one CUDA-only VRAM/system-RAM parity test skipped on current ComfyUI `2340099d`, original H3 integration commit `e377e263`, and compatibility commit `0dd9b154`.
+Existing workflows retain serialized input values. Deterministic RES continues to enforce its sampler-safe three-step minimum.

--- a/comfyui_spectrum_h3/config.py
+++ b/comfyui_spectrum_h3/config.py
@@ -18,7 +18,7 @@ class SpectrumH3Config:
     history_storage: str = "system_ram"
     debug: bool = False
     force_actual: bool = False
-    bootstrap_first_forecast: bool = False
+    bootstrap_first_forecast: bool = True
 
     @property
     def min_fit_points(self) -> int:
@@ -82,4 +82,5 @@ AGGRESSIVE_PRESET = SpectrumH3Config(
     flex_window=3.0,
     warmup_steps=5,
     tail_actual_steps=1,
+    bootstrap_first_forecast=False,
 )

--- a/comfyui_spectrum_h3/nodes.py
+++ b/comfyui_spectrum_h3/nodes.py
@@ -25,7 +25,7 @@ class SpectrumApplyMiniMaxH3:
             },
             "optional": {
                 "history_storage": (["system_ram", "vram"], {"default": "system_ram"}),
-                "bootstrap_first_forecast": ("BOOLEAN", {"default": False}),
+                "bootstrap_first_forecast": ("BOOLEAN", {"default": True}),
             },
         }
 
@@ -48,7 +48,7 @@ class SpectrumApplyMiniMaxH3:
         max_history,
         debug,
         history_storage="system_ram",
-        bootstrap_first_forecast=False,
+        bootstrap_first_forecast=True,
     ):
         if not enabled:
             return (model,)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.1.7"
+version = "0.1.8"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import inspect
 
 import pytest
 
-from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.config import AGGRESSIVE_PRESET, SpectrumH3Config
 from comfyui_spectrum_h3.nodes import SpectrumApplyMiniMaxH3
 
 
@@ -27,20 +27,27 @@ def test_history_storage_rejects_unknown_locations():
         SpectrumH3Config(history_storage="automatic").validate()
 
 
-def test_bootstrap_first_forecast_defaults_to_false():
-    assert SpectrumH3Config().bootstrap_first_forecast is False
-
-
 def test_preliminary_scheduler_defaults():
     config = SpectrumH3Config()
     required = SpectrumApplyMiniMaxH3.INPUT_TYPES()["required"]
+    optional = SpectrumApplyMiniMaxH3.INPUT_TYPES()["optional"]
+    apply_parameters = inspect.signature(SpectrumApplyMiniMaxH3.apply).parameters
 
     assert config.degree == 1
     assert config.warmup_steps == 1
     assert config.tail_actual_steps == 1
+    assert config.bootstrap_first_forecast is True
     assert required["degree"][1]["default"] == 1
     assert required["warmup_steps"][1]["default"] == 1
     assert required["tail_actual_steps"][1]["default"] == 1
+    assert optional["bootstrap_first_forecast"] == ("BOOLEAN", {"default": True})
+    assert apply_parameters["bootstrap_first_forecast"].default is True
+
+
+def test_aggressive_preset_explicitly_disables_degree_one_bootstrap():
+    assert AGGRESSIVE_PRESET.degree == 4
+    assert AGGRESSIVE_PRESET.bootstrap_first_forecast is False
+    AGGRESSIVE_PRESET.validate()
 
 
 @pytest.mark.parametrize("value", [0, 1, "true", None])
@@ -71,11 +78,3 @@ def test_bootstrap_first_forecast_accepts_degree_one_and_one_warmup_step():
     ).validate()
 
     assert config.bootstrap_first_forecast is True
-
-
-def test_node_exposes_bootstrap_as_an_optional_boolean():
-    optional = SpectrumApplyMiniMaxH3.INPUT_TYPES()["optional"]
-    apply_parameters = inspect.signature(SpectrumApplyMiniMaxH3.apply).parameters
-
-    assert optional["bootstrap_first_forecast"] == ("BOOLEAN", {"default": False})
-    assert apply_parameters["bootstrap_first_forecast"].default is False

--- a/tests/test_native_equivalence.py
+++ b/tests/test_native_equivalence.py
@@ -184,7 +184,14 @@ def test_exact_forecast_reproduces_the_native_audio_video_velocity(monkeypatch):
     assert "target" in captured
 
     runtime = SpectrumH3Runtime(
-        SpectrumH3Config(degree=1, max_history=4, warmup_steps=2, tail_actual_steps=0, window_size=2.0)
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            warmup_steps=2,
+            tail_actual_steps=0,
+            window_size=2.0,
+            bootstrap_first_forecast=False,
+        )
     )
     run_id = runtime.start_run(torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]), "sample_euler", supported_sampler=True)
     _wrapped_call(model, runtime, 1.0, 1000.0, x, context, payload)
@@ -212,7 +219,14 @@ def test_forecast_step_skips_every_transformer_block_and_preserves_output_shapes
     model, block = _tiny_model()
     x, context, payload = _inputs(PackedLayout)
     runtime = SpectrumH3Runtime(
-        SpectrumH3Config(degree=1, max_history=4, warmup_steps=2, tail_actual_steps=0, window_size=2.0)
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            warmup_steps=2,
+            tail_actual_steps=0,
+            window_size=2.0,
+            bootstrap_first_forecast=False,
+        )
     )
     run_id = runtime.start_run(torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]), "sample_euler", supported_sampler=True)
     _first, first_decision = _wrapped_call(model, runtime, 1.0, 1000.0, x, context, payload)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -17,6 +17,7 @@ def _runtime(**overrides):
         "warmup_steps": 2,
         "tail_actual_steps": 0,
         "window_size": 2.0,
+        "bootstrap_first_forecast": False,
     }
     values.update(overrides)
     return SpectrumH3Runtime(SpectrumH3Config(**values))
@@ -95,6 +96,7 @@ def test_preliminary_runtime_defaults():
     assert config.warmup_steps == 1
     assert config.tail_actual_steps == 1
     assert config.history_storage == "system_ram"
+    assert config.bootstrap_first_forecast is True
 
 
 @pytest.mark.parametrize(
@@ -585,6 +587,7 @@ def test_twenty_step_degree_four_schedule_counts(
             warmup_steps=5,
             flex_window=flex_window,
             tail_actual_steps=tail_actual_steps,
+            bootstrap_first_forecast=False,
         )
     )
     runtime.start_run(torch.linspace(1.0, 0.0, 21), "sample_euler", supported_sampler=True)
@@ -702,7 +705,7 @@ def test_twenty_step_res_schedule_refreshes_once_and_enforces_three_step_tail():
         previous_was_forecast = not actual
         runtime.finalize_step(decision["run_id"], decision["step_id"])
 
-    assert forecast_indices == [2, 4, 6, 8, 10, 12, 14, 16]
+    assert forecast_indices == [1, 3, 5, 7, 9, 11, 13, 15]
     assert runtime.stats.actual_steps == 12
     assert runtime.stats.forecast_steps == 8
 
@@ -771,6 +774,6 @@ def test_twenty_step_euler_schedule_refreshes_between_forecasts():
         previous_was_forecast = not actual
         runtime.finalize_step(decision["run_id"], decision["step_id"])
 
-    assert forecast_indices == [2, 4, 6, 8, 10, 12, 14, 16, 18]
+    assert forecast_indices == [1, 3, 5, 7, 9, 11, 13, 15, 17]
     assert runtime.stats.actual_steps == 11
     assert runtime.stats.forecast_steps == 9


### PR DESCRIPTION
## Summary

- make `bootstrap_first_forecast=true` part of the preliminary new-node defaults
- align the runtime config, ComfyUI input metadata, and `apply()` fallback
- keep the incompatible degree-4 aggressive preset explicitly bootstrap-disabled
- bump the patch release to v0.1.8 and update documentation
- separate legacy scheduler tests from default-bootstrap schedule assertions

## Root cause

v0.1.7 changed `degree`, `warmup_steps`, and `tail_actual_steps` to the tested preliminary values but left the new bootstrap flag disabled in three default layers. That produced a new node which did not use the validated one-point schedule.

## Validation

- current ComfyUI `2340099d`: 105 passed, 1 CUDA-only skip
- ComfyUI `e377e263`: 105 passed, 1 CUDA-only skip
- ComfyUI `0dd9b154`: 105 passed, 1 CUDA-only skip
- forecaster smoke test passed
- v0.1.8 sdist and wheel build passed
- remote tree exactly matches the locally validated tree