### PR TITLE
Auto-disable incompatible one-point bootstrap settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ The node accepts and returns `MODEL`. Disabled mode returns the original model o
 | `ridge_lambda` | `0.10` | Ridge regularization applied to the small Gram matrix. |
 | `window_size` | `2.0` | Initial adaptive interval. |
 | `flex_window` | `0.75` | Amount added to the interval after a scheduled post-warmup actual step. |
-| `warmup_steps` | `1` | Initial solver steps forced to native transformer evaluation. |
+| `warmup_steps` | `1` | Initial solver steps forced to native transformer evaluation. Values above `1` disable the one-point bootstrap. |
 | `tail_actual_steps` | `1` | Requested final native tail. Deterministic RES enforces a sampler-safe minimum of `3`. |
 | `max_history` | `8` | Maximum model-dtype actual feature snapshots retained. |
 | `debug` | `false` | Enables concise run, step, topology, fallback, sanitization, chunk, and teardown logs. |
 | `history_storage` | `system_ram` | Stores history in `system_ram`, or in `vram` to avoid transfer overhead when sufficient accelerator memory is free. |
-| `bootstrap_first_forecast` | `true` | Experimental degree-1 one-point hold that can forecast solver step 1 from the actual step-0 hidden feature. |
+| `bootstrap_first_forecast` | `true` | Experimental one-point hold for `degree=1` and `warmup_steps<=1`. Incompatible node settings disable it with a console warning. |
 
 Every value is validated. `max_history` must be at least `degree + 1`.
 
