### PR TITLE
Support native ER-SDE sampler forecasting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           - e377e263049f9338b4d12a3dd417b36ae62948ff
           - 0dd9b154a1654fc699dcdc3af066c7cce096045a
           - 5599a05fea715cb2aff11f30f5b06e16d0dfa0c4
+          - 27bca654eb9a70237d93f56a6ea336ab55f8925d
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,8 +1,8 @@
 # MiniMax H3 integration notes
 
-Source review date: 2026-08-08
+Source review date: 2026-08-12
 
-Reviewed native ComfyUI commits: `e377e263049f9338b4d12a3dd417b36ae62948ff`, `0dd9b154a1654fc699dcdc3af066c7cce096045a`, and `5599a05fea715cb2aff11f30f5b06e16d0dfa0c4`
+Reviewed native ComfyUI commits: `e377e263049f9338b4d12a3dd417b36ae62948ff`, `0dd9b154a1654fc699dcdc3af066c7cce096045a`, `5599a05fea715cb2aff11f30f5b06e16d0dfa0c4`, and current master `27bca654eb9a70237d93f56a6ea336ab55f8925d`
 
 Reviewed Spectrum paper: arXiv `2603.01623v1`
 
@@ -41,7 +41,13 @@ This preserves:
 
 ## Sampler contract
 
-Solver-step IDs are assigned by a `PREDICT_NOISE` wrapper inside an `OUTER_SAMPLE` run transaction. Forecasting is allowlisted only for deterministic native `sample_euler`, `sample_res_multistep`, and `sample_res_multistep_cfg_pp`, whose reviewed implementations perform exactly one `predict_noise` call per solver iteration. Euler requires one completed actual H3 evaluation after every forecast. RES stores each current denoised result for the following second-order update. The actual step after a forecast consumes that forecast-derived value, then replaces `old_denoised` with its native result; one completed actual evaluation therefore clears the retained forecast before forecasting resumes. RES also enforces a three-step actual tail. These sampler floors are applied at run time and cannot be weakened by an older saved workflow. Ancestral variants remain native because they inject noise between model evaluations. Other samplers remain native and report a debug fallback reason.
+Solver-step IDs are assigned by a `PREDICT_NOISE` wrapper inside an `OUTER_SAMPLE` run transaction. Forecasting is allowlisted only for the reviewed native `sample_euler`, `sample_er_sde`, `sample_res_multistep`, and `sample_res_multistep_cfg_pp` functions plus Larryvrh's reviewed `_turbo_sampler`. Each performs exactly one `predict_noise` call per outer solver iteration. Euler, ER-SDE, and Turbo require one completed actual H3 evaluation after every forecast. RES stores each current denoised result for the following second-order update. The actual step after a forecast consumes that forecast-derived value, then replaces `old_denoised` with its native result; one completed actual evaluation therefore clears the retained forecast before forecasting resumes. RES also enforces a three-step actual tail. These sampler floors are applied at run time and cannot be weakened by an older saved workflow. Unreviewed ancestral variants and other samplers remain native and report a debug fallback reason.
+
+Current ComfyUI `sample_er_sde` has one `model(x, sigmas[i] * s_in, ...)` evaluation in its sole outer loop. `stage_used = min(max_stage, i + 1)` changes only how that denoised result is combined with solver-local history. Stage 2 carries `old_denoised` and the current finite difference `denoised_d`; stage 3 additionally carries `old_denoised_d`. Both histories are initialized inside the function and replaced during the invocation, so no native ER state survives a separate sampler call. The final sigma-zero iteration assigns `x = denoised`, still invokes the callback once, and skips every ER update and SDE noise draw.
+
+With native defaults, the function constructs `default_noise_sampler(x, seed=extra_args["seed"])` once per invocation. ComfyUI's `CFGGuider.inner_sample` rebuilds `extra_args` with the same outer seed on each Spectrum pass. The default sampler owns a fresh device generator seeded identically for each invocation (with the same CPU seed offset), so identical initial packed noise, latent, sigmas, seed, and sampler options reconstruct the same random sequence. On every nonterminal iteration with effective `s_noise > 0`, one noise sample is generated after the stage update and injected into `x`; `s_noise <= 0` or a model `noise_scale <= 0` suppresses the draw. `max_stage` does not alter model-call or noise-draw counts. `s_noise`, `max_stage`, and the native default `noise_scaler` therefore preserve the reviewed logical-step contract.
+
+A custom `noise_sampler` or `noise_scaler` object is stored in the persistent KSampler's `extra_options` and can retain mutable state between the capture and replay invocations. Spectrum cannot prove that such an override restarts deterministically. Ordinary single-pass Spectrum remains eligible because the one-model-call topology is unchanged; default-on offline replay detects either override before opening a run and executes one native pass. ER-SDE does not enable `anchor_residual_feedback` or `selective_rollback_correction`; those experiments remain limited to their independently reviewed contracts.
 
 Coordinates are derived from the actual supplied sigma sequence. Evaluated sigma values are affinely normalized between the run's evaluated minimum and maximum into `[-1, 1]`; no fixed step count is assumed.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Offline smoothing replay is the standard default-on H3 path because it removed t
 |---|---|---|---:|---|
 | `anchor_residual_feedback` | Experimental / off | Euler, RES multistep, RES multistep CFG++ | 1 | Ordinary Spectrum/native fallback rules remain active. |
 | `selective_rollback_correction` | Experimental / off | Exact deterministic `sample_euler`, with `s_churn=0` | 1, with local replay on a trigger | RES, CFG++, churned, ancestral, unknown, intercepted, and multi-GPU paths log once and run ordinary Spectrum. |
