### PR TITLE
Make offline audio correction the v0.2.1 default

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -63,9 +63,9 @@ The one-point bootstrap bypasses spectral and linear weight construction and sup
 
 Native H3 lays out target rows as one contiguous `[audio | video]` packed tail. Actual capture archives that tail without materializing an audio/video concatenation. System-RAM mode copies the view directly to CPU. VRAM mode must clone it into compact owned device storage, because retaining the view would pin the complete final-block hidden tensor. When one model call contains the complete canonical branch set, the archived tensor transfers directly into forecaster history; split conditional calls retain the transactional canonicalization path and assemble rows only after all calls complete. Debug summaries expose the storage location and wall-clock archive, history-update, and forecast-prediction counters. Device-to-host archiving can synchronize outstanding CUDA work, while device cloning can be asynchronously enqueued.
 
-## Default-off trajectory-correction experiments
+## Default trajectory correction and retained experiments
 
-The published Spectrum procedure remains the causal online baseline. When `enabled=True`, `anchor_residual_feedback`, `selective_rollback_correction`, and `offline_smoothing_replay` are mutually exclusive repository experiments. With all three false, no experimental archive, probe, correction, or sampler controller is allocated.
+The published Spectrum procedure remains the causal online baseline. MiniMax H3 uses offline smoothing replay as its standard default-on correction because same-seed testing reproduced causal video-to-audio degradation in the single-pass path and removed it with isolated capture/replay. `anchor_residual_feedback` and `selective_rollback_correction` remain default-off repository experiments. When `enabled=True`, those two modes and `offline_smoothing_replay` are mutually exclusive. With all three false, no archive, probe, correction, or sampler controller is allocated and the node executes the explicit single-pass comparison path.
 
 ### Residual boundary and policy
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ This repository is independent from [ComfyUI-Spectrum-Proper](https://github.com
 
 Spectrum is an approximate accelerator, not a lossless or bit-identical execution path. Forecasted steps change the denoising trajectory, so outputs can differ even when the prompt, seed, model, sampler, and workflow are otherwise identical.
 
-The current `degree=1`, `warmup_steps=1`, `bootstrap_first_forecast=true` defaults are an aggressive, performance-oriented configuration. In local exact-seed testing with the pruned BF16 checkpoint at approximately 0.8 MP, they did not produce an obvious visible or audible quality decrease. That result does not establish the same tolerance for every checkpoint, resolution, generation mode, or prompt.
+The current `degree=1`, `warmup_steps=1`, `bootstrap_first_forecast=true` schedule is aggressive and performance-oriented. The default `offline_smoothing_replay=true`, `blend_weight=0.5`, `audio_blend_weight=0` path separates the video blend from the causal joint audio-video trajectory. On the exact seed that reproduced degraded speech and stuttering in single-pass mode, this path restored clean, high-quality audio while retaining the preferred image result. That result does not establish the same tolerance for every checkpoint, resolution, generation mode, or prompt.
 
 Broader exact-seed A/B testing and early user reports have exposed several kinds of changes:
 
 - **Trajectory deviations:** during fast or brief actions, the motion, pose, timing, gaze, or action path can diverge from the fully native run. For example, a subject may look up, move differently, or follow a different short motion than in the native output.
 - **Visual degradation:** eyes, fingers, fingernails, faces, limbs, or other articulated details can become malformed or unstable. Reported symptoms include distorted anatomy and additional limbs, especially in demanding motion.
-- **Audio degradation:** aggressive settings can distort generated audio as well as video. Reference-audio distortion has been reported with the Reference Model, and audiovisual synchronization should also be checked.
+- **Audio degradation:** single-pass forecasting and nonzero audio spectral blending can distort generated audio as well as video. Reference-audio distortion has also been reported with the Reference Model, and audiovisual synchronization should be checked.
 
 These effects can occur independently or together. Current evidence does not isolate a single cause. Checkpoint type and precision, output resolution, prompt and motion complexity, reference-audio conditioning, sampler and scheduler, the number of early native steps, the one-point bootstrap, and the total sampling-step count may all affect stability. Lower resolutions and heavily quantized model configurations may have less margin for absorbing forecast error, but this remains a hypothesis rather than a controlled finding.
 
-For quality-critical work, compare the same prompt and seed with Spectrum enabled and disabled. If the aggressive defaults cause visible or audible degradation, increase `degree` and `warmup_steps` and disable `bootstrap_first_forecast`; the [conservative quality-first preset](#conservative-quality-first-preset) below is a starting point. Increasing the total sampling-step count may also be necessary for reference-audio generations. One user reported reference-audio distortion with the aggressive defaults: increasing `degree` and `warmup_steps` helped, and a 30-step run with those increased settings produced clean audio on their setup.
+For quality-critical work, compare the same prompt and seed with Spectrum enabled and disabled. Keep the default offline replay and `audio_blend_weight=0` when evaluating audio. If the aggressive schedule still causes visible or audible degradation, increase `degree` and `warmup_steps` and disable `bootstrap_first_forecast`; the [conservative quality-first preset](#conservative-quality-first-preset) below is a starting point. Increasing the total sampling-step count may also be necessary for reference-audio generations. One user reported reference-audio distortion with the aggressive schedule: increasing `degree` and `warmup_steps` helped, and a 30-step run with those increased settings produced clean audio on their setup.
 
 Use Spectrum when the speed benefit is worth possible output differences. Disable it when maximum fidelity to the native MiniMax H3 trajectory is more important.
 
@@ -81,9 +81,9 @@ The node accepts and returns `MODEL`. Disabled mode returns the original model o
 | `debug` | `false` | Enables concise run, step, topology, fallback, sanitization, chunk, and teardown logs. |
 | `history_storage` | `system_ram` | Stores history in `system_ram`, or in `vram` to avoid transfer overhead when sufficient accelerator memory is free. |
 | `bootstrap_first_forecast` | `true` | Experimental one-point hold for `degree=1` and `warmup_steps<=1`. Incompatible node settings disable it with a console warning. |
-| `anchor_residual_feedback` | `false` | Experimental video-scored actual-refresh guard. It never injects a hidden residual. |
-| `selective_rollback_correction` | `false` | Experimental thresholded, budgeted rollback for the exact deterministic Euler sampler contract. |
-| `offline_smoothing_replay` | `false` | Experimental two-pass mode: local-only causal capture followed by cross-validated, transformer-free bidirectional replay. |
+| `anchor_residual_feedback` | `false` | Experimental video-scored actual-refresh guard. It never injects a hidden residual. Disable offline replay before enabling it. |
+| `selective_rollback_correction` | `false` | Experimental thresholded, budgeted rollback for the exact deterministic Euler sampler contract. Disable offline replay before enabling it. |
+| `offline_smoothing_replay` | `true` | Standard two-pass audio-quality path: local-only causal capture followed by cross-validated, transformer-free bidirectional replay. |
 | `audio_blend_weight` | `0.00` | Direct audio spectral share. Zero prevents spectral mixing of audio rows; ordinary single-pass H3 can still couple later audio to the video trajectory. |
 
 Every value is validated. `max_history` must be at least `degree + 1`.
@@ -96,17 +96,17 @@ A subsequent full-H3 comparison showed that direct row separation was necessary 
 
 On the same seed that reproduced the defect, revised offline replay with `video=0.5, audio=0` removed the speech stutter and retained the preferred image result. Disabling offline replay with the same weights brought the stutter back. This same-seed A/B validates the isolated capture/replay mechanism for that case: local-only capture preserves the clean audio anchor trajectory, and replay-only video blending cannot feed through another joint transformer call. It does not establish universal audio safety across seeds, checkpoints, samplers, prompts, or reference inputs. Ordinary one-pass Spectrum keeps the configured weights unchanged and remains susceptible to this indirect coupling path.
 
-When `enabled=True`, the three trajectory-correction settings are mutually exclusive. Enabling more than one raises an error that lists every conflicting setting. Existing workflows do not contain these optional inputs and therefore load with all three disabled. With all three disabled, the established single-pass schedule and output path are unchanged apart from the new modality-specific audio blend default.
+When `enabled=True`, the three trajectory modes are mutually exclusive. Enabling more than one raises an error that lists every conflicting setting. New nodes use offline replay by default. Workflows created before v0.2.0 did not store this input and therefore also receive the new default. Workflows saved with v0.2.0 may retain their serialized `offline_smoothing_replay=false` value after upgrading; turn it on once in those existing nodes to use the corrected default path. Turning it off explicitly retains the single-pass comparison path.
 
-## Experimental trajectory correction
+## Default trajectory correction and retained experiments
 
-These repository-specific experiments extend the published causal, online Spectrum algorithm. They remain default-off. Real-checkpoint tests at 0.65 MP, 8 seconds, 20-step Euler found an audio stutter with the original audiovisual anchor-feedback injection and excessive rollback work under the original `score > 1` trigger. Later same-seed testing validated the revised offline capture/replay separation for one reproducibly affected speech case. The safeguards below respond to those observations; broader quality, speed, memory, and stability remain unproven.
+Offline smoothing replay is the standard default-on H3 path because it prevents the reproduced causal video-to-audio feedback defect. The two repository-specific residual/rollback experiments remain default-off. Real-checkpoint tests at 0.65 MP, 8 seconds, 20-step Euler found an audio stutter with the original audiovisual anchor-feedback injection and excessive rollback work under the original `score > 1` trigger. The safeguards below retain those modes for continued research without placing them on the default execution path.
 
-| Setting | Sampler support | Passes | Behavior when unsupported |
-|---|---|---:|---|
-| `anchor_residual_feedback` | Euler, RES multistep, RES multistep CFG++ | 1 | Ordinary Spectrum/native fallback rules remain active. |
-| `selective_rollback_correction` | Exact deterministic `sample_euler`, with `s_churn=0` | 1, with local replay on a trigger | RES, CFG++, churned, ancestral, unknown, intercepted, and multi-GPU paths log once and run ordinary Spectrum. |
-| `offline_smoothing_replay` | Euler, RES multistep, RES multistep CFG++ | 2 | Unsupported samplers run one valid native pass. An incomplete first-pass archive returns the valid first-pass result. |
+| Setting | Status/default | Sampler support | Passes | Behavior when unsupported |
+|---|---|---|---:|---|
+| `anchor_residual_feedback` | Experimental / off | Euler, RES multistep, RES multistep CFG++ | 1 | Ordinary Spectrum/native fallback rules remain active. |
+| `selective_rollback_correction` | Experimental / off | Exact deterministic `sample_euler`, with `s_churn=0` | 1, with local replay on a trigger | RES, CFG++, churned, ancestral, unknown, intercepted, and multi-GPU paths log once and run ordinary Spectrum. |
+| `offline_smoothing_replay` | Standard / on | Euler, RES multistep, RES multistep CFG++ | 2 | Unsupported samplers run one valid native pass. An incomplete first-pass archive returns the valid local-only first-pass result. |
 
 ### Shared anchor residual
 
@@ -180,7 +180,7 @@ Replay adds a second sampler pass and output-head work while eliminating H3 tran
 
 Across three supplied 0.65 MP / 8-second runs of the earlier fixed-blend implementation, the transformer-free replay added 8.49%, 8.63%, and 8.95% to its corresponding first-pass sampler time while retaining 11 first-pass H3 calls. A later VRAM-resident local-only replay completed in `0.441 s`, while the matched ordinary Spectrum run used the same 11-call schedule. Global `blend_weight=0.5` produced audio issues in both ordinary Spectrum and offline replay; global `blend_weight=0` did not in either of two runs. Direct modality splitting improved the defect but left speech tripping in ordinary single-pass `video=0.5, audio=0`. With the revised isolated capture policy, offline replay at `video=0.5, audio=0` produced clean speech on that same seed; disabling offline replay with those weights reproduced the stutter. This validates the mechanism for the affected case while leaving broader quality and stability unproven.
 
-For workflows that reproduce this coupled speech defect, use this tested experimental combination as the first comparison point:
+The default audio-quality configuration is:
 
 ```text
 offline_smoothing_replay = true
@@ -202,6 +202,9 @@ tail_actual_steps = 1
 max_history = 8
 history_storage = system_ram
 bootstrap_first_forecast = true
+offline_smoothing_replay = true
+anchor_residual_feedback = false
+selective_rollback_correction = false
 ```
 
 ### Conservative quality-first preset
@@ -218,6 +221,9 @@ tail_actual_steps = 1
 max_history = 8
 history_storage = system_ram
 bootstrap_first_forecast = false
+offline_smoothing_replay = true
+anchor_residual_feedback = false
+selective_rollback_correction = false
 ```
 
 The preliminary defaults prioritize throughput and have not been established as universally quality-safe. Existing workflows retain their saved input values. The quality-first preset changes only the forecast degree, warmup, and bootstrap behavior relative to the defaults: it keeps the first five solver steps native, waits for the five actual history points required by degree 4, and does not use the one-point hold. It reduces the speed benefit and is a starting point rather than a guarantee; exact-seed Spectrum-on/Spectrum-off validation remains necessary for the intended workflow.
@@ -362,13 +368,14 @@ PYTHONPATH=/path/to/ComfyUI \
 python -m pytest -q
 ```
 
-## Manual validation required for experimental promotion
+## Validation boundaries
 
-Before any experimental mode is considered for a default-on or non-experimental status, test 20-step Euler and RES multistep, plus RES CFG++ where applicable, at approximately 0.65 MP, 8 seconds, and 24 fps. Keep prompt, seed, checkpoint, resolution, duration, sampler, scheduler, images, and audio references identical across:
+The offline mode was promoted because the affected same-seed A/B isolated the failure path: single-pass `video=0.5, audio=0` reproduced the audio defect, while offline capture/replay with the same weights removed it and retained the preferred image result. Broader checkpoint, sampler, prompt, and conditioning coverage remains valuable. Before either retained experiment is considered for promotion, test 20-step Euler and RES multistep, plus RES CFG++ where applicable, at approximately 0.65 MP, 8 seconds, and 24 fps. Keep prompt, seed, checkpoint, resolution, duration, sampler, scheduler, images, and audio references identical across:
 
 - native Spectrum-off;
-- ordinary Spectrum with all three settings false; and
-- each experimental setting enabled separately.
+- the default offline path;
+- explicit single-pass mode with all three settings false; and
+- each retained experimental setting enabled separately with offline replay disabled.
 
 Inspect video quality, generated audio, reference-audio distortion, audiovisual synchronization, total wall time, actual/discarded/replayed transformer calls, peak VRAM, and peak system RAM. Cancel during the first pass, residual evaluation, rollback replay, and offline replay. Run at least ten consecutive generations with Sol-Attn enabled and load old saved workflows to detect retained state, memory growth, deadlocks, callback duplication, WSL wedges, and compatibility regressions.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,46 +1,31 @@
-# Spectrum MiniMax H3 v0.2.0
+# Spectrum MiniMax H3 v0.2.1
 
-Adds three default-off trajectory-correction experiments and isolates MiniMax H3 audio from unsafe shared spectral blending. Existing workflows continue to load with every new experiment disabled.
+Makes the validated H3 audio-quality correction the standard default path.
 
-## Audio and modality handling
+## Corrected default
 
-- Keep `blend_weight` as the video spectral share for saved-workflow compatibility.
-- Add `audio_blend_weight`, defaulting to `0.0`, so audio uses local prediction unless explicitly enabled for experiments.
-- Apply audio and video history weights independently inside one bounded packed prediction buffer.
-- Fail closed when native H3 cannot prove the target audio/video boundary.
-- Report configured, causal, and effective per-modality blends in debug summaries.
+- `offline_smoothing_replay` now defaults to `true` in the runtime configuration, node schema, and Python call signature.
+- The mode is no longer classified as experimental.
+- The default remains `blend_weight=0.5` for video and `audio_blend_weight=0.0` for audio.
+- Offline capture uses causal `video=0, audio=0`; configured per-modality weights are applied only during transformer-free replay.
 
-Matched full-checkpoint runs reproduced speech stutter when a video spectral forecast entered the causal joint audio-video trajectory, even with direct audio blending disabled. The revised offline path fixes that observed seed by capturing with `video=0, audio=0` and applying the configured `video=0.5, audio=0` only during transformer-free replay. Disabling offline replay with the same weights reproduced the stutter. This is a validated case, not a universal quality guarantee.
+This default follows the matched full-checkpoint result from v0.2.0 development. Single-pass `video=0.5, audio=0` reproduced degraded speech and stuttering because video forecasts fed into later joint audio-video transformer calls. Offline capture/replay with the same weights removed the defect and restored high-quality audio on that seed while retaining the preferred image result. Disabling offline replay brought the defect back.
 
-## Experimental trajectory correction
+## Retained research modes
 
-- `anchor_residual_feedback`: a video-scored actual-refresh guard with no hidden-residual injection, a `1.5` trigger, and a three-refresh budget.
-- `selective_rollback_correction`: thresholded deterministic Euler rollback with exact sampler-state restoration and a three-correction budget.
-- `offline_smoothing_replay`: local-only capture followed by transformer-free bidirectional replay using exact actual anchors, bracketing interpolation, affine-corrected spectral weights, and leave-one-anchor-out per-modality attenuation.
-- The three modes are mutually exclusive while Spectrum is enabled and remain disabled by default.
-- Unsupported and recoverably incomplete experimental paths preserve a valid ordinary/native result according to each mode's documented contract; cancellation, OOM, and other fatal exceptions propagate with normal teardown.
+- `anchor_residual_feedback` remains experimental and default-off.
+- `selective_rollback_correction` remains experimental and default-off.
+- Both remain mutually exclusive with each other and with the standard offline path. Disable `offline_smoothing_replay` before enabling either research mode.
+- Explicitly setting all three trajectory modes to `false` retains the single-pass comparison path.
 
-## Memory, telemetry, and compatibility
+## Upgrade behavior
 
-- Share immutable offline anchors with causal history instead of keeping a duplicate archive.
-- Keep offline anchors on the selected `history_storage` device; VRAM mode avoids repeated multi-GiB host transfers when sufficient memory is available.
-- Add detailed residual, rollback, archive, validation, replay, blend, call-count, timing, and memory telemetry.
-- Preserve exact actual anchors, constant hidden trajectories, callback order, cancellation, OOM propagation, clone-local state, and teardown.
-- Support native `t2va`, `fl2va`, and `ref2va` conditioning; reference-only rows remain outside forecast history.
-- Retain ordinary single-pass Spectrum when all three experiments are disabled.
+New nodes use offline replay automatically. Workflows created before v0.2.0 did not store this input and therefore also receive the new default. Workflows saved with v0.2.0 may retain a serialized `offline_smoothing_replay=false`; enable it once in those existing nodes to use the corrected path.
+
+Offline replay retains every actual hidden anchor plus cloned sampling inputs. `history_storage=system_ram` remains the default; `vram` avoids large host transfers when enough VRAM is available. Unsupported samplers run one valid native pass, and an incomplete replay archive returns the valid local-only first-pass result. Cancellation, OOM, and other fatal exceptions preserve normal teardown and propagation.
 
 ## Validation
 
-- Full current-ComfyUI contract suite, forecaster smoke test, compilation, and diff checks pass.
-- Native tiny-H3 tests cover forced-actual equivalence, zero-transformer forecast replay, output-head behavior, modality splitting, and visual/audio reference conditioning.
-- CUDA-only storage/parity checks remain skipped in CPU CI; full-checkpoint evidence comes from the documented user runs.
-
-Recommended configuration for the reproduced speech case:
-
-```text
-offline_smoothing_replay = true
-blend_weight = 0.5
-audio_blend_weight = 0.0
-```
-
-The other two correction modes remain available for research. All three settings are experimental and require exact-seed video, audio, timing, and memory validation on the intended workflow.
+- Default-value tests cover the dataclass, ComfyUI node schema, and Python call signature.
+- The outer-sampler integration test now proves that the omitted/default setting executes capture plus transformer-free replay.
+- Existing single-pass, residual-feedback, rollback, native-equivalence, `t2va`, `fl2va`, and `ref2va` contracts remain covered.

--- a/comfyui_spectrum_h3/config.py
+++ b/comfyui_spectrum_h3/config.py
@@ -21,22 +21,22 @@ class SpectrumH3Config:
     bootstrap_first_forecast: bool = True
     anchor_residual_feedback: bool = False
     selective_rollback_correction: bool = False
-    offline_smoothing_replay: bool = False
+    offline_smoothing_replay: bool = True
     audio_blend_weight: float = 0.0
 
     def __post_init__(self) -> None:
-        experimental = {
+        trajectory_modes = {
             "anchor_residual_feedback": self.anchor_residual_feedback,
             "selective_rollback_correction": self.selective_rollback_correction,
             "offline_smoothing_replay": self.offline_smoothing_replay,
         }
-        for name, value in experimental.items():
+        for name, value in trajectory_modes.items():
             if not isinstance(value, bool):
                 raise TypeError(f"{name} must be a boolean")
-        conflicts = [name for name, value in experimental.items() if value]
+        conflicts = [name for name, value in trajectory_modes.items() if value]
         if self.enabled and len(conflicts) > 1:
             raise ValueError(
-                "Spectrum H3 experimental modes are mutually exclusive; conflicting settings: "
+                "Spectrum H3 trajectory modes are mutually exclusive; conflicting settings: "
                 + ", ".join(conflicts)
             )
 
@@ -71,7 +71,7 @@ class SpectrumH3Config:
         ]
         if self.enabled and len(conflicts) > 1:
             raise ValueError(
-                "Spectrum H3 experimental modes are mutually exclusive; conflicting settings: "
+                "Spectrum H3 trajectory modes are mutually exclusive; conflicting settings: "
                 + ", ".join(conflicts)
             )
         if not math.isfinite(self.blend_weight) or not 0.0 <= self.blend_weight <= 1.0:

--- a/comfyui_spectrum_h3/nodes.py
+++ b/comfyui_spectrum_h3/nodes.py
@@ -91,23 +91,31 @@ class SpectrumApplyMiniMaxH3:
                     "BOOLEAN",
                     {
                         "default": False,
-                        "tooltip": "Experimental video-scored actual-refresh guard; never injects a hidden residual.",
+                        "tooltip": (
+                            "Experimental video-scored actual-refresh guard; never injects a hidden residual. "
+                            "Disable offline_smoothing_replay before enabling this mode."
+                        ),
                     },
                 ),
                 "selective_rollback_correction": (
                     "BOOLEAN",
                     {
                         "default": False,
-                        "tooltip": "Experimental thresholded, budgeted rollback for the reviewed deterministic Euler sampler only.",
+                        "tooltip": (
+                            "Experimental thresholded, budgeted rollback for the reviewed deterministic Euler sampler only. "
+                            "Disable offline_smoothing_replay before enabling this mode."
+                        ),
                     },
                 ),
                 "offline_smoothing_replay": (
                     "BOOLEAN",
                     {
-                        "default": False,
+                        "default": True,
                         "tooltip": (
-                            "Experimental two-pass replay: capture a local-only trajectory, then apply "
-                            "the configured video/audio blends using past and future anchors."
+                            "Default audio-quality path: capture a local-only trajectory, then apply the "
+                            "configured video/audio blends using past and future anchors without causal "
+                            "video-to-audio feedback. Uses a second sampler pass and retains every actual anchor. "
+                            "Disable only for single-pass comparisons or either research mode."
                         ),
                     },
                 ),
@@ -120,7 +128,7 @@ class SpectrumApplyMiniMaxH3:
                         "step": 0.01,
                         "tooltip": (
                             "Direct audio spectral share. The default 0 prevents spectral mixing of audio rows. "
-                            "Use offline_smoothing_replay to isolate capture from video-to-audio trajectory coupling."
+                            "The default offline replay path also isolates capture from video-to-audio trajectory coupling."
                         ),
                     },
                 ),
