### PR TITLE
Fix ComfyUI Manager installation through Registry

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -1,0 +1,3 @@
+# Development-only files must not be shipped in Comfy Registry archives.
+.github/
+tests/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,18 @@
-# Spectrum MiniMax H3 v0.2.2
+# Spectrum MiniMax H3 v0.2.3
 
-Fixes ComfyUI progress reporting for the default offline smoothing replay path.
+Restores installation through ComfyUI Manager's default channel.
 
-## Progress reporting
+## Registry packaging
 
-- The compute-heavy capture pass now reports live progress to ComfyUI instead of running with no visible progress bar.
-- Capture and replay share one continuous two-pass range. For a 20-step sampler run, capture reports steps 1–20 and replay completes steps 21–40.
-- The normal terminal sampler bar follows capture. The transformer-free replay suppresses its own terminal bar, avoiding a second bar that appears and completes almost instantly.
-- External callbacks and previews remain replay-only, so accepted output side effects still occur once per logical sampler step.
-- If capture cannot be replayed or replay aborts recoverably, the combined progress range is completed before the valid first-pass result is returned.
+- Adds a root `.comfyignore` so Comfy Registry packages contain the runtime node and exclude `.github/` workflows and `tests/`.
+- Earlier Registry versions were automatically flagged because the published archives included development-only code that reads the test environment, launches an isolated test subprocess, and reads the package version in the release workflow.
+- The runtime node contains none of those flagged operations; they were packaging false positives from files that are never imported or executed by ComfyUI.
 
 ## Compatibility
 
-This release changes progress reporting only. Node inputs, saved workflows, sampling schedules, generated-result handling, and the v0.2.1 audio-quality defaults are unchanged.
+This release changes Registry packaging only. Node code, inputs, saved workflows, sampling behavior, generated results, and the v0.2.2 progress reporting fix are unchanged.
 
 ## Validation
 
-- Confirmed in a live ComfyUI GPU generation: progress is visible during capture and completes through replay.
-- 173 tests pass against ComfyUI commit `00d02f2`; the two CUDA-only tests are skipped in the CPU test environment.
-- Tests cover successful capture/replay progress, replay-only callback forwarding, incomplete capture, recoverable replay abort, result retention, and runtime cleanup.
+- Verified the Registry archive file set excludes `.github/` and `tests/` while retaining every runtime Python module, `pyproject.toml`, README, and license file.
+- Verified the excluded files cover every finding reported by the Comfy Registry scanner for v0.2.1.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,28 @@
 # Spectrum MiniMax H3 v0.2.3
 
-Restores installation through ComfyUI Manager's default channel.
+Restores the ComfyUI Manager installation path and brings the README in line with the current v0.2.1+ audio behavior.
 
-## Registry packaging
+## Comfy Registry and Manager installation
 
-- Adds a root `.comfyignore` so Comfy Registry packages contain the runtime node and exclude `.github/` workflows and `tests/`.
-- Earlier Registry versions were automatically flagged because the published archives included development-only code that reads the test environment, launches an isolated test subprocess, and reads the package version in the release workflow.
-- The runtime node contains none of those flagged operations; they were packaging false positives from files that are never imported or executed by ComfyUI.
+- Adds a root `.comfyignore` so Comfy Registry packages retain the complete runtime node while excluding `.github/` workflows and `tests/`.
+- Earlier Registry archives included development-only files that read test environment variables, launch an isolated test subprocess, and read release metadata. The Registry scanner flagged those files even though ComfyUI never imports or executes them.
+- Publishing v0.2.3 with those files excluded gives Manager a clean Registry version to resolve through its default channel once Registry scanning completes.
+
+## Audio documentation
+
+- Documents the current default audio path: `offline_smoothing_replay=true`, `blend_weight=0.5`, and `audio_blend_weight=0`.
+- Separates reproduced pre-v0.2.1 single-pass audio failures from the current offline capture/replay behavior.
+- Clarifies that workflows saved with v0.2.0 may retain `offline_smoothing_replay=false` and need it re-enabled once.
+- Records increased `degree`, increased `warmup_steps`, and the reported clean 30-step run as historical single-setup evidence, not requirements for the current default.
+- Updates the documented ComfyUI validation target and v0.2.2 progress-reporting coverage.
 
 ## Compatibility
 
-This release changes Registry packaging only. Node code, inputs, saved workflows, sampling behavior, generated results, and the v0.2.2 progress reporting fix are unchanged.
+Runtime node code, inputs, saved-workflow compatibility, sampling schedules, and generated-result handling are unchanged. This release changes Registry packaging and documentation only.
 
 ## Validation
 
-- Verified the Registry archive file set excludes `.github/` and `tests/` while retaining every runtime Python module, `pyproject.toml`, README, and license file.
-- Verified the excluded files cover every finding reported by the Comfy Registry scanner for v0.2.1.
+- Verified the Registry archive excludes every `.github/` and `tests/` path while retaining every runtime Python module, `pyproject.toml`, README, and license file.
+- Verified the excluded paths cover every scanner finding reported for v0.2.1.
+- The documentation branch passes Markdown fence and internal-anchor validation.
+- The test matrix passes, including 173 tests against ComfyUI commit `00d02f2854892ee5b9808bc2f6348b972017886a`; two CUDA-only tests are skipped in the CPU environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.2"
+version = "0.2.3"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- add a root `.comfyignore` that removes `.github/` and `tests/` from Comfy Registry archives;
- bump the package to `0.2.3`;
- document the Registry-only release and its compatibility boundary.

## Root cause

`comfy node publish` packages every git-tracked file unless `.comfyignore` excludes it. This repository had no Registry ignore file, so its published archives included CI workflows and the complete test suite.

The Registry scanner flagged four development-only operations:

- `.github/workflows/release.yml`: reading `pyproject.toml` to obtain the release version;
- `tests/conftest.py`: reading `COMFYUI_PATH`;
- `tests/test_sampler_contract.py`: reading `COMFYUI_PATH`;
- `tests/test_entrypoint.py`: launching the isolated entrypoint test subprocess.

Consequently, every released version through `0.2.1` is `NodeVersionStatusFlagged`, while `0.2.2` is still pending the same scan. With no active installable version, Manager fails to resolve the package through its default channel and falls into the unknown-Git-URL security gate, which produces the reported security-level message.

The runtime node does not contain the flagged operations. Changing Manager's `security_level` cannot correct the published package state.

## Validation

- Built a Registry archive with the current `comfy-cli` `zip_files` implementation.
- Compared its complete manifest with the expected git-tracked file set after applying `.comfyignore`; there were no missing or unexpected files.
- Confirmed the archive contains no `.github/` or `tests/` paths and retains every runtime module.
- Confirmed the archive contains package version `0.2.3`.
- Built `comfyui_spectrum_minimax_h3-0.2.3-py3-none-any.whl` successfully.
- Python byte-compilation and `git diff --check` pass.
- All three GitHub test-matrix jobs pass against ComfyUI commits `e377e263`, `0dd9b154`, and `5599a05f`.

No runtime source changed. After merge, correctness of the external fix is established when Registry marks `0.2.3` active rather than flagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restored installation through the ComfyUI Manager default channel.
  - Updated Registry packaging to exclude development-only files.

- **Documentation**
  - Added release notes for version 0.2.3.
  - Clarified packaging validation and confirmed no runtime behavior changes.

- **Chores**
  - Updated the project version to 0.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->