-| `offline_smoothing_replay` | Standard / on | Euler, Larryvrh MiniMax H3 Turbo, RES multistep, RES multistep CFG++ | 2 | Unsupported samplers run one valid native pass. An incomplete first-pass archive returns the valid local-only first-pass result. |
+| `offline_smoothing_replay` | Standard / on | Euler, native ER-SDE, Larryvrh MiniMax H3 Turbo, RES multistep, RES multistep CFG++ | 2 | Unsupported or replay-unsafe sampler configurations run one valid native pass. An incomplete first-pass archive returns the valid local-only first-pass result. |
 
 ### Shared anchor residual
 
@@ -305,11 +305,16 @@ This option changes the denoising trajectory and is experimental. Validate video
 Forecasting is currently allowlisted for:
 
 - Euler (`sample_euler`)
+- native ER-SDE (`sample_er_sde`, KSampler name `er_sde`)
 - Larryvrh MiniMax H3 Turbo (`_turbo_sampler`)
 - RES multistep (`sample_res_multistep`)
 - RES multistep CFG++ (`sample_res_multistep_cfg_pp`)
 
-The reviewed implementations make one `predict_noise` call per solver iteration. Euler feeds each approximate denoised result into the latent used by the next evaluation, so it requires one completed actual H3 evaluation after every forecast. Larryvrh's reviewed MiniMax H3 Turbo sampler follows the same deterministic single-call contract and uses the same conservative limit of one consecutive forecast plus one completed actual refresh. RES multistep stores each current denoised result as `old_denoised` for the following second-order update. The actual evaluation immediately after a forecast still consumes forecast-derived history, then replaces `old_denoised` with its native result before another forecast is allowed. This prevents any RES update from combining two forecasted denoised results. RES also keeps its final three solver steps native; this tail floor applies even when a saved workflow supplies a smaller `tail_actual_steps` value. Ancestral samplers execute native MiniMax H3 because injected noise invalidates the smooth deterministic feature trajectory used by the forecaster. Debug mode logs the exact fallback, tail, or post-forecast refresh reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
+The reviewed implementations make one `predict_noise` call per solver iteration. Euler feeds each approximate denoised result into the latent used by the next evaluation, so it requires one completed actual H3 evaluation after every forecast. ER-SDE also makes exactly one model call per outer iteration: `max_stage` reuses the current and previous denoised results for its higher-stage finite differences and does not add model evaluations. Its native default noise sampler is recreated from the same workflow seed for each offline pass, draws once after each nonterminal deterministic update when effective `s_noise > 0`, and does not draw on the final sigma-zero step. Custom `noise_sampler` or `noise_scaler` callables may carry mutable state across invocations, so offline replay fails closed to one native pass when either override is supplied. ER-SDE uses the same conservative limit of one consecutive forecast followed by one completed actual refresh and has no additional forced tail.
+
+Larryvrh's reviewed MiniMax H3 Turbo sampler follows the same deterministic single-call contract and refresh policy. RES multistep stores each current denoised result as `old_denoised` for the following second-order update. The actual evaluation immediately after a forecast still consumes forecast-derived history, then replaces `old_denoised` with its native result before another forecast is allowed. This prevents any RES update from combining two forecasted denoised results. RES also keeps its final three solver steps native; this tail floor applies even when a saved workflow supplies a smaller `tail_actual_steps` value. Other unreviewed ancestral samplers execute native MiniMax H3. Debug mode logs the exact fallback, tail, or post-forecast refresh reason. Multi-GPU parallel sampling also remains native because distributed forecast-row transactions are not yet validated.
+
+ER-SDE support applies to ordinary Spectrum and the standard offline smoothing replay path. The default-off `anchor_residual_feedback` and `selective_rollback_correction` experiments remain restricted to their separately reviewed sampler contracts.
 
 Native EasyCache and LazyCache must not accelerate the same model branch as Spectrum. Either cache can return an approximate diffusion result without invoking MiniMax H3, so Spectrum cannot capture the actual post-transformer feature required by its solver-step transaction. If both are attached, Spectrum now logs one warning and remains inactive for that run while the cache continues normally. Use one of these accelerators on a model branch.
 