@@ -149,7 +157,7 @@ class SpectrumApplyMiniMaxH3:
         bootstrap_first_forecast=True,
         anchor_residual_feedback=False,
         selective_rollback_correction=False,
-        offline_smoothing_replay=False,
+        offline_smoothing_replay=True,
         audio_blend_weight=0.0,
     ):
         if not enabled:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,7 @@ def test_preliminary_scheduler_defaults():
     assert config.bootstrap_first_forecast is True
     assert config.blend_weight == 0.5
     assert config.audio_blend_weight == 0.0
+    assert config.offline_smoothing_replay is True
     assert required["degree"][1]["default"] == 1
     assert required["warmup_steps"][1]["default"] == 1
     assert required["tail_actual_steps"][1]["default"] == 1
@@ -63,11 +64,10 @@ def test_preliminary_scheduler_defaults():
     assert optional["audio_blend_weight"][0] == "FLOAT"
     assert optional["audio_blend_weight"][1]["default"] == 0.0
     assert apply_parameters["audio_blend_weight"].default == 0.0
-    for name in (
-        "anchor_residual_feedback",
-        "selective_rollback_correction",
-        "offline_smoothing_replay",
-    ):
+    assert optional["offline_smoothing_replay"][0] == "BOOLEAN"
+    assert optional["offline_smoothing_replay"][1]["default"] is True
+    assert apply_parameters["offline_smoothing_replay"].default is True
+    for name in ("anchor_residual_feedback", "selective_rollback_correction"):
         assert getattr(config, name) is False
         assert optional[name][0] == "BOOLEAN"
         assert optional[name][1]["default"] is False
