### PR TITLE
Handle downstream H3 bypasses and release v0.1.10

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -49,6 +49,8 @@ The optional `bootstrap_first_forecast` path is evaluated after configured warmu
 
 Native EasyCache and LazyCache may terminate a diffusion-model wrapper chain without an H3 call. Their shared `transformer_options["easycache"]` holder is therefore detected before Spectrum opens a run transaction. Spectrum remains inactive for that run and the cache owns the acceleration path.
 
+Other downstream wrappers can also return a valid `predict_noise` result before the native H3 wrapper is reached. This cannot be detected reliably before execution. A zero-call step therefore commits as a passthrough boundary: Spectrum disables forecasting for the rest of the run, clears all retained history, resets forecast-refresh state, and accepts the wrapped result. It logs the transition once and tracks subsequent bypasses separately from actual and forecast steps.
+
 ## Forecast memory model
 
 The forecaster stores at most `max_history` detached model-dtype snapshots in the configured history storage: system RAM by default, or the producing model device when the opt-in VRAM mode is selected. It solves only for history weights:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ The native path is used when forecasting is unsupported or cannot be proven safe
 
 Split conditional calls are assigned by ComfyUI's `cond_or_uncond` and UUID labels. Row allocation is transactional. If correspondence becomes incomplete after an earlier subcall forecast, the entire `predict_noise` attempt is discarded and rerun as an actual step. Exceptions abort the active step without advancing scheduler state, preserve the original traceback, and outer-run teardown releases all history.
 
+If a downstream model or cache patch returns a successful `predict_noise` result without reaching the native MiniMax H3 wrapper, Spectrum accepts that result as a passthrough, disables itself for the rest of the run, and releases its forecast history. One warning identifies the bypass. This preserves the other patch's execution path without letting Spectrum continue from an unobserved solver step.
+
 Model wrappers are registered on the cloned `ModelPatcher`. A clone callback creates a new runtime for every downstream clone. The shared inner H3 module stores no Spectrum state and is never monkey-patched.
 
 ## Validation status