@@ -377,7 +382,7 @@ Automated tests cover:
 - model detection and clone runtime isolation;
 - exact native versus wrapped forced-actual video/audio output on a deterministic tiny native H3 fixture;
 - proof that a forecast fixture invokes zero H3 transformer blocks;
-- exact MiniMax H3 Turbo sampler recognition, prefix rejection, Euler-safe refresh policy, and complete offline capture/replay coverage;
+- exact MiniMax H3 Turbo and native ER-SDE recognition, prefix rejection, conservative refresh policies, seeded ER-SDE replay guards, and complete offline capture/replay coverage;
 - refresh-only anchor feedback with video-only policy scoring, a `1.5` threshold, a three-refresh budget, and no retained/injected hidden residual;
 - terminal feedback-probe elimination while preserving the final rollback validation probe;
 - rollback threshold and three-correction budget enforcement;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,38 +1,32 @@
-# Spectrum MiniMax H3 v0.2.5
+# Spectrum MiniMax H3 v0.2.6
 
-Reduces offline replay GPU memory pressure and enables Spectrum forecasting for Larryvrh's MiniMax H3 Turbo sampler.
+Adds proper native ComfyUI `er_sde` sampler support to Spectrum's ordinary path and the default offline smoothing replay path.
 
-## Offline replay memory fix
+## Native ER-SDE integration
 
-- Separates the causal forecast history from the full offline replay archive.
-- Keeps `history_storage` bounded by `max_history`, including when it is set to `vram`.
-- Adds `offline_archive_storage`, defaulting to `system_ram` for new and existing workflows.
-- Retains `offline_archive_storage=vram` as an explicit option for systems with sufficient headroom.
-- Reports both configured storage locations and the resolved archive device in debug summaries.
+- Recognizes ComfyUI's exact native `sample_er_sde` implementation behind the `er_sde` KSampler name.
+- Preserves the one-to-one mapping between Spectrum logical steps and ER-SDE model evaluations.
+- Applies a conservative schedule of at most one consecutive forecast followed by one completed actual refresh.
+- Keeps ER-SDE's solver-local denoised history, stage updates, callbacks, final sigma-zero behavior, and stochastic update order inside the native sampler loop.
+- Supports the standard `offline_smoothing_replay=true` path with deterministic reconstruction of the native seeded noise sequence.
+- Uses no additional forced actual tail beyond the configured user tail.
 
-### Root cause
+## Replay safety
 
-Before offline replay, `history_storage=vram` retained at most `max_history` feature snapshots. Offline replay reused that setting for every actual anchor until its second pass completed. The meaning of the existing option therefore changed from a bounded causal history to an all-anchor CUDA archive. One recorded 20-step run retained about 4.3 GiB for that archive, enough to cause allocator pressure, severe slowdown, or an out-of-memory error on a 12 GB GPU.
+ER-SDE's default noise sampler is recreated from the same ComfyUI seed on each sampler invocation. This allows capture and replay to reproduce the same stochastic innovations from identical inputs.
 