@@ -131,6 +131,8 @@ warmup_steps <= 1
 ```
 
 After actual step 0, the bootstrap reuses that step's packed final-transformer-block hidden feature as the prediction for step 1. The current step still computes its native H3 timestep conditioning, runs `FinalLayer`, performs the video and audio projections and reconstruction, and applies the current sigma-dependent audio processing. It does not copy the previous step's final video or audio output.
+
+When the ComfyUI node receives `degree != 1` or `warmup_steps > 1`, it disables only `bootstrap_first_forecast` for that execution and logs the supplied values. The requested degree and warmup remain unchanged, and normal history-based forecasting continues. Direct `SpectrumH3Config` callers still receive a validation error for an incompatible enabled bootstrap so configuration mistakes outside the node are not silently accepted.
 
 This bootstrap is separate from polynomial regression. Ordinary degree-1 forecasting still requires at least two actual history entries, no factorization is attempted with one entry, and a bootstrap result is never inserted into actual history. Consequently, step 2 is actual because history still contains only step 0; after step 2, ordinary degree-1 forecasts can proceed.
 

--- a/comfyui_spectrum_h3/nodes.py
+++ b/comfyui_spectrum_h3/nodes.py
@@ -1,9 +1,31 @@
 from __future__ import annotations
 
+import logging
+
 from .config import SpectrumH3Config
 from .minimax_h3 import install_h3_wrapper, require_native_minimax_h3
 from .runtime import SpectrumH3Runtime
 from .sampling import install_sampler_wrappers
+
+LOG = logging.getLogger(__name__)
+
+
+def _effective_bootstrap_first_forecast(
+    *,
+    requested: bool,
+    degree: int,
+    warmup_steps: int,
+) -> bool:
+    if not requested or (degree == 1 and warmup_steps <= 1):
+        return requested
+    LOG.warning(
+        "Spectrum H3: bootstrap_first_forecast was enabled but requires "
+        "degree=1 and warmup_steps<=1; got degree=%d and warmup_steps=%d. "
+        "Disabling bootstrap_first_forecast for this node execution.",
+        degree,
+        warmup_steps,
+    )
+    return False
 
 
 class SpectrumApplyMiniMaxH3:
@@ -14,18 +36,45 @@ class SpectrumApplyMiniMaxH3:
                 "model": ("MODEL",),
                 "enabled": ("BOOLEAN", {"default": True}),
                 "blend_weight": ("FLOAT", {"default": 0.50, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "degree": ("INT", {"default": 1, "min": 1, "max": 16, "step": 1}),
+                "degree": (
+                    "INT",
+                    {
+                        "default": 1,
+                        "min": 1,
+                        "max": 16,
+                        "step": 1,
+                        "tooltip": "Polynomial degree. Values other than 1 disable bootstrap_first_forecast.",
+                    },
+                ),
                 "ridge_lambda": ("FLOAT", {"default": 0.10, "min": 0.0, "max": 10.0, "step": 0.01}),
                 "window_size": ("FLOAT", {"default": 2.0, "min": 1.0, "max": 16.0, "step": 0.05}),
                 "flex_window": ("FLOAT", {"default": 0.75, "min": 0.0, "max": 8.0, "step": 0.05}),
-                "warmup_steps": ("INT", {"default": 1, "min": 0, "max": 64, "step": 1}),
+                "warmup_steps": (
+                    "INT",
+                    {
+                        "default": 1,
+                        "min": 0,
+                        "max": 64,
+                        "step": 1,
+                        "tooltip": "Initial native solver steps. Values above 1 disable bootstrap_first_forecast.",
+                    },
+                ),
                 "tail_actual_steps": ("INT", {"default": 1, "min": 0, "max": 64, "step": 1}),
                 "max_history": ("INT", {"default": 8, "min": 2, "max": 64, "step": 1}),
                 "debug": ("BOOLEAN", {"default": False}),
             },
             "optional": {
                 "history_storage": (["system_ram", "vram"], {"default": "system_ram"}),
-                "bootstrap_first_forecast": ("BOOLEAN", {"default": True}),
+                "bootstrap_first_forecast": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": (
+                            "Forecast solver step 1 from the actual step-0 feature. Requires degree=1 "
+                            "and warmup_steps<=1; incompatible settings disable it with a console warning."
+                        ),
+                    },
+                ),
             },
         }
 
@@ -53,18 +102,27 @@ class SpectrumApplyMiniMaxH3:
         if not enabled:
             return (model,)
         require_native_minimax_h3(model)
+        resolved_degree = int(degree)
+        resolved_warmup_steps = int(warmup_steps)
+        if not isinstance(bootstrap_first_forecast, bool):
+            raise TypeError("bootstrap_first_forecast must be a boolean")
+        effective_bootstrap = _effective_bootstrap_first_forecast(
+            requested=bootstrap_first_forecast,
+            degree=resolved_degree,
+            warmup_steps=resolved_warmup_steps,
+        )
         config = SpectrumH3Config(
             enabled=bool(enabled),
             blend_weight=float(blend_weight),
-            degree=int(degree),
+            degree=resolved_degree,
             ridge_lambda=float(ridge_lambda),
             window_size=float(window_size),
             flex_window=float(flex_window),
-            warmup_steps=int(warmup_steps),
+            warmup_steps=resolved_warmup_steps,
             tail_actual_steps=int(tail_actual_steps),
             max_history=int(max_history),
             history_storage=str(history_storage),
-            bootstrap_first_forecast=bootstrap_first_forecast,
+            bootstrap_first_forecast=effective_bootstrap,
             debug=bool(debug),
         ).validate()
         patched = model.clone()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import inspect
+import logging
 
 import pytest
 
+from comfyui_spectrum_h3 import nodes as nodes_module
 from comfyui_spectrum_h3.config import AGGRESSIVE_PRESET, SpectrumH3Config
-from comfyui_spectrum_h3.nodes import SpectrumApplyMiniMaxH3
+from comfyui_spectrum_h3.nodes import (
+    SpectrumApplyMiniMaxH3,
+    _effective_bootstrap_first_forecast,
+)
 
 
 @pytest.mark.parametrize(
@@ -40,7 +45,12 @@ def test_preliminary_scheduler_defaults():
     assert required["degree"][1]["default"] == 1
     assert required["warmup_steps"][1]["default"] == 1
     assert required["tail_actual_steps"][1]["default"] == 1
-    assert optional["bootstrap_first_forecast"] == ("BOOLEAN", {"default": True})
+    assert optional["bootstrap_first_forecast"][0] == "BOOLEAN"
+    assert optional["bootstrap_first_forecast"][1]["default"] is True
+    assert "degree=1" in optional["bootstrap_first_forecast"][1]["tooltip"]
+    assert "warmup_steps<=1" in optional["bootstrap_first_forecast"][1]["tooltip"]
+    assert "disable bootstrap_first_forecast" in required["degree"][1]["tooltip"]
+    assert "disable bootstrap_first_forecast" in required["warmup_steps"][1]["tooltip"]
     assert apply_parameters["bootstrap_first_forecast"].default is True
 
 
@@ -78,3 +88,88 @@ def test_bootstrap_first_forecast_accepts_degree_one_and_one_warmup_step():
     ).validate()
 
     assert config.bootstrap_first_forecast is True
+
+
+@pytest.mark.parametrize(
+    ("degree", "warmup_steps"),
+    [
+        (2, 1),
+        (1, 2),
+        (2, 2),
+    ],
+)
+def test_node_disables_incompatible_bootstrap_settings(degree, warmup_steps, caplog):
+    with caplog.at_level(logging.WARNING, logger="comfyui_spectrum_h3.nodes"):
+        effective = _effective_bootstrap_first_forecast(
+            requested=True,
+            degree=degree,
+            warmup_steps=warmup_steps,
+        )
+
+    assert effective is False
+    assert "Disabling bootstrap_first_forecast" in caplog.text
+    assert f"degree={degree}" in caplog.text
+    assert f"warmup_steps={warmup_steps}" in caplog.text
+
+
+def test_node_keeps_compatible_bootstrap_without_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="comfyui_spectrum_h3.nodes"):
+        effective = _effective_bootstrap_first_forecast(
+            requested=True,
+            degree=1,
+            warmup_steps=1,
+        )
+
+    assert effective is True
+    assert not caplog.records
+
+
+def test_node_keeps_explicitly_disabled_bootstrap_without_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="comfyui_spectrum_h3.nodes"):
+        effective = _effective_bootstrap_first_forecast(
+            requested=False,
+            degree=4,
+            warmup_steps=5,
+        )
+
+    assert effective is False
+    assert not caplog.records
+
+
+def test_apply_normalizes_reported_warmup_conflict(monkeypatch, caplog):
+    captured = {}
+
+    class FakeModel:
+        def clone(self):
+            return FakeModel()
+
+    class FakeRuntime:
+        def __init__(self, config):
+            captured["config"] = config
+
+    monkeypatch.setattr(nodes_module, "require_native_minimax_h3", lambda model: None)
+    monkeypatch.setattr(nodes_module, "SpectrumH3Runtime", FakeRuntime)
+    monkeypatch.setattr(nodes_module, "install_sampler_wrappers", lambda model, runtime: None)
+    monkeypatch.setattr(nodes_module, "install_h3_wrapper", lambda model: None)
+
+    with caplog.at_level(logging.WARNING, logger="comfyui_spectrum_h3.nodes"):
+        (patched,) = SpectrumApplyMiniMaxH3().apply(
+            FakeModel(),
+            True,
+            0.50,
+            1,
+            0.10,
+            2.0,
+            0.75,
+            2,
+            1,
+            8,
+            False,
+            bootstrap_first_forecast=True,
+        )
+
+    assert isinstance(patched, FakeModel)
+    assert captured["config"].degree == 1
+    assert captured["config"].warmup_steps == 2
+    assert captured["config"].bootstrap_first_forecast is False
+    assert "Disabling bootstrap_first_forecast" in caplog.text


### PR DESCRIPTION
## Summary

- auto-disable `bootstrap_first_forecast` at the ComfyUI node boundary when `degree != 1` or `warmup_steps > 1`
- emit a console warning containing the supplied degree and warmup values
- add inline tooltips for all three dependent inputs and document the normalization behavior in the README
- retain strict `SpectrumH3Config.validate()` errors for direct programmatic callers

## Root cause

ComfyUI exposes `degree`, `warmup_steps`, and `bootstrap_first_forecast` as independent widgets. The node forwarded every combination into strict configuration validation, so the default-enabled bootstrap made a user-requested larger warmup fail before sampling even though the correct effective behavior is well-defined: keep the requested warmup and disable only the step-1 bootstrap.

The same trap existed for `degree != 1`, so the node boundary now normalizes both bootstrap preconditions consistently.

## Behavior and safety

Compatible settings are unchanged. Explicitly disabled bootstrap settings are unchanged. In incompatible node configurations, only the effective bootstrap flag changes; `degree` and `warmup_steps` retain their supplied values and normal history-based forecasting continues. Direct configuration construction remains strict so non-UI mistakes are still rejected.

## Validation

- focused node/config regression suite: 20 passed
- includes the reported `warmup_steps=2` apply path, degree-only conflict, warmup-only conflict, combined conflict, compatible path, explicit-disable path, warning contents, and tooltip metadata
- `python -m compileall -q comfyui_spectrum_h3 tests`
- `git diff --check`

The available runner does not include PyTorch, so tensor-dependent full-suite execution was unavailable. The focused suite used an empty Torch import stub and does not execute tensor code.