### PR TITLE
Support MiniMax H3 Turbo sampler forecasting

### DIFF
--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -24,6 +24,7 @@ KJ_PREVIEW_WRAPPER_KEY = "kj_preview_override"
 
 SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset(
     {
+        "_turbo_sampler",
         "sample_euler",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -34,6 +34,7 @@ def _sampler(function_name: str) -> SimpleNamespace:
 @pytest.mark.parametrize(
     "function_name",
     (
+        "_turbo_sampler",
         "sample_euler",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
@@ -55,6 +56,7 @@ def test_reviewed_single_call_samplers_are_supported(function_name):
         "res_multistep",
         "sample_res_multistep_experimental",
         "sample_heun",
+        "_turbo_sampler_ancestral",
     ),
 )
 def test_unreviewed_sampler_names_do_not_match_by_prefix(function_name):
@@ -64,6 +66,7 @@ def test_unreviewed_sampler_names_do_not_match_by_prefix(function_name):
 @pytest.mark.parametrize(
     "function_name",
     (
+        "_turbo_sampler",
         "sample_euler",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
@@ -81,8 +84,9 @@ def test_res_multistep_policy_refreshes_once_and_protects_tail(function_name):
     assert min_tail_actual_steps(sampler) == 3
 
 
-def test_euler_policy_keeps_one_refresh_and_user_tail():
-    sampler = _sampler("sample_euler")
+@pytest.mark.parametrize("function_name", ("sample_euler", "_turbo_sampler"))
+def test_euler_policy_keeps_one_refresh_and_user_tail(function_name):
+    sampler = _sampler(function_name)
 
     assert min_actual_steps_after_forecast(sampler) == 1
     assert min_tail_actual_steps(sampler) == 0
@@ -250,7 +254,10 @@ def test_predict_noise_passthrough_survives_a_downstream_model_bypass(caplog):
         runtime.end_run(run_id)
 
 
-def test_default_offline_outer_sample_reports_both_passes_and_callbacks_only_replay(monkeypatch):
+@pytest.mark.parametrize("function_name", ("sample_euler", "_turbo_sampler"))
+def test_default_offline_outer_sample_reports_both_passes_and_callbacks_only_replay(
+    monkeypatch, function_name
+):
     runtime = SpectrumH3Runtime(
         SpectrumH3Config(
             degree=1,
@@ -356,7 +363,7 @@ def test_default_offline_outer_sample_reports_both_passes_and_callbacks_only_rep
         Executor(),
         noise,
         latent,
-        _sampler("sample_euler"),
+        _sampler(function_name),
         sigmas,
         callback=callback,
         seed=7,


### PR DESCRIPTION
Fixes #33.

## Root cause

Spectrum recognizes reviewed samplers by the exact `KSAMPLER.sampler_function.__name__`. Larryvrh's MiniMax H3 Turbo node supplies `_turbo_sampler`, which was absent from that reviewed set. With the default offline smoothing path enabled, Spectrum therefore took its deliberate native bypass before starting capture, replay, or forecasting.

## Change

- Recognize the external `_turbo_sampler` contract explicitly.
- Apply the existing conservative Euler constraints: at most one consecutive forecast, one required actual refresh after a forecast, and the configured user tail.
- Keep unknown samplers on the native bypass. This avoids enabling Spectrum for stochastic, multi-call, or stateful samplers whose contracts have not been reviewed.
- Add regression coverage for exact-name matching, constraint selection, prefix rejection, and the complete offline capture/replay path.

The reviewed Turbo implementation makes exactly one denoiser call per scheduler step in both modes. On current ComfyUI its update is ordinary Euler; on legacy ComfyUI it applies the returned derivative to video and audio with separate clock deltas. Neither branch introduces ancestral noise, churn, or extra model calls.

## Validation

- `python -m compileall -q comfyui_spectrum_h3 tests`
- Full CPU suite against the supplied current ComfyUI snapshot: **180 passed, 2 CUDA-only tests skipped**
- `git diff --check`

The repository's pull-request matrix will also test the three pinned reviewed ComfyUI revisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `_turbo_sampler` sampling option.

* **Tests**
  * Expanded sampler coverage to verify policy behavior, refresh handling, replay behavior, and callbacks for the new sampler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->