-The archive now has its own storage policy. Existing workflows do not contain the new trailing input, so they receive the safe `system_ram` archive default automatically.
+Custom `noise_sampler` or `noise_scaler` callables may retain mutable state that Spectrum cannot safely reconstruct. When either override is present, offline replay fails closed to one native pass. Ordinary single-pass Spectrum remains available because the one-model-call topology is unchanged.
 
-## MiniMax H3 Turbo sampler support
-
-- Recognizes Larryvrh's exact `_turbo_sampler` contract.
-- Applies the existing conservative Euler safeguards: at most one consecutive forecast and one required actual refresh after a forecast.
-- Covers the standard offline capture and transformer-free replay path.
-- Keeps similarly named and otherwise unknown samplers on the native bypass.
-
-The reviewed Turbo implementation makes one denoiser call per scheduler step and does not inject ancestral noise, churn, or additional model evaluations.
+The default-off `anchor_residual_feedback` and `selective_rollback_correction` experiments remain limited to their separately reviewed sampler contracts.
 
 ## Compatibility
 
-The new archive selector is a trailing optional node input, preserving existing saved workflows. Existing Euler and RES schedules, offline smoothing, audio handling, progress reporting, and generated-result processing are unchanged. Workflows that intentionally want the former all-anchor CUDA behavior can select `offline_archive_storage=vram`.
+Existing workflows retain their saved values. Euler, MiniMax H3 Turbo, RES multistep, RES multistep CFG++, offline smoothing, audio handling, progress reporting, and native fallback behavior are unchanged.
 
 ## Validation
 
-- The revised default archive behavior was confirmed in a real H3 generation after the reported VRAM regression.
-- The combined CPU suite passes 183 tests; four CUDA-only test cases are skipped in the CPU environment.
-- Mixed-storage tests cover causal history on CUDA with the archive on CPU and the inverse placement.
-- Turbo tests cover exact-name recognition, prefix rejection, policy constraints, callbacks, and complete offline capture/replay.
-- Both feature PRs passed the three-version ComfyUI GitHub Actions matrix and CodeRabbit review.
+- Confirmed in a real MiniMax H3 ER-SDE generation with the default offline smoothing replay path.
+- 116 CPU tests passed; three CUDA-only tests were skipped in the CPU environment.
+- Native sampler-contract tests passed against all three older pinned ComfyUI revisions.
+- The four-version GitHub Actions matrix passed, including reviewed current ComfyUI master `27bca654eb9a70237d93f56a6ea336ab55f8925d`.
+- CodeRabbit reported no actionable review findings.

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -26,6 +26,7 @@ SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset(
     {
         "_turbo_sampler",
         "sample_euler",
+        "sample_er_sde",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
     }
@@ -37,6 +38,8 @@ RES_MULTISTEP_SAMPLERS = frozenset(
         "sample_res_multistep_cfg_pp",
     }
 )
+
+ER_SDE_SAMPLERS = frozenset({"sample_er_sde"})
 
 
 @dataclass(slots=True)
@@ -51,6 +54,19 @@ def sampler_name(sampler: Any) -> str:
 
 def sampler_is_supported(sampler: Any) -> bool:
     return sampler_name(sampler) in SUPPORTED_SINGLE_CALL_SAMPLERS
+
+
+def sampler_supports_seeded_replay(sampler: Any) -> bool:
+    """Return whether a fresh invocation can reconstruct the sampler's random stream."""
+    if not sampler_is_supported(sampler):
+        return False
+    if sampler_name(sampler) not in ER_SDE_SAMPLERS:
+        return True
+
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return False
+    return options.get("noise_sampler") is None and options.get("noise_scaler") is None
 
 
 def max_consecutive_forecasts(sampler: Any) -> int | None:
@@ -191,6 +207,13 @@ def outer_sample_wrapper(
             min_actual_steps_after_forecast=min_actual_steps_after_forecast(sampler),
             min_tail_actual_steps=min_tail_actual_steps(sampler),
         )
