### PR TITLE
Fix native SamplerER_SDE offline replay detection

### DIFF
--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -76,6 +77,16 @@ def _er_sde_noise_scaler_supports_replay(noise_scaler: Any) -> bool:
 
     code = getattr(noise_scaler, "__code__", None)
     if code is None or tuple(code.co_freevars) != expected_freevars:
+        return False
+
+    native_module = sys.modules.get(ER_SDE_NATIVE_SCALER_MODULE)
+    if native_module is None or getattr(noise_scaler, "__globals__", None) is not vars(native_module):
+        return False
+    sampler_class = getattr(native_module, "SamplerER_SDE", None)
+    execute = getattr(sampler_class, "execute", None)
+    execute_function = getattr(execute, "__func__", execute)
+    execute_code = getattr(execute_function, "__code__", None)
+    if execute_code is None or not any(item is code for item in execute_code.co_consts):
         return False
 
     closure = getattr(noise_scaler, "__closure__", None) or ()

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -319,8 +319,8 @@ def outer_sample_wrapper(
         )
     if not sampler_supports_seeded_replay(sampler):
         LOG.warning(
-            "Spectrum H3 offline smoothing replay requires ER-SDE's default seeded "
-            "noise_sampler and a reviewed replay-safe noise_scaler; running one native pass"
+            "Spectrum H3 offline smoothing replay requires ER-SDE's native seeded "
+            "noise_sampler and noise_scaler; running one native pass"
         )
         return executor(
             noise,

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -40,6 +40,12 @@ RES_MULTISTEP_SAMPLERS = frozenset(
 )
 
 ER_SDE_SAMPLERS = frozenset({"sample_er_sde"})
+ER_SDE_NATIVE_SCALER_MODULE = "comfy_extras.nodes_custom_sampler"
+ER_SDE_NATIVE_SCALER_FREEVARS = {
+    "SamplerER_SDE.execute.<locals>.er_sde_noise_scaler": ("eta",),
+    "SamplerER_SDE.execute.<locals>.reverse_time_sde_noise_scaler": ("eta",),
+    "SamplerER_SDE.execute.<locals>.ode_noise_scaler": (),
+}
 
 
 @dataclass(slots=True)
@@ -56,6 +62,35 @@ def sampler_is_supported(sampler: Any) -> bool:
     return sampler_name(sampler) in SUPPORTED_SINGLE_CALL_SAMPLERS
 
 
+def _er_sde_noise_scaler_supports_replay(noise_scaler: Any) -> bool:
+    """Accept only the reviewed native SamplerER_SDE scaler closures."""
+    if noise_scaler is None:
+        return True
+    if getattr(noise_scaler, "__module__", None) != ER_SDE_NATIVE_SCALER_MODULE:
+        return False
+
+    qualname = getattr(noise_scaler, "__qualname__", None)
+    expected_freevars = ER_SDE_NATIVE_SCALER_FREEVARS.get(qualname)
+    if expected_freevars is None:
+        return False
+
+    code = getattr(noise_scaler, "__code__", None)
+    if code is None or tuple(code.co_freevars) != expected_freevars:
+        return False
+
+    closure = getattr(noise_scaler, "__closure__", None) or ()
+    if len(closure) != len(expected_freevars):
+        return False
+    for cell in closure:
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            return False
+        if type(value) not in (int, float):
+            return False
+    return True
+
+
 def sampler_supports_seeded_replay(sampler: Any) -> bool:
     """Return whether a fresh invocation can reconstruct the sampler's random stream."""
     if not sampler_is_supported(sampler):
@@ -66,7 +101,9 @@ def sampler_supports_seeded_replay(sampler: Any) -> bool:
     options = getattr(sampler, "extra_options", {}) or {}
     if not isinstance(options, dict):
         return False
-    return options.get("noise_sampler") is None and options.get("noise_scaler") is None
+    if options.get("noise_sampler") is not None:
+        return False
+    return _er_sde_noise_scaler_supports_replay(options.get("noise_scaler"))
 
 
 def max_consecutive_forecasts(sampler: Any) -> int | None:
@@ -282,8 +319,8 @@ def outer_sample_wrapper(
         )
     if not sampler_supports_seeded_replay(sampler):
         LOG.warning(
-            "Spectrum H3 offline smoothing replay requires ER-SDE's native seeded "
-            "noise_sampler and noise_scaler; running one native pass"
+            "Spectrum H3 offline smoothing replay requires ER-SDE's default seeded "
+            "noise_sampler and a reviewed replay-safe noise_scaler; running one native pass"
         )
         return executor(
             noise,

--- a/tests/test_er_sde_replay_guard.py
+++ b/tests/test_er_sde_replay_guard.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from comfyui_spectrum_h3.sampling import sampler_supports_seeded_replay
+
+
+def _er_sde_sampler(**options):
+    def sample_er_sde():
+        pass
+
+    return SimpleNamespace(sampler_function=sample_er_sde, extra_options=options)
+
+
+def _native_sampler_er_sde_scaler(name: str, eta: float = 0.75):
+    if name == "er_sde_noise_scaler":
+        def er_sde_noise_scaler(x):
+            return x * ((x ** 0.3).exp() + 10.0) ** eta
+
+        scaler = er_sde_noise_scaler
+    elif name == "reverse_time_sde_noise_scaler":
+        def reverse_time_sde_noise_scaler(x):
+            return x ** (eta + 1)
+
+        scaler = reverse_time_sde_noise_scaler
+    elif name == "ode_noise_scaler":
+        def ode_noise_scaler(x):
+            return x
+
+        scaler = ode_noise_scaler
+    else:
+        raise AssertionError(f"unexpected native scaler name: {name}")
+
+    scaler.__module__ = "comfy_extras.nodes_custom_sampler"
+    scaler.__qualname__ = f"SamplerER_SDE.execute.<locals>.{name}"
+    return scaler
+
+
+@pytest.mark.parametrize(
+    "scaler_name",
+    (
+        "er_sde_noise_scaler",
+        "reverse_time_sde_noise_scaler",
+        "ode_noise_scaler",
+    ),
+)
+def test_native_sampler_er_sde_scalers_are_seeded_replay_safe(scaler_name):
+    sampler = _er_sde_sampler(
+        s_noise=0.8,
+        max_stage=3,
+        noise_scaler=_native_sampler_er_sde_scaler(scaler_name),
+    )
+
+    assert sampler_supports_seeded_replay(sampler)
+
+
+def test_custom_er_sde_noise_sampler_remains_replay_unsafe():
+    sampler = _er_sde_sampler(noise_sampler=lambda *_args: None)
+
+    assert not sampler_supports_seeded_replay(sampler)
+
+
+def test_unknown_er_sde_noise_scaler_remains_replay_unsafe():
+    sampler = _er_sde_sampler(noise_scaler=lambda value: value)
+
+    assert not sampler_supports_seeded_replay(sampler)
+
+
+def test_native_named_er_sde_scaler_with_changed_closure_contract_fails_closed():
+    mutable_state = []
+
+    def er_sde_noise_scaler(x):
+        mutable_state.append(x)
+        return x
+
+    er_sde_noise_scaler.__module__ = "comfy_extras.nodes_custom_sampler"
+    er_sde_noise_scaler.__qualname__ = (
+        "SamplerER_SDE.execute.<locals>.er_sde_noise_scaler"
+    )
+    sampler = _er_sde_sampler(noise_scaler=er_sde_noise_scaler)
+
+    assert not sampler_supports_seeded_replay(sampler)
+
+
+def _loaded_names(node: ast.AST) -> set[str]:
+    return {
+        item.id
+        for item in ast.walk(node)
+        if isinstance(item, ast.Name) and isinstance(item.ctx, ast.Load)
+    }
+
+
+def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
+    comfyui_path = os.environ.get("COMFYUI_PATH")
+    if not comfyui_path:
+        pytest.skip("COMFYUI_PATH is required for native sampler contract tests")
+
+    source = Path(comfyui_path) / "comfy_extras/nodes_custom_sampler.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    sampler_class = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "SamplerER_SDE"
+    )
+    execute = next(
+        node
+        for node in sampler_class.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "execute"
+    )
+
+    local_scalers = {
+        node.name: node
+        for node in execute.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert set(local_scalers) == {
+        "er_sde_noise_scaler",
+        "reverse_time_sde_noise_scaler",
+        "ode_noise_scaler",
+    }
+    assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= {"x", "eta"}
+    assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= {"x", "eta"}
+    assert _loaded_names(local_scalers["ode_noise_scaler"]) <= {"x"}
+
+    ksampler_call = next(
+        call
+        for call in ast.walk(execute)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "ksampler"
+    )
+    assert len(ksampler_call.args) >= 2
+    options = ksampler_call.args[1]
+    assert isinstance(options, ast.Dict)
+    option_names = {
+        key.value
+        for key in options.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    assert option_names == {"s_noise", "noise_scaler", "max_stage"}
+    assert "noise_sampler" not in option_names

--- a/tests/test_er_sde_replay_guard.py
+++ b/tests/test_er_sde_replay_guard.py
@@ -116,15 +116,16 @@ def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
         for node in execute.body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
-    assert set(local_scalers) == {
+    reviewed_scalers = {
         "er_sde_noise_scaler",
         "reverse_time_sde_noise_scaler",
         "ode_noise_scaler",
     }
+    assert local_scalers
+    assert set(local_scalers) <= reviewed_scalers
     allowed_scaler_names = {"x", "eta", "torch"}
-    assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= allowed_scaler_names
-    assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= allowed_scaler_names
-    assert _loaded_names(local_scalers["ode_noise_scaler"]) <= allowed_scaler_names
+    for scaler in local_scalers.values():
+        assert _loaded_names(scaler) <= allowed_scaler_names
 
     ksampler_call = next(
         call

--- a/tests/test_er_sde_replay_guard.py
+++ b/tests/test_er_sde_replay_guard.py
@@ -121,9 +121,10 @@ def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
         "reverse_time_sde_noise_scaler",
         "ode_noise_scaler",
     }
-    assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= {"x", "eta", "torch"}
-    assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= {"x", "eta", "torch"}
-    assert _loaded_names(local_scalers["ode_noise_scaler"]) <= {"x"}
+    allowed_scaler_names = {"x", "eta", "torch"}
+    assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= allowed_scaler_names
+    assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= allowed_scaler_names
+    assert _loaded_names(local_scalers["ode_noise_scaler"]) <= allowed_scaler_names
 
     ksampler_call = next(
         call

--- a/tests/test_er_sde_replay_guard.py
+++ b/tests/test_er_sde_replay_guard.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import ast
 import os
+import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import FunctionType, ModuleType, SimpleNamespace
 
 import pytest
 
 from comfyui_spectrum_h3.sampling import sampler_supports_seeded_replay
+
+
+NATIVE_SCALER_MODULE = "comfy_extras.nodes_custom_sampler"
 
 
 def _er_sde_sampler(**options):
@@ -17,28 +21,58 @@ def _er_sde_sampler(**options):
     return SimpleNamespace(sampler_function=sample_er_sde, extra_options=options)
 
 
-def _native_sampler_er_sde_scaler(name: str, eta: float = 0.75):
-    if name == "er_sde_noise_scaler":
+def _install_native_sampler_er_sde_module(monkeypatch, eta: float = 0.75):
+    module = ModuleType(NATIVE_SCALER_MODULE)
+    exec(
+        """
+class SamplerER_SDE:
+    @classmethod
+    def execute(cls, eta):
         def er_sde_noise_scaler(x):
-            return x * ((x ** 0.3).exp() + 10.0) ** eta
+            return x + eta
 
-        scaler = er_sde_noise_scaler
-    elif name == "reverse_time_sde_noise_scaler":
         def reverse_time_sde_noise_scaler(x):
             return x ** (eta + 1)
 
-        scaler = reverse_time_sde_noise_scaler
-    elif name == "ode_noise_scaler":
         def ode_noise_scaler(x):
             return x
 
-        scaler = ode_noise_scaler
-    else:
-        raise AssertionError(f"unexpected native scaler name: {name}")
+        return {
+            "er_sde_noise_scaler": er_sde_noise_scaler,
+            "reverse_time_sde_noise_scaler": reverse_time_sde_noise_scaler,
+            "ode_noise_scaler": ode_noise_scaler,
+        }
+""",
+        module.__dict__,
+    )
+    monkeypatch.setitem(sys.modules, NATIVE_SCALER_MODULE, module)
+    return module.SamplerER_SDE.execute(eta)
 
-    scaler.__module__ = "comfy_extras.nodes_custom_sampler"
-    scaler.__qualname__ = f"SamplerER_SDE.execute.<locals>.{name}"
-    return scaler
+
+def _closure_cell(value):
+    def capture():
+        return value
+
+    return capture.__closure__[0]
+
+
+def _body_dump(body: list[ast.stmt]) -> str:
+    return ast.dump(ast.Module(body=body, type_ignores=[]), include_attributes=False)
+
+
+def _reviewed_body(source: str) -> str:
+    function = ast.parse(f"def scaler(x):\n    {source}\n").body[0]
+    assert isinstance(function, ast.FunctionDef)
+    return _body_dump(function.body)
+
+
+REVIEWED_SCALER_BODIES = {
+    "er_sde_noise_scaler": _reviewed_body(
+        "return x * ((x ** 0.3).exp() + 10.0) ** eta"
+    ),
+    "reverse_time_sde_noise_scaler": _reviewed_body("return x ** (eta + 1)"),
+    "ode_noise_scaler": _reviewed_body("return x"),
+}
 
 
 @pytest.mark.parametrize(
@@ -49,11 +83,12 @@ def _native_sampler_er_sde_scaler(name: str, eta: float = 0.75):
         "ode_noise_scaler",
     ),
 )
-def test_native_sampler_er_sde_scalers_are_seeded_replay_safe(scaler_name):
+def test_native_sampler_er_sde_scalers_are_seeded_replay_safe(monkeypatch, scaler_name):
+    native_scalers = _install_native_sampler_er_sde_module(monkeypatch)
     sampler = _er_sde_sampler(
         s_noise=0.8,
         max_stage=3,
-        noise_scaler=_native_sampler_er_sde_scaler(scaler_name),
+        noise_scaler=native_scalers[scaler_name],
     )
 
     assert sampler_supports_seeded_replay(sampler)
@@ -71,28 +106,43 @@ def test_unknown_er_sde_noise_scaler_remains_replay_unsafe():
     assert not sampler_supports_seeded_replay(sampler)
 
 
-def test_native_named_er_sde_scaler_with_changed_closure_contract_fails_closed():
-    mutable_state = []
+def test_native_metadata_and_globals_spoof_with_different_code_fails_closed(monkeypatch):
+    native_scalers = _install_native_sampler_er_sde_module(monkeypatch)
+    eta = 0.75
 
-    def er_sde_noise_scaler(x):
-        mutable_state.append(x)
-        return x
+    def spoofed_er_sde_noise_scaler(x):
+        return x * eta
 
-    er_sde_noise_scaler.__module__ = "comfy_extras.nodes_custom_sampler"
-    er_sde_noise_scaler.__qualname__ = (
-        "SamplerER_SDE.execute.<locals>.er_sde_noise_scaler"
+    trusted_globals = native_scalers["er_sde_noise_scaler"].__globals__
+    spoofed = FunctionType(
+        spoofed_er_sde_noise_scaler.__code__,
+        trusted_globals,
+        name="er_sde_noise_scaler",
+        closure=spoofed_er_sde_noise_scaler.__closure__,
     )
-    sampler = _er_sde_sampler(noise_scaler=er_sde_noise_scaler)
+    spoofed.__module__ = NATIVE_SCALER_MODULE
+    spoofed.__qualname__ = "SamplerER_SDE.execute.<locals>.er_sde_noise_scaler"
+    assert spoofed.__code__.co_freevars == ("eta",)
+
+    sampler = _er_sde_sampler(noise_scaler=spoofed)
 
     assert not sampler_supports_seeded_replay(sampler)
 
 
-def _loaded_names(node: ast.AST) -> set[str]:
-    return {
-        item.id
-        for item in ast.walk(node)
-        if isinstance(item, ast.Name) and isinstance(item.ctx, ast.Load)
-    }
+def test_native_scaler_code_with_mutable_closure_state_fails_closed(monkeypatch):
+    native_scalers = _install_native_sampler_er_sde_module(monkeypatch)
+    native = native_scalers["er_sde_noise_scaler"]
+    forged = FunctionType(
+        native.__code__,
+        native.__globals__,
+        name=native.__name__,
+        closure=(_closure_cell([]),),
+    )
+    forged.__module__ = native.__module__
+    forged.__qualname__ = native.__qualname__
+    sampler = _er_sde_sampler(noise_scaler=forged)
+
+    assert not sampler_supports_seeded_replay(sampler)
 
 
 def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
@@ -116,16 +166,10 @@ def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
         for node in execute.body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
-    reviewed_scalers = {
-        "er_sde_noise_scaler",
-        "reverse_time_sde_noise_scaler",
-        "ode_noise_scaler",
-    }
     assert local_scalers
-    assert set(local_scalers) <= reviewed_scalers
-    allowed_scaler_names = {"x", "eta", "torch"}
-    for scaler in local_scalers.values():
-        assert _loaded_names(scaler) <= allowed_scaler_names
+    assert set(local_scalers) <= set(REVIEWED_SCALER_BODIES)
+    for name, scaler in local_scalers.items():
+        assert _body_dump(scaler.body) == REVIEWED_SCALER_BODIES[name]
 
     ksampler_call = next(
         call
@@ -137,10 +181,12 @@ def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
     assert len(ksampler_call.args) >= 2
     options = ksampler_call.args[1]
     assert isinstance(options, ast.Dict)
-    option_names = {
-        key.value
-        for key in options.keys
+    option_map = {
+        key.value: value
+        for key, value in zip(options.keys, options.values)
         if isinstance(key, ast.Constant) and isinstance(key.value, str)
     }
-    assert option_names == {"s_noise", "noise_scaler", "max_stage"}
-    assert "noise_sampler" not in option_names
+    assert set(option_map) == {"s_noise", "noise_scaler", "max_stage"}
+    assert isinstance(option_map["noise_scaler"], ast.Name)
+    assert option_map["noise_scaler"].id == "noise_scaler"
+    assert "noise_sampler" not in option_map

--- a/tests/test_er_sde_replay_guard.py
+++ b/tests/test_er_sde_replay_guard.py
@@ -122,7 +122,7 @@ def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
         "ode_noise_scaler",
     }
     assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= {"x", "eta", "torch"}
-    assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= {"x", "eta"}
+    assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= {"x", "eta", "torch"}
     assert _loaded_names(local_scalers["ode_noise_scaler"]) <= {"x"}
 
     ksampler_call = next(

--- a/tests/test_er_sde_replay_guard.py
+++ b/tests/test_er_sde_replay_guard.py
@@ -121,7 +121,7 @@ def test_comfyui_sampler_er_sde_wires_only_reviewed_native_scaler_closures():
         "reverse_time_sde_noise_scaler",
         "ode_noise_scaler",
     }
-    assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= {"x", "eta"}
+    assert _loaded_names(local_scalers["er_sde_noise_scaler"]) <= {"x", "eta", "torch"}
     assert _loaded_names(local_scalers["reverse_time_sde_noise_scaler"]) <= {"x", "eta"}
     assert _loaded_names(local_scalers["ode_noise_scaler"]) <= {"x"}
 


### PR DESCRIPTION
## Summary

Fix issue #42: Spectrum's ER-SDE replay-safety gate incorrectly rejected ComfyUI's native `SamplerER_SDE` node whenever `offline_smoothing_replay` was enabled.

## Root cause

`sample_er_sde` itself has an optional `noise_sampler=None` parameter. With `None`, it reconstructs the native default noise sampler from `extra_args["seed"]` for each invocation. Current `SamplerER_SDE` does not populate a `noise_sampler` extra option, so keeping a non-`None` custom `noise_sampler` replay-unsafe is intentional.

The broken part was the blanket `noise_scaler is None` requirement. Current ComfyUI's native `SamplerER_SDE.execute()` uses deterministic built-in scaler closures in `extra_options`; older supported ComfyUI revisions use a subset of those closures or `None` while keeping the same native options contract. Spectrum therefore misclassified valid native ER-SDE configurations as replay-unsafe and fell back to one native pass before any Spectrum run began.

The suggestion to invert both checks to `is not None` would reverse the intended semantics: missing/`None` means the reconstructible native default, while a non-`None` `noise_sampler` is an external override whose mutable RNG/state Spectrum cannot assume it can recreate across capture and replay.

## Fix

- keep rejecting any externally supplied non-`None` `noise_sampler`;
- accept `noise_scaler=None` for the regular/default ER-SDE path;
- accept a non-`None` scaler only when it matches a reviewed native `SamplerER_SDE` scaler contract;
- require trusted runtime provenance: the scaler must use the loaded `comfy_extras.nodes_custom_sampler` module globals and its exact `__code__` object must be one of the nested scaler code objects owned by that loaded module's `SamplerER_SDE.execute`;
- retain the reviewed qualified-name/free-variable contract and immutable numeric closure-state checks;
- continue failing closed for arbitrary/custom/stateful scaler callables, metadata/code spoofs, or future upstream shapes that no longer match the reviewed contract.

This preserves the offline-replay invariant: both passes must start from identical inputs and reconstruct the same stochastic innovations and deterministic scaler behavior.

## Regression coverage

Focused tests prove:

- all currently reviewed native `SamplerER_SDE` scaler variants are replay-safe;
- custom `noise_sampler` remains replay-unsafe;
- arbitrary custom `noise_scaler` remains replay-unsafe;
- a callable with matching module/qualname/freevars and even trusted native globals is rejected when its code is not the actual native nested scaler code object;
- mutable closure state is rejected even when using the actual trusted native scaler code object;
- each pinned ComfyUI source revision wires only reviewed native scaler closures (or `None`), passes `noise_scaler` through the expected option, and does not pass a custom `noise_sampler` option;
- the source-contract test validates the exact reviewed scaler function-body semantics rather than only symbol names.

The full four-revision ComfyUI CI matrix is green, including the forecaster smoke test, Ruff/compileall, and native MiniMax-H3 tests.

Closes #42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seeded replay for ER-SDE sampling when using validated native noise scalers.
  * Custom, unknown, or modified noise scalers are now rejected to prevent unsafe replay behavior.

* **Tests**
  * Added coverage for native, custom, unknown, and altered noise scaler scenarios.
  * Added safeguards verifying approved sampler configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->