--- a/README.md
+++ b/README.md
@@ -10,14 +10,19 @@ This repository is independent from [ComfyUI-Spectrum-Proper](https://github.com
 
 Spectrum is an approximate accelerator, not a lossless or bit-identical execution path. Forecasted steps change the denoising trajectory, so outputs can differ even when the prompt, seed, model, sampler, and workflow are otherwise identical.
 
-Initial testing did not reveal obvious differences in several outputs, but broader exact-seed A/B testing has since exposed two distinct kinds of changes:
+The current `degree=1`, `warmup_steps=1`, `bootstrap_first_forecast=true` defaults are an aggressive, performance-oriented configuration. In local exact-seed testing with the pruned BF16 checkpoint at approximately 0.8 MP, they did not produce an obvious visible or audible quality decrease. That result does not establish the same tolerance for every checkpoint, resolution, generation mode, or prompt.
+
+Broader exact-seed A/B testing and early user reports have exposed several kinds of changes:
 
 - **Trajectory deviations:** during fast or brief actions, the motion, pose, timing, gaze, or action path can diverge from the fully native run. For example, a subject may look up, move differently, or follow a different short motion than in the native output.
-- **Localized quality degradation during fast motion:** when eyes, fingers, fingernails, or other small articulated details move quickly or are visible only briefly, those details can become malformed or unstable.
+- **Visual degradation:** eyes, fingers, fingernails, faces, limbs, or other articulated details can become malformed or unstable. Reported symptoms include distorted anatomy and additional limbs, especially in demanding motion.
+- **Audio degradation:** aggressive settings can distort generated audio as well as video. Reference-audio distortion has been reported with the Reference Model, and audiovisual synchronization should also be checked.
 
-These effects can occur independently or together. A rapid action may simply follow a different trajectory without obvious artifacting, while in another output the fast-moving or briefly visible details may also degrade. Further local testing and user reports have shown both behaviors. These are qualitative observations rather than a controlled quality benchmark; the effect varies with the prompt, motion, sampler, resolution, references, and Spectrum settings.
+These effects can occur independently or together. Current evidence does not isolate a single cause. Checkpoint type and precision, output resolution, prompt and motion complexity, reference-audio conditioning, sampler and scheduler, the number of early native steps, the one-point bootstrap, and the total sampling-step count may all affect stability. Lower resolutions and heavily quantized model configurations may have less margin for absorbing forecast error, but this remains a hypothesis rather than a controlled finding.
 
-Use Spectrum when the speed benefit is worth possible output differences. Disable it when maximum fidelity to the native MiniMax H3 trajectory is more important. For quality-critical work, compare the same prompt and seed with Spectrum enabled and disabled.
+For quality-critical work, compare the same prompt and seed with Spectrum enabled and disabled. If the aggressive defaults cause visible or audible degradation, increase `degree` and `warmup_steps` and disable `bootstrap_first_forecast`; the [conservative quality-first preset](#conservative-quality-first-preset) below is a starting point. Increasing the total sampling-step count may also be necessary for reference-audio generations. One user reported reference-audio distortion with the aggressive defaults: increasing `degree` and `warmup_steps` helped, and a 30-step run with those increased settings produced clean audio on their setup.
+
+Use Spectrum when the speed benefit is worth possible output differences. Disable it when maximum fidelity to the native MiniMax H3 trajectory is more important.
 
 ## Supported native path
 
@@ -60,7 +65,7 @@ The node accepts and returns `MODEL`. Disabled mode returns the original model o
 
 ## Parameters
 
-| Parameter | Preliminary default | Meaning |
+| Parameter | Preliminary performance default | Meaning |
 |---|---:|---|
 | `enabled` | `true` | Enables the clone-local Spectrum runtime. |
 | `blend_weight` | `0.50` | Spectral share of the prediction. The remainder is a two-point local linear forecast. |
@@ -77,7 +82,7 @@ The node accepts and returns `MODEL`. Disabled mode returns the original model o
 
 Every value is validated. `max_history` must be at least `degree + 1`.
 
-### Preliminary default preset
+### Preliminary performance preset (default)
 
 ```text
 blend_weight = 0.50
@@ -92,14 +97,14 @@ history_storage = system_ram
 bootstrap_first_forecast = true
 ```
 
-### Provisional aggressive preset
+### Conservative quality-first preset
 
 ```text
-blend_weight = 0.75
+blend_weight = 0.50
 degree = 4
 ridge_lambda = 0.10
 window_size = 2.0
-flex_window = 3.0
+flex_window = 0.75
 warmup_steps = 5
 tail_actual_steps = 1
 max_history = 8
@@ -107,7 +112,7 @@ history_storage = system_ram
 bootstrap_first_forecast = false
 ```
 
-The default degree, warmup, tail, and one-point bootstrap are preliminary pending broader prompt, sampler, and quality coverage. Existing workflows retain their saved input values. The aggressive preset remains an explicit alternative and disables the degree-1-only bootstrap.
+The preliminary defaults prioritize throughput and have not been established as universally quality-safe. Existing workflows retain their saved input values. The quality-first preset changes only the forecast degree, warmup, and bootstrap behavior relative to the defaults: it keeps the first five solver steps native, waits for the five actual history points required by degree 4, and does not use the one-point hold. It reduces the speed benefit and is a starting point rather than a guarantee; exact-seed Spectrum-on/Spectrum-off validation remains necessary for the intended workflow.
 
 ## Adaptive schedule
 
@@ -123,7 +128,7 @@ Schedule counts depend on the sampler safeguards and whether the experimental on
 
 ### Experimental one-point bootstrap
 
-`bootstrap_first_forecast=true` (the preliminary default) enables an H3-specific zero-order hold for solver step 1. It requires:
+`bootstrap_first_forecast=true` (the preliminary performance default) enables an H3-specific zero-order hold for solver step 1. It requires:
 
 ```text
 degree = 1
@@ -221,11 +226,12 @@ Automated tests cover:
 - target audio/video segment ordering and sanitization;
 - model detection and clone runtime isolation;
 - exact native versus wrapped forced-actual video/audio output on a deterministic tiny native H3 fixture;
-- proof that a forecast fixture invokes zero H3 transformer blocks.
+- proof that a forecast fixture invokes zero H3 transformer blocks;
+- downstream `predict_noise` passthroughs that never reach the native H3 wrapper, including one-warning disablement and retained-history release.
 
 A community compatibility report confirmed that revision `dc6291525112cb4246f864738e5bb4e2b85446da` ran without source changes on Windows 11 with a Radeon AI PRO R9700 32 GB, PyTorch 2.9.1 + ROCm 7.2.1, and ComfyUI 0.30.0. In the reported 20-step RES multistep, 864x480, 107-frame `system_ram` workflow, the expected 14 actual and 6 forecasted evaluations reduced warm elapsed time from 212.73 s to 160.97 s (24.33% lower time; about 1.32x throughput). This validates only that exact configuration; other AMD GPUs, ROCm builds, workflows, and quality cases remain unverified. See [issue #6](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/issues/6).
 
-No full MiniMax H3 checkpoint is available in the automated environment. The supplied real-checkpoint A/B runs validate the 0.5 MP VRAM allocation and show a small, variable timing benefit. Exact-seed full-checkpoint comparisons have also shown both trajectory deviations during fast or brief actions and localized degradation in rapidly moving or briefly visible details such as eyes, fingers, and fingernails. These effects can occur separately or together. Other resolutions, durations, CFG topologies, reference modes, hardware, decoded video metrics, audio metrics, and audiovisual synchronization remain unverified. Spectrum must not be treated as lossless or output-identical to native sampling.
+No full MiniMax H3 checkpoint is available in the automated environment. The supplied real-checkpoint A/B runs validate the 0.5 MP VRAM allocation and show a small, variable timing benefit. Local exact-seed testing with the pruned BF16 checkpoint at approximately 0.8 MP did not reveal an obvious visible or audible quality decrease with the preliminary performance defaults. Other exact-seed comparisons and user reports have shown trajectory deviations, malformed rapidly moving details, distorted anatomy, additional limbs, and reference-audio distortion on some setups. In the reported reference-audio case, increasing `degree` and `warmup_steps` helped, and a 30-step run with those increased settings produced clean audio. This evidence is qualitative and does not isolate checkpoint precision, resolution, bootstrap behavior, or total step count as the cause. Other resolutions, durations, CFG topologies, reference modes, hardware, decoded video metrics, audio metrics, and audiovisual synchronization remain unverified. Spectrum must not be treated as lossless or output-identical to native sampling.
 
 ## Tests
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,20 @@
-# Spectrum MiniMax H3 v0.1.9
+# Spectrum MiniMax H3 v0.1.10
 
-Prevents incompatible one-point-bootstrap settings from turning a valid ComfyUI workflow into an execution-time error.
+Makes Spectrum tolerate valid downstream model-patch paths that complete a solver evaluation without reaching Spectrum's native MiniMax H3 wrapper.
 
 ## Fixed
 
-- When `bootstrap_first_forecast` is enabled with `warmup_steps > 1`, keep the requested warmup and automatically disable only the one-point bootstrap for that execution.
-- Apply the same normalization when `degree != 1`, since the bootstrap is defined only for degree 1.
-- Emit a console warning with the supplied degree and warmup values whenever normalization occurs.
-- Add inline ComfyUI tooltips for `degree`, `warmup_steps`, and `bootstrap_first_forecast`, and document the effective behavior in the README.
-- Preserve strict `SpectrumH3Config` validation for direct programmatic callers outside the ComfyUI node boundary.
+- Accept the downstream patch's successful `predict_noise` result instead of raising `Spectrum H3 solver step completed without an H3 model call`.
+- Disable Spectrum forecasting for the remainder of that sampling run after a bypass, preventing history from advancing across an unobserved solver step.
+- Immediately release retained forecast history and reset refresh state at the bypass boundary.
+- Emit one precise warning per run and report bypassed steps separately from actual and forecast work.
+- Preserve normal Spectrum operation when downstream patches, including the current MiniMax H3 Sol-Attn path, continue through the native H3 wrapper.
 
-Compatible settings and explicitly disabled bootstrap configurations are unchanged. Normal history-based forecasting continues with the requested degree and warmup values.
+## Documentation
+
+- Identify the default degree-1, one-step-warmup, one-point-bootstrap schedule as the preliminary performance preset.
+- Add a conservative degree-4, five-step-warmup, bootstrap-disabled starting preset for quality-sensitive workflows.
+- Expand the fidelity guidance to cover trajectory changes, visual artifacts, generated/reference-audio distortion, and audiovisual validation.
+- Record the reported reference-audio result precisely: increasing `degree` and `warmup_steps` helped, and a 30-step run with those increased settings produced clean audio on that setup.
+
+Existing workflow inputs and normal native-H3 sampling behavior are unchanged. If a downstream patch bypasses the native H3 wrapper, that patch remains active while Spectrum safely becomes a passthrough for the rest of the run.

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -39,6 +39,7 @@ class RuntimeStats:
     actual_transformer_calls: int = 0
     forecast_model_calls: int = 0
     forecast_fallbacks: int = 0
+    bypassed_steps: int = 0
     history_archive_seconds: float = 0.0
     history_update_seconds: float = 0.0
     forecast_prediction_seconds: float = 0.0
@@ -309,8 +310,9 @@ class SpectrumH3Runtime:
             raise RuntimeError("Spectrum H3 solver-step context is stale")
         return self._step
 
-    def _disable_forecasting(self, reason: str) -> None:
-        if not self._disabled:
+    def _disable_forecasting(self, reason: str) -> bool:
+        newly_disabled = not self._disabled
+        if newly_disabled:
             self._disabled = True
             self._disable_reason = str(reason)
             self.stats.disabled = True
@@ -318,6 +320,7 @@ class SpectrumH3Runtime:
         self.forecaster.reset()
         self._history_topology = None
         self._history_labels = None
+        return newly_disabled
 
     def _fallback_or_retry(self, step: _StepState, reason: str) -> None:
         self._disable_forecasting(reason)
@@ -520,8 +523,21 @@ class SpectrumH3Runtime:
                 self.stats.current_window = self._current_window
                 self._step = None
                 return
-            self._disable_forecasting("solver step completed without an H3 model call")
-            raise RuntimeError("Spectrum H3 solver step completed without an H3 model call")
+            reason = "solver step completed without reaching the native H3 model wrapper"
+            newly_disabled = self._disable_forecasting(reason)
+            self._consecutive_forecasts = 0
+            self._required_actual_refreshes = 0
+            self.stats.bypassed_steps += 1
+            self.stats.current_window = self._current_window
+            self._step = None
+            if newly_disabled:
+                LOG.warning(
+                    "Spectrum H3 disabled for the rest of this run because a predict-noise "
+                    "evaluation returned without reaching the native MiniMax H3 model wrapper; "
+                    "accepting the wrapped result as a passthrough. Another model or cache patch "
+                    "may have intercepted the evaluation."
+                )
+            return
 
         if step.mode == "forecast":
             if any(call.observed_actual for call in step.calls) or not all(call.used_forecast for call in step.calls):
@@ -578,7 +594,8 @@ class SpectrumH3Runtime:
             f"forecast_steps={self.stats.forecast_steps} "
             f"actual_transformer_calls={self.stats.actual_transformer_calls} "
             f"forecast_calls={self.stats.forecast_model_calls} "
-            f"fallbacks={self.stats.forecast_fallbacks} disabled={self.stats.disabled} "
+            f"fallbacks={self.stats.forecast_fallbacks} "
+            f"bypassed_steps={self.stats.bypassed_steps} disabled={self.stats.disabled} "
             f"history_archive_s={self.stats.history_archive_seconds:.3f} "
             f"history_update_s={self.stats.history_update_seconds:.3f} "
             f"forecast_predict_s={self.stats.forecast_prediction_seconds:.3f} "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.1.9"
+version = "0.1.10"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -735,6 +735,42 @@ def test_aborted_res_refresh_does_not_consume_refresh_state():
     runtime.abort_step(run_id, retried["step_id"])
 
 
+def test_missing_h3_call_disables_forecasting_and_releases_history():
+    runtime = _runtime(
+        bootstrap_first_forecast=True,
+        warmup_steps=1,
+        tail_actual_steps=0,
+    )
+    runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.25, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    _actual_step(runtime, 1.0, [(LABEL, torch.ones(1, 3, 4))])
+
+    decision = runtime.begin_step(torch.tensor([0.5]))
+    assert not decision["actual"]
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    assert runtime.active_step_id is None
+    assert runtime.stats.bypassed_steps == 1
+    assert runtime.stats.actual_steps == 1
+    assert runtime.stats.forecast_steps == 0
+    assert runtime.stats.disabled
+    assert "without reaching the native H3 model wrapper" in runtime.disabled_reason
+    assert runtime.forecaster.history_length == 0
+
+    summary = runtime.debug_summary()
+    assert "bypassed_steps=1" in summary
+
+    next_step = runtime.begin_step(torch.tensor([0.25]))
+    assert next_step["actual"]
+    assert next_step["reason"] == runtime.disabled_reason
+    runtime.abort_step(next_step["run_id"], next_step["step_id"])
+
+
 def test_twenty_step_euler_schedule_refreshes_between_forecasts():
     runtime = SpectrumH3Runtime(SpectrumH3Config())
     runtime.start_run(

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from comfyui_spectrum_h3.config import SpectrumH3Config
 from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
@@ -13,6 +14,7 @@ from comfyui_spectrum_h3.sampling import (
     min_actual_steps_after_forecast,
     min_tail_actual_steps,
     outer_sample_wrapper,
+    predict_noise_wrapper,
     sampler_is_supported,
     sampler_name,
 )
@@ -126,3 +128,47 @@ def test_easycache_on_same_model_bypasses_spectrum_run(caplog):
     assert len(calls) == 1
     assert runtime.active_run_id is None
     assert "EasyCache or LazyCache is active" in caplog.text
+
+
+def test_predict_noise_passthrough_survives_a_downstream_model_bypass(caplog):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            warmup_steps=1,
+            tail_actual_steps=0,
+            bootstrap_first_forecast=True,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    guider = SimpleNamespace(model_options={BINDING_KEY: SpectrumH3Binding(runtime)})
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            calls.append((args, kwargs))
+            return f"intercepted-result-{len(calls)}"
+
+    try:
+        with caplog.at_level("WARNING"):
+            first = predict_noise_wrapper(
+                Executor(), "latent", torch.tensor([1.0]), {"sentinel": True}, seed=7
+            )
+            second = predict_noise_wrapper(
+                Executor(), "latent", torch.tensor([0.5]), {"sentinel": True}, seed=7
+            )
+
+        assert first == "intercepted-result-1"
+        assert second == "intercepted-result-2"
+        assert len(calls) == 2
+        assert runtime.stats.bypassed_steps == 2
+        assert runtime.active_step_id is None
+        assert caplog.text.count("accepting the wrapped result as a passthrough") == 1
+    finally:
+        runtime.end_run(run_id)


### PR DESCRIPTION
## What changed

- Treat a successful `predict_noise` result that never reaches Spectrum's native MiniMax H3 wrapper as a passthrough boundary.
- Disable Spectrum for the remainder of that run, clear retained forecast history, reset refresh state, and continue with the downstream patch's result.
- Emit one diagnostic warning and track bypassed steps separately from actual and forecast steps.
- Document the transaction behavior and add runtime plus wrapper-level regression coverage.
- Expand the README quality guidance to cover trajectory changes, visual degradation, reference-audio distortion, and audiovisual validation.
- Identify the degree-1/warmup-1/bootstrap defaults as the preliminary performance configuration and add a degree-4/warmup-5/bootstrap-disabled quality-first preset.
- Record the reference-audio report precisely: increasing `degree` and `warmup_steps` helped, and a 30-step run with those increased settings produced clean audio on that setup.
- Bump package metadata to `0.1.10` and publish synchronized release notes.

## Root cause

Spectrum opened a solver-step transaction before delegating to the remaining ComfyUI wrapper chain. It assumed every successful delegated result would invoke the native H3 diffusion wrapper. A downstream model or cache patch may legally intercept the evaluation and return a result first. The delegated call therefore succeeded while Spectrum observed zero H3 calls, and `finalize_step` converted that compatibility case into a fatal runtime error.

The current Sol-Attn H3 hooks were also exercised with Spectrum's native wrapper in a tiny integration fixture; those hooks do reach the H3 wrapper. User workflow validation confirms sampling completes with Sol-Attn. The fix remains at the violated transaction boundary so state-dependent or future interceptors cannot crash the run.

## Validation

- `COMFYUI_PATH=../comfyui-current PYTHONPATH=../comfyui-current python -m pytest -q`
- 113 passed, 1 skipped (CUDA-only forecaster test; CUDA unavailable)
- Direct tiny native-H3 check with current Sol-Attn H3 hooks: one native transformer call observed and captured
- User validation: sampling completes with Sol-Attn
- Release version and notes synchronized at `0.1.10`

Closes #23.