+        if name in ER_SDE_SAMPLERS and (
+            runtime.config.anchor_residual_feedback
+            or runtime.config.selective_rollback_correction
+        ):
+            runtime.disable_experiment(
+                "ER-SDE is reviewed only for ordinary Spectrum and offline smoothing replay"
+            )
         if runtime.config.debug:
             LOG.warning(
                 "Spectrum H3 run start phase=%s run_id=%s sampler=%s steps=%s supported=%s",
@@ -245,6 +268,22 @@ def outer_sample_wrapper(
         LOG.warning(
             "Spectrum H3 offline smoothing replay is unsupported for sampler %s; running one native pass",
             name,
+        )
+        return executor(
+            noise,
+            latent_image,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+    if not sampler_supports_seeded_replay(sampler):
+        LOG.warning(
+            "Spectrum H3 offline smoothing replay requires ER-SDE's native seeded "
+            "noise_sampler and noise_scaler; running one native pass"
         )
         return executor(
             noise,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.5"
+version = "0.2.6"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_sampler_contract.py
+++ b/tests/test_sampler_contract.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import ast
+import copy
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import torch
 
 RES_VARIANTS = (
     "sample_res_multistep",
@@ -19,17 +22,29 @@ ANCESTRAL_VARIANTS = (
 )
 
 
-def _native_sampling_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+def _native_tree(relative_path: str) -> ast.Module:
     comfyui_path = os.environ.get("COMFYUI_PATH")
     if not comfyui_path:
         pytest.skip("COMFYUI_PATH is required for native sampler contract tests")
-    source_path = Path(comfyui_path) / "comfy" / "k_diffusion" / "sampling.py"
-    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    source_path = Path(comfyui_path) / relative_path
+    return ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+
+def _native_sampling_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
     return {
         node.name: node
-        for node in tree.body
+        for node in _native_tree("comfy/k_diffusion/sampling.py").body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
+
+
+def _compile_native_sampling_function(name: str, globals_: dict):
+    function = copy.deepcopy(_native_sampling_functions()[name])
+    function.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = dict(globals_)
+    exec(compile(module, f"<native {name}>", "exec"), namespace)
+    return namespace[name]
 
 
 def _named_calls(node: ast.AST, name: str) -> list[ast.Call]:
@@ -147,3 +162,200 @@ def test_native_ancestral_variants_inject_or_delegate_to_noise(function_name):
     )
 
     assert "noise_sampler" in loaded or delegates_to_ancestral_core
+
+def test_native_er_sde_makes_one_model_call_per_outer_solver_iteration():
+    function = _native_sampling_functions()["sample_er_sde"]
+    loops = [node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor))]
+
+    assert len(loops) == 1
+    assert len(_named_calls(loops[0], "model")) == 1
+    assert len(_named_calls(function, "model")) == 1
+
+
+def test_native_er_sde_stages_reuse_only_solver_local_denoised_history():
+    function = _native_sampling_functions()["sample_er_sde"]
+    loop = next(node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor)))
+    loaded = _loaded_names(loop)
+    initial_history = {
+        target.id
+        for assignment in function.body
+        if isinstance(assignment, ast.Assign)
+        and isinstance(assignment.value, ast.Constant)
+        and assignment.value.value is None
+        for target in assignment.targets
+        if isinstance(target, ast.Name)
+    }
+
+    assert {"old_denoised", "old_denoised_d"} <= initial_history
+    assert {"max_stage", "old_denoised", "old_denoised_d"} <= loaded
+    assert len(_named_calls(loop, "model")) == 1
+    assert len(_named_calls(loop, "min")) == 1
+
+    history_targets = {
+        target.id
+        for assignment in ast.walk(loop)
+        if isinstance(assignment, ast.Assign)
+        for target in assignment.targets
+        if isinstance(target, ast.Name)
+    }
+    assert {"old_denoised", "old_denoised_d"} <= history_targets
+
+
+def test_native_er_sde_noise_and_callback_contract_is_one_per_nonterminal_or_outer_step():
+    function = _native_sampling_functions()["sample_er_sde"]
+    loop = next(node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor)))
+
+    callback_calls = _named_calls(loop, "callback")
+    noise_calls = _named_calls(loop, "noise_sampler")
+    assert len(callback_calls) == 1
+    assert len(noise_calls) == 1
+    assert len(_named_calls(function, "default_noise_sampler")) == 1
+
+    terminal_branch = next(
+        node
+        for node in ast.walk(loop)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and any(
+            isinstance(comparator, ast.Constant) and comparator.value == 0
+            for comparator in node.test.comparators
+        )
+        and any(
+            isinstance(item, ast.Name) and item.id == "sigmas"
+            for item in ast.walk(node.test)
+        )
+    )
+    assert not _named_calls(ast.Module(body=terminal_branch.body, type_ignores=[]), "noise_sampler")
+    terminal_updates = [
+        assignment
+        for assignment in ast.walk(ast.Module(body=terminal_branch.orelse, type_ignores=[]))
+        if isinstance(assignment, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "x" for target in assignment.targets)
+        and not _named_calls(assignment, "noise_sampler")
+    ]
+    assert len(
+        _named_calls(ast.Module(body=terminal_branch.orelse, type_ignores=[]), "noise_sampler")
+    ) == 1
+    assert terminal_updates
+    assert max(assignment.lineno for assignment in terminal_updates) < noise_calls[0].lineno
+    assert callback_calls[0].lineno < noise_calls[0].lineno
+
+
+def test_native_er_sde_runtime_counts_are_independent_of_max_stage():
+    native_er_sde = _compile_native_sampling_function(
+        "sample_er_sde",
+        {
+            "torch": torch,
+            "trange": lambda count, disable=None: range(count),
+            "default_noise_sampler": object(),
+            "offset_first_sigma_for_snr": lambda sigmas, _model_sampling: sigmas,
+            "sigma_to_half_log_snr": (
+                lambda sigmas, _model_sampling: -torch.log(sigmas.clamp_min(1e-6))
+            ),
+        },
+    )
+    model_sampling = SimpleNamespace(noise_scale=1.0)
+
+    class Patcher:
+        def get_model_object(self, name):
+            assert name == "model_sampling"
+            return model_sampling
+
+    def run(max_stage, s_noise=1.0):
+        model_calls = []
+        callbacks = []
+        noise_draws = []
+
+        class Model:
+            inner_model = SimpleNamespace(model_patcher=Patcher())
+
+            def __call__(self, x, sigma, **_extra_args):
+                model_calls.append(sigma.detach().clone())
+                sigma_view = sigma.reshape(-1, *([1] * (x.ndim - 1)))
+                return x * 0.25 + sigma_view * 0.05
+
+        def noise_sampler(sigma, sigma_next):
+            noise_draws.append((float(sigma), float(sigma_next)))
+            return torch.zeros((1, 2), dtype=torch.float32)
+
+        result = native_er_sde(
+            Model(),
+            torch.ones((1, 2), dtype=torch.float32),
+            torch.tensor([4.0, 3.0, 2.0, 1.0, 0.0]),
+            extra_args={"seed": 17},
+            callback=lambda state: callbacks.append(state["i"]),
+            disable=True,
+            noise_sampler=noise_sampler,
+            noise_scaler=lambda value: value + 10.0,
+            max_stage=max_stage,
+            s_noise=s_noise,
+        )
+        return result, model_calls, callbacks, noise_draws
+
+    stage_one = run(1)
+    stage_three = run(3)
+    noise_disabled = run(3, s_noise=0.0)
+
+    for result, model_calls, callbacks, noise_draws in (stage_one, stage_three):
+        assert torch.isfinite(result).all()
+        assert len(model_calls) == 4
+        assert callbacks == [0, 1, 2, 3]
+        assert noise_draws == [(4.0, 3.0), (3.0, 2.0), (2.0, 1.0)]
+
+    assert len(noise_disabled[1]) == 4
+    assert noise_disabled[2] == [0, 1, 2, 3]
+    assert noise_disabled[3] == []
+
+
+def test_native_default_noise_sampler_restarts_the_same_seeded_sequence():
+    default_noise_sampler = _compile_native_sampling_function(
+        "default_noise_sampler",
+        {"torch": torch},
+    )
+    x = torch.zeros((2, 3), dtype=torch.float32)
+    first = default_noise_sampler(x, seed=1234)
+    replay = default_noise_sampler(x, seed=1234)
+
+    for _ in range(3):
+        first_draw = first(torch.tensor(1.0), torch.tensor(0.5))
+        replay_draw = replay(torch.tensor(1.0), torch.tensor(0.5))
+        torch.testing.assert_close(first_draw, replay_draw)
+
+
+def test_current_comfyui_registers_er_sde_as_native_ksampler():
+    tree = _native_tree("comfy/samplers.py")
+    sampler_names = next(
+        node.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "KSAMPLER_NAMES" for target in node.targets)
+    )
+
+    assert isinstance(sampler_names, ast.List)
+    assert "er_sde" in {
+        item.value
+        for item in sampler_names.elts
+        if isinstance(item, ast.Constant) and isinstance(item.value, str)
+    }
+
+    ksampler = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "ksampler"
+    )
+    assert any(
+        isinstance(call.func, ast.Name)
+        and call.func.id == "getattr"
+        and len(call.args) >= 2
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "k_diffusion_sampling"
+        and isinstance(call.args[1], ast.Call)
+        and isinstance(call.args[1].func, ast.Attribute)
+        and call.args[1].func.attr == "format"
+        and isinstance(call.args[1].func.value, ast.Constant)
+        and call.args[1].func.value.value == "sample_{}"
+        and "sampler_name" in _loaded_names(call.args[1])
+        for call in ast.walk(ksampler)
+        if isinstance(call, ast.Call)
+    )

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -20,6 +20,7 @@ from comfyui_spectrum_h3.sampling import (
     sampler_is_supported,
     sampler_name,
     sampler_sample_wrapper,
+    sampler_supports_seeded_replay,
 )
 
 
