### PR TITLE
Release v0.2.5: bound replay VRAM and support H3 Turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The node adds no third-party Python dependency. It uses PyTorch and ComfyUI modu
 
 ### Updating
 
-Use v0.2.1 or newer for the corrected default audio path. Use v0.2.2 or newer for live two-pass progress reporting. Use v0.2.4 or newer for live KJNodes MiniMax H3 TAE previews during offline replay. Update a Git clone with:
+Use v0.2.1 or newer for the corrected default audio path. Use v0.2.2 or newer for live two-pass progress reporting. Use v0.2.4 or newer for live KJNodes MiniMax H3 TAE previews during offline replay. Use v0.2.5 or newer for bounded default replay VRAM and MiniMax H3 Turbo sampler support. Update a Git clone with:
 
 ```bash
 cd ComfyUI/custom_nodes/ComfyUI-Spectrum-MiniMax-H3
@@ -136,7 +136,7 @@ Offline smoothing replay is the standard default-on H3 path because it removed t
 |---|---|---|---:|---|
 | `anchor_residual_feedback` | Experimental / off | Euler, RES multistep, RES multistep CFG++ | 1 | Ordinary Spectrum/native fallback rules remain active. |
 | `selective_rollback_correction` | Experimental / off | Exact deterministic `sample_euler`, with `s_churn=0` | 1, with local replay on a trigger | RES, CFG++, churned, ancestral, unknown, intercepted, and multi-GPU paths log once and run ordinary Spectrum. |
-| `offline_smoothing_replay` | Standard / on | Euler, RES multistep, RES multistep CFG++ | 2 | Unsupported samplers run one valid native pass. An incomplete first-pass archive returns the valid local-only first-pass result. |
+| `offline_smoothing_replay` | Standard / on | Euler, Larryvrh MiniMax H3 Turbo, RES multistep, RES multistep CFG++ | 2 | Unsupported samplers run one valid native pass. An incomplete first-pass archive returns the valid local-only first-pass result. |
 
 ### Shared anchor residual
 
@@ -305,10 +305,11 @@ This option changes the denoising trajectory and is experimental. Validate video
 Forecasting is currently allowlisted for:
 
 - Euler (`sample_euler`)
+- Larryvrh MiniMax H3 Turbo (`_turbo_sampler`)
 - RES multistep (`sample_res_multistep`)
 - RES multistep CFG++ (`sample_res_multistep_cfg_pp`)
 
-The reviewed implementations make one `predict_noise` call per solver iteration. Euler feeds each approximate denoised result into the latent used by the next evaluation, so it requires one completed actual H3 evaluation after every forecast. RES multistep stores each current denoised result as `old_denoised` for the following second-order update. The actual evaluation immediately after a forecast still consumes forecast-derived history, then replaces `old_denoised` with its native result before another forecast is allowed. This prevents any RES update from combining two forecasted denoised results. RES also keeps its final three solver steps native; this tail floor applies even when a saved workflow supplies a smaller `tail_actual_steps` value. Ancestral samplers execute native MiniMax H3 because injected noise invalidates the smooth deterministic feature trajectory used by the forecaster. Debug mode logs the exact fallback, tail, or post-forecast refresh reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
+The reviewed implementations make one `predict_noise` call per solver iteration. Euler feeds each approximate denoised result into the latent used by the next evaluation, so it requires one completed actual H3 evaluation after every forecast. Larryvrh's reviewed MiniMax H3 Turbo sampler follows the same deterministic single-call contract and uses the same conservative limit of one consecutive forecast plus one completed actual refresh. RES multistep stores each current denoised result as `old_denoised` for the following second-order update. The actual evaluation immediately after a forecast still consumes forecast-derived history, then replaces `old_denoised` with its native result before another forecast is allowed. This prevents any RES update from combining two forecasted denoised results. RES also keeps its final three solver steps native; this tail floor applies even when a saved workflow supplies a smaller `tail_actual_steps` value. Ancestral samplers execute native MiniMax H3 because injected noise invalidates the smooth deterministic feature trajectory used by the forecaster. Debug mode logs the exact fallback, tail, or post-forecast refresh reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
 
 Native EasyCache and LazyCache must not accelerate the same model branch as Spectrum. Either cache can return an approximate diffusion result without invoking MiniMax H3, so Spectrum cannot capture the actual post-transformer feature required by its solver-step transaction. If both are attached, Spectrum now logs one warning and remains inactive for that run while the cache continues normally. Use one of these accelerators on a model branch.
 
@@ -368,6 +369,7 @@ Automated tests cover:
 - direct coefficient, history-weight, chunked, blended, and row-subset equivalence;
 - FP32, FP16, and BF16 features;
 - history eviction, repeated coordinates, zero ridge, bounded Cholesky jitter, and factorization reuse;
+- independent causal-history and full replay-archive storage, including mixed CPU/CUDA device placement;
 - absence of persistent full-feature FP32 RHS/coefficient storage;
 - warmup, final tail, adaptive counts, fallback accounting, abort rollback, and teardown;
 - split, reordered, missing, and duplicate branch labels;
@@ -375,6 +377,7 @@ Automated tests cover:
 - model detection and clone runtime isolation;
 - exact native versus wrapped forced-actual video/audio output on a deterministic tiny native H3 fixture;
 - proof that a forecast fixture invokes zero H3 transformer blocks;
+- exact MiniMax H3 Turbo sampler recognition, prefix rejection, Euler-safe refresh policy, and complete offline capture/replay coverage;
 - refresh-only anchor feedback with video-only policy scoring, a `1.5` threshold, a three-refresh budget, and no retained/injected hidden residual;
 - terminal feedback-probe elimination while preserving the final rollback validation probe;
 - rollback threshold and three-correction budget enforcement;
@@ -383,7 +386,7 @@ Automated tests cover:
 - continuous two-pass ComfyUI progress, capture progress callbacks, capture-and-replay KJ preview updates, replay-only ordinary external callback side effects and previews, and clean progress completion on recoverable replay fallbacks;
 - downstream `predict_noise` passthroughs that never reach the native H3 wrapper, including one-warning disablement and retained-history release.
 
-The v0.2.4 suite passes 175 tests against the attached current ComfyUI source; two CUDA-only tests are skipped in the CPU test environment. GitHub Actions also passes the full test suite against the three reviewed ComfyUI revisions listed in the test matrix.
+The v0.2.5 suite passes 183 tests against the attached current ComfyUI source; four CUDA-only test cases are skipped in the CPU test environment. GitHub Actions also passes the full test suite against the three reviewed ComfyUI revisions listed in the test matrix.
 
 A community compatibility report confirmed that revision `dc6291525112cb4246f864738e5bb4e2b85446da` ran without source changes on Windows 11 with a Radeon AI PRO R9700 32 GB, PyTorch 2.9.1 + ROCm 7.2.1, and ComfyUI 0.30.0. In the reported 20-step RES multistep, 864x480, 107-frame `system_ram` workflow, the expected 14 actual and 6 forecasted evaluations reduced warm elapsed time from 212.73 s to 160.97 s (24.33% lower time; about 1.32x throughput). This validates only that exact configuration; other AMD GPUs, ROCm builds, workflows, and quality cases remain unverified. See [issue #6](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/issues/6).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,26 +1,38 @@
-# Spectrum MiniMax H3 v0.2.4
+# Spectrum MiniMax H3 v0.2.5
 
-Restores useful live MiniMax H3 TAE previews while the default offline smoothing replay path is running.
+Reduces offline replay GPU memory pressure and enables Spectrum forecasting for Larryvrh's MiniMax H3 Turbo sampler.
 
-## Live preview repair
+## Offline replay memory fix
 
-- Restores KJNodes `Model Preview Override` updates during the compute-heavy capture pass and the accepted replay pass.
-- Supports either ordering of `Model Preview Override` and Spectrum in the model patch chain.
-- Capture previews show the provisional local-only trajectory. Replay previews update the widget with the accepted smoothed trajectory.
-- Keeps ordinary external sampler callbacks and their previews replay-only, so unrelated callback side effects still run once per logical step.
-- Preserves the existing wrapper order when offline smoothing is disabled.
+- Separates the causal forecast history from the full offline replay archive.
+- Keeps `history_storage` bounded by `max_history`, including when it is set to `vram`.
+- Adds `offline_archive_storage`, defaulting to `system_ram` for new and existing workflows.
+- Retains `offline_archive_storage=vram` as an explicit option for systems with sufficient headroom.
+- Reports both configured storage locations and the resolved archive device in debug summaries.
 
-## Root cause
+### Root cause
 
-Offline replay intentionally replaces the external callback during capture with a progress-only callback. When KJNodes' preview wrapper enclosed Spectrum's two-pass wrapper, it received callbacks only during the transformer-free replay, which usually completed too quickly to act as a useful live preview. Spectrum now places that observational wrapper immediately inside its own wrapper for offline runs, giving it one callback stream in each pass.
+Before offline replay, `history_storage=vram` retained at most `max_history` feature snapshots. Offline replay reused that setting for every actual anchor until its second pass completed. The meaning of the existing option therefore changed from a bounded causal history to an all-anchor CUDA archive. One recorded 20-step run retained about 4.3 GiB for that archive, enough to cause allocator pressure, severe slowdown, or an out-of-memory error on a 12 GB GPU.
+
+The archive now has its own storage policy. Existing workflows do not contain the new trailing input, so they receive the safe `system_ram` archive default automatically.
+
+## MiniMax H3 Turbo sampler support
+
+- Recognizes Larryvrh's exact `_turbo_sampler` contract.
+- Applies the existing conservative Euler safeguards: at most one consecutive forecast and one required actual refresh after a forecast.
+- Covers the standard offline capture and transformer-free replay path.
+- Keeps similarly named and otherwise unknown samplers on the native bypass.
+
+The reviewed Turbo implementation makes one denoiser call per scheduler step and does not inject ancestral noise, churn, or additional model evaluations.
 
 ## Compatibility
 
-This release does not change node inputs, saved workflows, forecast schedules, audio handling, progress accounting, or generated tensors. Kijai's MiniMax H3 TAE still requires KJNodes `Model Preview Override`.
+The new archive selector is a trailing optional node input, preserving existing saved workflows. Existing Euler and RES schedules, offline smoothing, audio handling, progress reporting, and generated-result processing are unchanged. Workflows that intentionally want the former all-anchor CUDA behavior can select `offline_archive_storage=vram`.
 
 ## Validation
 
-- A live user test of the PR confirmed that MiniMax H3 TAE previews work again.
-- Regression tests cover both wrapper orders and verify that single-pass ordering remains unchanged.
-- The full CPU suite passes with 175 tests; the two CUDA-only tests are skipped.
-- All three GitHub Actions ComfyUI compatibility jobs and the forecaster smoke test pass.
+- The revised default archive behavior was confirmed in a real H3 generation after the reported VRAM regression.
+- The combined CPU suite passes 183 tests; four CUDA-only test cases are skipped in the CPU environment.
+- Mixed-storage tests cover causal history on CUDA with the archive on CPU and the inverse placement.
+- Turbo tests cover exact-name recognition, prefix rejection, policy constraints, callbacks, and complete offline capture/replay.
+- Both feature PRs passed the three-version ComfyUI GitHub Actions matrix and CodeRabbit review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.4"
+version = "0.2.5"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- release the independently bounded offline replay archive from #34
- release MiniMax H3 Turbo sampler forecasting from #35
- bump the package version to 0.2.5
- document saved-workflow compatibility, storage behavior, sampler safeguards, and validation boundaries
- publish complete v0.2.5 release notes

## Included fixes

### Offline replay memory

`history_storage=vram` remains capped by `max_history`. The all-anchor replay archive now has an independent `offline_archive_storage` input that defaults to `system_ram`, including for existing workflows that do not contain the new trailing input.

### MiniMax H3 Turbo

Larryvrh's exact `_turbo_sampler` contract is allowlisted with the conservative Euler refresh policy. Unknown and similarly named samplers continue to use the native bypass.

## Validation

- #34: three-version Actions matrix passed; CodeRabbit passed; revised default confirmed in a real H3 generation
- #35: three-version Actions matrix passed; CodeRabbit produced no actionable findings
- expected combined CPU total: 183 passed, 4 CUDA-only cases skipped
- this release PR must pass the same three-version matrix before merge and tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Larryvrh MiniMax H3 Turbo sampler.
  - Added configurable offline replay archives, defaulting to system RAM, with an option to use VRAM.
  - Added live TAE preview support and debug reporting.

- **Documentation**
  - Updated compatibility, sampler recognition, safeguards, and validation details.
  - Documented expanded coverage, including 183 CPU tests and offline replay scenarios.

- **Release**
  - Updated the project version to 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->