@@ -83,7 +83,7 @@ def test_preliminary_scheduler_defaults():
     ),
 )
 @pytest.mark.parametrize("value", [0, 1, "false", None])
-def test_experimental_settings_require_strict_booleans(name, value):
+def test_trajectory_settings_require_strict_booleans(name, value):
     with pytest.raises(TypeError, match=rf"{name} must be a boolean"):
         SpectrumH3Config(**{name: value})
 
@@ -101,7 +101,7 @@ def test_experimental_settings_require_strict_booleans(name, value):
         ),
     ),
 )
-def test_experimental_settings_are_mutually_exclusive_on_construction(enabled):
+def test_trajectory_settings_are_mutually_exclusive_on_construction(enabled):
     values = {name: True for name in enabled}
     with pytest.raises(ValueError) as error:
         SpectrumH3Config(**values)
@@ -109,7 +109,25 @@ def test_experimental_settings_are_mutually_exclusive_on_construction(enabled):
         assert name in str(error.value)
 
 
-def test_disabled_config_allows_irrelevant_experimental_conflicts():
+@pytest.mark.parametrize(
+    "name",
+    ("anchor_residual_feedback", "selective_rollback_correction"),
+)
+def test_research_modes_require_explicitly_disabling_default_offline_replay(name):
+    with pytest.raises(ValueError) as error:
+        SpectrumH3Config(**{name: True})
+    assert name in str(error.value)
+    assert "offline_smoothing_replay" in str(error.value)
+
+    config = SpectrumH3Config(
+        **{name: True},
+        offline_smoothing_replay=False,
+    ).validate()
+    assert getattr(config, name) is True
+    assert config.offline_smoothing_replay is False
+
+
+def test_disabled_config_allows_irrelevant_trajectory_conflicts():
     config = SpectrumH3Config(
         enabled=False,
         anchor_residual_feedback=True,
@@ -119,7 +137,7 @@ def test_disabled_config_allows_irrelevant_experimental_conflicts():
     config.validate()
 
 
-def test_disabled_node_returns_original_before_experimental_validation():
+def test_disabled_node_returns_original_before_trajectory_validation():
     model = object()
     (result,) = SpectrumApplyMiniMaxH3().apply(
         model,
@@ -142,6 +160,7 @@ def test_disabled_node_returns_original_before_experimental_validation():
 def test_aggressive_preset_explicitly_disables_degree_one_bootstrap():
     assert AGGRESSIVE_PRESET.degree == 4
     assert AGGRESSIVE_PRESET.bootstrap_first_forecast is False
+    assert AGGRESSIVE_PRESET.offline_smoothing_replay is True
     AGGRESSIVE_PRESET.validate()
 
 

--- a/tests/test_native_equivalence.py
+++ b/tests/test_native_equivalence.py
@@ -358,6 +358,7 @@ def test_anchor_residual_probe_runs_current_heads_without_marking_actual_as_fore
             flex_window=0.0,
             bootstrap_first_forecast=False,
             anchor_residual_feedback=True,
+            offline_smoothing_replay=False,
         )
     )
     run_id = runtime.start_run(

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -74,6 +74,7 @@ def _run(
             flex_window=0.0,
             bootstrap_first_forecast=False,
             selective_rollback_correction=True,
+            offline_smoothing_replay=False,
             audio_blend_weight=0.5,
         )
     )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -24,6 +24,7 @@ def _runtime(**overrides):
         "tail_actual_steps": 0,
         "window_size": 2.0,
         "bootstrap_first_forecast": False,