@@ -36,6 +37,7 @@ def _sampler(function_name: str) -> SimpleNamespace:
     (
         "_turbo_sampler",
         "sample_euler",
+        "sample_er_sde",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
     ),
@@ -68,6 +70,7 @@ def test_unreviewed_sampler_names_do_not_match_by_prefix(function_name):
     (
         "_turbo_sampler",
         "sample_euler",
+        "sample_er_sde",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
     ),
@@ -84,8 +87,8 @@ def test_res_multistep_policy_refreshes_once_and_protects_tail(function_name):
     assert min_tail_actual_steps(sampler) == 3
 
 
-@pytest.mark.parametrize("function_name", ("sample_euler", "_turbo_sampler"))
-def test_euler_policy_keeps_one_refresh_and_user_tail(function_name):
+@pytest.mark.parametrize("function_name", ("sample_euler", "sample_er_sde", "_turbo_sampler"))
+def test_non_res_policy_keeps_one_refresh_and_user_tail(function_name):
     sampler = _sampler(function_name)
 
     assert min_actual_steps_after_forecast(sampler) == 1
@@ -98,6 +101,23 @@ def test_unsupported_sampler_has_no_forecast_streak_policy():
     assert max_consecutive_forecasts(sampler) is None
     assert min_actual_steps_after_forecast(sampler) == 0
     assert min_tail_actual_steps(sampler) == 0
+
+
+def test_er_sde_native_sampler_components_are_seeded_replay_safe():
+    sampler = _sampler("sample_er_sde")
+    sampler.extra_options = {"max_stage": 2, "s_noise": 0.75}
+
+    assert sampler_is_supported(sampler)
+    assert sampler_supports_seeded_replay(sampler)
+
+
+@pytest.mark.parametrize("option_name", ("noise_sampler", "noise_scaler"))
+def test_er_sde_custom_sampler_components_are_not_seeded_replay_safe(option_name):
+    sampler = _sampler("sample_er_sde")
+    sampler.extra_options = {option_name: lambda *args: args[0]}
+
+    assert sampler_is_supported(sampler)
+    assert not sampler_supports_seeded_replay(sampler)
 
 
 class _WrapperTestModel:
@@ -254,7 +274,7 @@ def test_predict_noise_passthrough_survives_a_downstream_model_bypass(caplog):
         runtime.end_run(run_id)
 
 
-@pytest.mark.parametrize("function_name", ("sample_euler", "_turbo_sampler"))
+@pytest.mark.parametrize("function_name", ("sample_euler", "sample_er_sde", "_turbo_sampler"))
 def test_default_offline_outer_sample_reports_both_passes_and_callbacks_only_replay(
     monkeypatch, function_name
 ):
@@ -529,6 +549,95 @@ def test_offline_progress_finishes_when_replay_aborts(monkeypatch):
     assert callback_arguments == []
     assert runtime.active_run_id is None
     assert runtime.offline_archive is None