+        "offline_smoothing_replay": False,
     }
     values.update(overrides)
     return SpectrumH3Runtime(SpectrumH3Config(**values))
@@ -870,6 +871,7 @@ def _measured_anchor(runtime, timestep, *, video_values, audio_values):
 def _feedback_runtime():
     runtime = _runtime(
         anchor_residual_feedback=True,
+        offline_smoothing_replay=False,
         warmup_steps=2,
         window_size=2.0,
         flex_window=0.75,
@@ -1124,7 +1126,7 @@ def test_terminal_feedback_probe_is_skipped_but_rollback_probe_is_retained():
         ("anchor_residual_feedback", False),
         ("selective_rollback_correction", True),
     ):
-        runtime = _runtime(**{setting: True})
+        runtime = _runtime(offline_smoothing_replay=False, **{setting: True})
         runtime.start_run(
             torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
             "sample_euler",

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -176,7 +176,7 @@ def test_predict_noise_passthrough_survives_a_downstream_model_bypass(caplog):
         runtime.end_run(run_id)
 
 
-def test_offline_outer_sample_restarts_from_cloned_inputs_and_callbacks_only_replay():
+def test_default_offline_outer_sample_restarts_from_cloned_inputs_and_callbacks_only_replay():
     runtime = SpectrumH3Runtime(
         SpectrumH3Config(
             degree=1,
@@ -184,7 +184,6 @@ def test_offline_outer_sample_restarts_from_cloned_inputs_and_callbacks_only_rep
             warmup_steps=2,
             tail_actual_steps=0,
             bootstrap_first_forecast=False,
-            offline_smoothing_replay=True,
             audio_blend_weight=0.5,
         )
     )
@@ -322,6 +321,7 @@ def test_selective_rollback_res_falls_back_before_sampler_mutation(monkeypatch, 
             warmup_steps=2,
             bootstrap_first_forecast=False,
             selective_rollback_correction=True,
+            offline_smoothing_replay=False,
         )
     )
     run_id = runtime.start_run(


### PR DESCRIPTION
## What changed

- make `offline_smoothing_replay=true` the runtime, ComfyUI schema, and Python-call default
- classify offline replay as the standard H3 audio-quality path
- keep `anchor_residual_feedback` and `selective_rollback_correction` experimental and default-off
- preserve mutual exclusion among the three trajectory modes
- add UI guidance for the research-mode opt-out and offline memory/pass cost
- add default-path and research-mode configuration regressions
- bump the package and release notes to v0.2.1

## Root cause

v0.2.0 contained the validated audio correction while still presenting it as a default-off experiment. Single-pass `video=0.5, audio=0` reproduced degraded speech/stuttering because video forecasts entered later joint audio-video transformer evaluations. Isolated local-only capture plus transformer-free `video=0.5, audio=0` replay removed the defect on the same seed and retained the preferred image result.

The published default therefore selected the known failing path for new users.

## Compatibility

- new nodes default to offline replay
- pre-v0.2.0 workflows lack the optional input and receive the new Python default
- v0.2.0 workflows may retain a serialized explicit `false`; the README and release notes call out the one-time toggle
- explicit `false` retains single-pass comparison behavior
- the two retained experiments remain available when offline replay is disabled

## Validation

- committed tree matches the locally reviewed tree exactly
- Python compilation passed
- v0.2.1 wheel build passed
- diff whitespace checks passed
- full PyTorch/current-ComfyUI matrix is delegated to this PR's existing CI because the local runtime does not provide PyTorch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline smoothing replay is now enabled by default as the validated audio-quality path.
  * Added clearer behavior for replay storage, fallback handling, and fatal errors.
  * Research modes remain opt-in, mutually exclusive, and require disabling offline replay.

* **Documentation**
  * Updated setup, workflow compatibility, presets, validation guidance, and upgrade notes.

* **Bug Fixes**
  * Improved configuration messaging and handling for trajectory mode combinations.

* **Release**
  * Updated version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->