+
+
+@pytest.mark.parametrize("option_name", ("noise_sampler", "noise_scaler"))
+def test_offline_er_sde_custom_sampler_components_use_true_native_bypass(
+    option_name, caplog
+):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            bootstrap_first_forecast=False,
+            offline_smoothing_replay=True,
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime), "transformer_options": {}}
+    )
+    sampler = _sampler("sample_er_sde")
+    sampler.extra_options = {option_name: lambda *args: args[0]}
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            assert runtime.active_run_id is None
+            calls.append((args, kwargs))
+            return "native-er-sde-result"
+
+    callback = object()
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.0]),
+            callback=callback,
+            seed=7,
+        )
+
+    assert result == "native-er-sde-result"
+    assert len(calls) == 1
+    assert calls[0][0][5] is callback
+    assert runtime.active_run_id is None
+    assert "native seeded noise_sampler and noise_scaler" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "experiment_name",
+    ("anchor_residual_feedback", "selective_rollback_correction"),
+)
+def test_er_sde_does_not_enable_unreviewed_experimental_modes(
+    experiment_name, caplog
+):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            bootstrap_first_forecast=False,
+            offline_smoothing_replay=False,
+            **{experiment_name: True},
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime), "transformer_options": {}}
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            assert runtime.supported_sampler
+            assert runtime.experiment_disabled_reason is not None
+            return "ordinary-spectrum-er-sde"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            _sampler("sample_er_sde"),
+            torch.tensor([1.0, 0.5, 0.0]),
+            seed=7,
+        )
+
+    assert result == "ordinary-spectrum-er-sde"
+    assert runtime.active_run_id is None
+    assert "reviewed only for ordinary Spectrum and offline smoothing replay" in caplog.text
 
 
 def test_offline_unsupported_sampler_uses_true_native_bypass(caplog):


### PR DESCRIPTION
## Summary

Add source-reviewed support for ComfyUI's native `er_sde` KSampler (`sample_er_sde`) to the ordinary Spectrum and default offline smoothing replay paths.

- allowlist the exact native function name with the existing one-forecast/one-actual-refresh policy
- keep ER-SDE's native solver loop and stochastic update intact
- replay the default native random stream from the same ComfyUI seed and cloned initial inputs
- fail closed to one native pass when custom `noise_sampler` or `noise_scaler` objects make replay state unverifiable
- leave `anchor_residual_feedback` and `selective_rollback_correction` outside the ER-SDE contract
- add current ComfyUI master `27bca654eb9a70237d93f56a6ea336ab55f8925d` to the native-contract matrix

## Reviewed native contract

Current `sample_er_sde` performs one `model(...)` evaluation and one callback per outer solver iteration. `max_stage` changes only the use of invocation-local `old_denoised` and `old_denoised_d` history; it does not add model calls or noise draws.

With effective `s_noise > 0`, the native implementation draws once after the deterministic ER update for each nonterminal step. The final sigma-zero step assigns `x = denoised` and draws no noise. The default noise sampler creates a fresh device generator from `extra_args["seed"]` on every sampler invocation, so Spectrum's capture and replay calls reconstruct the same sequence from identical cloned inputs. No native ER history survives a separate invocation.

## Why this is a real integration

Spectrum's logical step remains aligned one-to-one with ER-SDE's denoiser evaluation and sigma coordinate. Replay rebuilds the native sampler's local history from the replayed denoised sequence while using the same stochastic innovations. Stateful custom sampler/scaler callables are detected before capture and never enter an unsafe two-pass transaction.

## Validation

- `116 passed, 3 skipped` across sampling, sampler-contract, runtime, offline archive/smoothing, and rollback suites against current ComfyUI master
- `16 passed` independently against each of the three existing pinned ComfyUI revisions
- dynamic native-source tests cover stage 1 versus stage 3 call counts, callbacks, nonterminal/final noise draws, `s_noise=0`, seeded generator restart, solver-local history, and KSampler registration/mapping
- Python compilation passed for all modified Python files

The skipped cases are CUDA-only storage tests in the CPU validation environment.

GitHub Actions run #95 passed all four reviewed ComfyUI matrix jobs, including current master `27bca654eb9a70237d93f56a6ea336ab55f8925d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native ER-SDE sampler support.
  - Added deterministic replay safeguards for supported ER-SDE configurations.
  - Added ER-SDE to sampler availability and offline replay coverage.

- **Bug Fixes**
  - Custom noise samplers or scalers now safely fall back to a native single-pass execution when replay requirements are unmet.
  - Disabled unsupported experimental correction modes for ER-SDE to ensure predictable behavior.

- **Documentation**
  - Updated sampler support, replay behavior, and validation guidance for ER-SDE and Turbo sampling policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->