### PR TITLE
Release v0.2.11: fix native ER-SDE forecast solver-state mismatch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
             comfyui_spectrum_h3/sampling.py \
             comfyui_spectrum_h3/__init__.py \
             tests/test_config.py \
+            tests/test_er_sde_solver_dense_output.py \
             tests/test_er_sde_stochastic_compensation.py \
             tests/test_generic_correction.py \
             tests/test_generic_correction_calibration.py \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
             comfyui_spectrum_h3/generic_correction_runtime.py \
             comfyui_spectrum_h3/generic_correction_topology.py \
             comfyui_spectrum_h3/experiments.py \
+            comfyui_spectrum_h3/er_sde_ksampler_contract.py \
             comfyui_spectrum_h3/er_sde_stochastic.py \
             comfyui_spectrum_h3/objective_media.py \
             comfyui_spectrum_h3/objective_media_bounded.py \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,7 @@ jobs:
             tests/test_runtime.py \
             tests/test_sampler_contract.py \
             tests/test_sampling.py \
+            tests/test_tiled_diffusion_ksampler_contract.py \
             tests/conftest.py \
             tools/analyze_generic_correction.py \
             --ignore N999,I001,C408,UP035

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,7 @@ jobs:
             comfyui_spectrum_h3/objective_media_bounded.py \
             comfyui_spectrum_h3/objective_media_nodes.py \
             comfyui_spectrum_h3/nodes.py \
+            comfyui_spectrum_h3/postrun_safety.py \
             comfyui_spectrum_h3/runtime.py \
             comfyui_spectrum_h3/sampling.py \
             comfyui_spectrum_h3/__init__.py \
@@ -87,6 +88,7 @@ jobs:
             tests/test_objective_media_bounded.py \
             tests/test_objective_media_seed_link.py \
             tests/test_objective_media_sequential.py \
+            tests/test_postrun_safety.py \
             tests/test_runtime.py \
             tests/test_sampler_contract.py \
             tests/test_sampling.py \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
             comfyui_spectrum_h3/generic_correction_runtime.py \
             comfyui_spectrum_h3/generic_correction_topology.py \
             comfyui_spectrum_h3/experiments.py \
+            comfyui_spectrum_h3/er_sde_stochastic.py \
             comfyui_spectrum_h3/objective_media.py \
             comfyui_spectrum_h3/objective_media_bounded.py \
             comfyui_spectrum_h3/objective_media_nodes.py \
@@ -72,6 +73,7 @@ jobs:
             comfyui_spectrum_h3/sampling.py \
             comfyui_spectrum_h3/__init__.py \
             tests/test_config.py \
+            tests/test_er_sde_stochastic_compensation.py \
             tests/test_generic_correction.py \
             tests/test_generic_correction_calibration.py \
             tests/test_generic_correction_core.py \
@@ -84,6 +86,7 @@ jobs:
             tests/test_objective_media_seed_link.py \
             tests/test_objective_media_sequential.py \
             tests/test_runtime.py \
+            tests/test_sampler_contract.py \
             tests/test_sampling.py \
             tests/conftest.py \
             tools/analyze_generic_correction.py \

--- a/README.md
+++ b/README.md
@@ -1,14 +1,64 @@
 # ComfyUI Spectrum MiniMax H3
 
-Training-free Spectrum-style feature forecasting for ComfyUI's native **MiniMax H3 audio-video model**.
+Training-free feature forecasting for ComfyUI's native **MiniMax H3 audio-video model**.
 
-Spectrum reduces the number of expensive H3 transformer evaluations during sampling. Actual steps run native MiniMax H3 and capture the packed target hidden state after the final transformer block. Forecast steps predict that hidden state from previous actual anchors with a Chebyshev ridge model, skip the H3 transformer blocks, then run the current native `FinalLayer`, video/audio reconstruction, sigma handling, and sampler update.
+Spectrum reduces the number of expensive H3 transformer evaluations during sampling. Actual steps run native MiniMax H3 and retain the packed target hidden state after the final transformer block. Forecast steps predict that state from previous actual anchors, skip the H3 transformer blocks for that step, and continue through the native output/sampler path.
 
-Spectrum is an **approximate accelerator**. Forecasted steps change the denoising trajectory. Outputs can differ from native H3 in motion, timing, pose, anatomy, facial behavior, audio, and synchronization even with the same seed and workflow.
+Spectrum is an **approximate accelerator**. Forecasted steps change the denoising trajectory, so output can differ from native H3 even with the same seed and workflow.
+
+## v0.2.11: native ER-SDE quality fix
+
+v0.2.11 fixes the characteristic high-frequency / "confetti" corruption that could appear on Spectrum forecast steps with native ER-SDE.
+
+The problem was not simply ER-SDE's random increment. A skipped H3 hidden/velocity forecast was being reconstructed against ER-SDE's current stochastic latent as if it were a valid current-state denoised/x0 estimate. ER-SDE then consumed that inconsistent value in its own solver update and higher-order derivative history.
+
+Spectrum now keeps ER-SDE's native stochastic latent trajectory unchanged while reconstructing skipped **solver-facing denoised/x0 values in ER-SDE solver space** from exact actual denoised anchors:
+
+- the first causal forecast after one actual anchor uses the latest exact actual denoised value;
+- later causal forecasts use bounded linear dense output in native ER-SDE lambda coordinate from the two latest exact actual anchors;
+- degenerate or excessive extrapolation falls back to the latest exact actual anchor;
+- the native ER-SDE random stream, `s_noise`, stage-2/stage-3 history, and latent `x` trajectory remain intact;
+- no additional H3 transformer/denoiser NFE is added.
+
+Real MiniMax H3 validation removed the forecast confetti completely and produced a modest but repeatable improvement in fine/low-resolution visual structure without an observed loss of motion/action or audio quality.
+
+The release also hardens post-run teardown: generic-correction research persistence/evaluation is no longer allowed to block a completed sampler result from reaching VAE decode or video saving.
+
+## Installation
+
+### ComfyUI Manager / Registry
+
+Install **ComfyUI-Spectrum-MiniMax-H3** through ComfyUI Manager / the Comfy Registry, then restart ComfyUI.
+
+### Git
+
+```bash
+cd ComfyUI/custom_nodes
+git clone https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3.git
+```
+
+To update an existing Git install:
+
+```bash
+cd ComfyUI/custom_nodes/ComfyUI-Spectrum-MiniMax-H3
+git pull --ff-only
+```
+
+Restart ComfyUI after updating.
 
 ## Quick start
 
-For new workflows, the current compatibility-safe defaults are:
+Recommended model chain:
+
+```text
+MiniMax H3 model loader
+-> LoRA / model patches
+-> MiniMax H3 Sigma Shift
+-> Spectrum Apply MiniMax H3
+-> guider / sampler
+```
+
+The current Python defaults are:
 
 ```text
 enabled = true
@@ -26,6 +76,7 @@ offline_archive_storage = system_ram
 bootstrap_first_forecast = true
 offline_smoothing_replay = true
 model_aware_mode = off
+model_aware_risk_threshold = 0.65
 model_aware_trust_shrinkage = false
 model_aware_replay_generic_correction = false
 generic_correction_mode = coordinate_rls
@@ -36,442 +87,239 @@ anchor_residual_feedback = false
 selective_rollback_correction = false
 ```
 
-With the current defaults, a 20-step **Euler** run normally produces **11 actual transformer evaluations and 9 forecasts** when no fallback or model-aware scheduling rule adds an actual step. Other reviewed samplers can impose sampler-specific tail or replay safeguards that change the count.
+A normal 20-step run commonly resolves to **11 actual H3 transformer evaluations + 9 forecasts** when no fallback or sampler-specific safeguard adds an actual step.
 
-For quality-critical work, run an exact-seed A/B with Spectrum enabled and disabled for the checkpoint, sampler, resolution, duration, prompt, references, and LoRAs you intend to use.
+For quality-critical work, compare Spectrum enabled/disabled with the exact same seed, prompt, checkpoint, references, sampler, schedule, resolution, duration and LoRAs.
 
-## Current recommendations
+## Recommended configurations
 
-### General use
+### General/default path
 
-Keep the defaults above. The default two-pass `offline_smoothing_replay` path was introduced after matched MiniMax H3 tests isolated two audio-degradation paths in the earlier single-pass design:
+Keep the defaults unless you have a reason to change them.
 
-- direct spectral mixing of audio rows;
-- later joint H3 transformer evaluations inheriting a video-forecast trajectory change.
+`offline_smoothing_replay=true` uses a compute-heavy causal capture pass followed by a transformer-free replay. It was introduced to preserve audio fidelity after matched H3 testing showed that direct audio spectral mixing and later joint H3 evaluations could cause speech/stutter regressions. The default keeps `audio_blend_weight=0.0`.
 
-The current default captures a local-only first pass, keeps `audio_blend_weight=0`, then performs a transformer-free replay that applies the accepted video smoothing. This removed the reproduced speech/stutter failure on the affected seed and retained the preferred video result.
+### Native ER-SDE quality path
 
-The result remains approximate. Broader audio and visual behavior depends on the model, prompt, sampler, references, resolution, duration, precision, and step count.
-
-### Native ER-SDE quality testing
-
-Current controlled native ER-SDE testing found the best temporal facial behavior among the compared model-aware configurations with:
+For native ER-SDE, the currently preferred quality-oriented single-pass setup is:
 
 ```text
 model_aware_mode = full
-model_aware_trust_shrinkage = false
 offline_smoothing_replay = false
+model_aware_trust_shrinkage = false
 ```
 
-In the tested 20-step run, `full` kept the same 11-actual / 9-forecast schedule as `schedule_confidence`, reduced the measured hidden forecast error, and removed a recurring false eye-motion artifact. Earlier same-seed ER-SDE testing also found a pronunciation case that improved with `full`.
-
-This recommendation is scoped to the tested native ER-SDE setup. No equivalent quality ranking has been established for Euler, RES/RES CFG++, Turbo/LightX2V, or other samplers. The global defaults therefore remain `model_aware_mode=off` and `offline_smoothing_replay=true`.
-
-When the opt-in `model_aware_mode=full` causal path is active, its validated
-generic-correction defaults are `coordinate_rls + no_attenuation + hard_clip +
-0.40` with canonical RLS lambda `0.90`. This promotion is supported by three
-independent whole-run hidden-space groups and three controlled decoded-media
-ER-SDE triads. The explicit `legacy + mode_default + rational + 0.25`
-configuration remains available for exact reproduction.
-
-### Speed-up / few-step LoRAs
-
-Turbo/LightX2V-style LoRAs can be combined with Spectrum at runtime. Maintainer testing found a large additional speed gain and lower visual fidelity than the normal 20-step Spectrum path, including smoother/plasticky detail and larger changes in composition, action, and motion.
-
-A measured 8-second LightX2V 8-step run at roughly 0.9 MP used:
+The validated full-mode generic correction is:
 
 ```text
-Sampler: ER-SDE
-Total steps: 8
-Actual transformer evaluations: 5
-Forecast steps: 3
-Spectrum first-pass wall time: 91.256 s
+generic_correction_mode = coordinate_rls
+generic_correction_attenuation = no_attenuation
+generic_correction_limiter = hard_clip
+generic_correction_limit = 0.40
 ```
 
-A representative 8-second plain-Spectrum run from the earlier roughly 0.7 MP / 20-step family used:
+The ER-SDE solver-space dense-output correction added in v0.2.11 is automatic; it does not require a new node setting.
+
+The exact legacy generic-correction reproduction remains:
 
 ```text
-Total steps: 20
-Actual transformer evaluations: 11
-Forecast steps: 9
-Spectrum first-pass wall time: 157.793 s
+generic_correction_mode = legacy
+generic_correction_attenuation = mode_default
+generic_correction_limiter = rational
+generic_correction_limit = 0.25
 ```
 
-That comparison is about **1.73x faster** in first-pass sampling time for the LightX2V + Spectrum run. It is not a controlled benchmark pair: the resolutions differ and the 20-step candidate is representative of a rerun cluster. Similar visual degradation was observed with the acceleration LoRA without Spectrum.
+### Few-step / acceleration LoRAs
 
-For quality-critical generation, the normal-step path remains the safer starting point.
+Turbo/LightX2V-style LoRAs can be combined with Spectrum. They can reduce sampling time further, but maintainer testing found noticeably larger changes in composition, motion and fine-detail quality than the normal 20-step path. Treat this as a separate quality/speed tradeoff rather than a free additional acceleration.
 
-## Supported native path
+## How Spectrum works
 
-Spectrum targets native ComfyUI `comfy.ldm.minimax.model.MiniMaxH3Model` and the packed MiniMax H3 sampler path.
-
-Supported native generation layouts:
-
-- text-to-video/audio (`t2va`)
-- first/last-frame-to-video/audio (`fl2va`)
-- reference-to-video/audio (`ref2va`)
-
-The minimum native integration contract is the MiniMax H3 packed-latent API introduced by ComfyUI commit [`e377e263`](https://github.com/Comfy-Org/ComfyUI/commit/e377e263049f9338b4d12a3dd417b36ae62948ff). Older ComfyUI revisions are unsupported.
-
-Spectrum forecasts only the target portion of the final-transformer-block hidden state:
+MiniMax H3 packs target audio and video rows into the final-transformer hidden state. Spectrum forecasts only the target portion:
 
 ```text
 [target audio rows | target video rows]
 ```
 
-Text rows and keyframe/reference-only rows stay outside forecast history.
+Text rows and keyframe/reference-only rows are not stored in forecast history.
 
-Actual steps continue through native H3 `_forward`. Forecast steps skip the transformer blocks, RoPE construction, conditioning projections, reference embedding, and per-block prefetch for that step, then execute the native current-step output path.
+On an **actual step** Spectrum lets native H3 run normally and captures the target hidden state. On a **forecast step** it predicts that hidden state from retained actual anchors and skips the expensive H3 transformer blocks. The current native output head/reconstruction path still runs.
+
+For ordinary deterministic/single-call samplers this hidden-state forecast is used directly. Native ER-SDE needs an additional solver bridge because its stochastic latent state and higher-order denoised history make `x - sigma * forecast_velocity` an invalid skipped solver observation. v0.2.11 therefore substitutes a bounded denoised-space dense output before ER-SDE consumes the result.
+
+## Supported native path
+
+Spectrum targets native ComfyUI `comfy.ldm.minimax.model.MiniMaxH3Model` and the packed MiniMax H3 sampler path.
+
+Supported native generation layouts include:
+
+- text-to-video/audio (`t2va`)
+- first/last-frame-to-video/audio (`fl2va`)
+- reference-to-video/audio (`ref2va`)
+
+The minimum reviewed packed-H3 integration contract starts at ComfyUI commit [`e377e263`](https://github.com/Comfy-Org/ComfyUI/commit/e377e263049f9338b4d12a3dd417b36ae62948ff). Older revisions are unsupported.
 
 ## Supported samplers
 
-Forecasting is allowlisted for these reviewed single-call sampler contracts:
+Forecasting is fail-closed and allowlisted for reviewed single-call sampler contracts.
 
 | Sampler | Function | Spectrum policy |
 |---|---|---|
-| Euler | `sample_euler` | At most one forecast, then a completed actual refresh. |
-| Native ER-SDE | `sample_er_sde` | Same one-forecast/one-refresh rule; native seeded replay is supported for reviewed native scaler closures. |
-| MiniMax H3 Turbo | `_turbo_sampler` | Larryvrh's reviewed deterministic single-call contract; same conservative refresh rule. |
-| RES multistep | `sample_res_multistep` | One-forecast/one-refresh rule and a protected three-step native tail. |
+| Euler | `sample_euler` | At most one forecast before an actual refresh. |
+| Native ER-SDE | `sample_er_sde` | Same conservative cadence plus stochastic-state tracking and solver-space dense output. |
+| MiniMax H3 Turbo | `_turbo_sampler` | Reviewed deterministic single-call contract. |
+| RES multistep | `sample_res_multistep` | Conservative cadence with protected native tail. |
 | RES multistep CFG++ | `sample_res_multistep_cfg_pp` | Same RES safeguards. |
 
-Unknown or unreviewed samplers fail closed to native execution.
+Unknown or changed sampler contracts fall back to native execution rather than guessing.
 
-For ER-SDE offline replay, an explicitly supplied custom `noise_sampler`, arbitrary/stateful `noise_scaler`, or unknown future scaler closure is replay-unsafe and falls back to one native pass. The reviewed native `SamplerER_SDE` scaler closures are accepted. Offline replay also promotes the ER-SDE penultimate step only when the normal schedule would otherwise forecast it, preserving an exact terminal replay anchor without imposing a blanket two-step tail.
+### ER-SDE compatibility details
+
+The v0.2.11 path keeps the exact native ER-SDE sampler implementation and RNG stream. Spectrum tracks the native stochastic increment only to maintain state ownership and replay compatibility; it does not disable or rescale ER-SDE noise.
+
+Custom/unreviewed `noise_sampler` or `noise_scaler` implementations fail closed to native behavior where their contract cannot be proven.
+
+ComfyUI-TiledDiffusion's current `KSAMPLER.sample(*args, **kwargs)` passthrough monkeypatch is supported through a narrow semantic validator that recursively verifies its stored native delegate. Arbitrary variadic sampler wrappers are not accepted automatically.
+
+## Scheduling
+
+Warmup and tail constraints are always actual. Reviewed samplers also limit the causal forecast horizon and require actual refreshes.
+
+The default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins.
+
+Typical 20-step Euler/ER-SDE single-pass cadence is approximately:
+
+```text
+A F A F A F A F A F A F A F A F A F A A
+```
+
+That is 11 actual evaluations and 9 forecasts. Fallbacks, model-aware scheduling, replay, RES tail rules, force-actual conditions and saved workflow settings can change the exact schedule.
+
+## Model-aware modes
+
+`model_aware_mode` controls additional scheduling/correction logic:
+
+- `off` — compatibility/default path;
+- `schedule` — model-informed scheduling without confidence gating;
+- `schedule_confidence` — scheduling with confidence/risk gating;
+- `full` — scheduling plus the validated scalar generic correction.
+
+The shipping full-mode generic controller uses signed coordinate transport with scalar RLS and a hard `±0.40` gain bound. More experimental reliability/regional controller options remain available for research/reproduction but are not the production default.
+
+## Offline smoothing replay
+
+With `offline_smoothing_replay=true`, Spectrum performs two sampler passes:
+
+1. a capture pass that gathers exact causal anchors;
+2. a transformer-free replay pass that applies the accepted bidirectional smoothing trajectory.
+
+The second pass does **not** double H3 transformer NFEs. It reuses the first-pass archive.
+
+Because callback side effects must not run twice, ordinary sampler callbacks are replay-only. This affects live preview timing.
+
+## Live preview
+
+The explicitly supported capture-pass preview integration is **KJNodes Model Preview Override**, typically used with Kijai's MiniMax H3 TAE. Spectrum recognizes the `kj_preview_override` wrapper as observational and keeps it active during capture/replay.
+
+Built-in ComfyUI preview callbacks, ComfyUI-bleh Better Previews, VHS Preview and other callback-based preview implementations are not currently guaranteed to update during the capture pass.
+
+For native ER-SDE single-pass operation, the v0.2.11 dense-output fix also means forecast previews no longer receive the solver-inconsistent confetti-corrupted denoised reconstruction seen in earlier versions.
+
+## Attention and other acceleration nodes
+
+Spectrum does not replace ComfyUI's attention backend.
+
+- actual steps use the attention backend selected by ComfyUI;
+- forecast steps skip the H3 transformer blocks, so they make no transformer attention call.
+
+CK / Comfy Kitchen attention works in maintainer testing. [Issue #41](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/issues/41) remains open for a reported second-generation freeze on some CK + Spectrum systems; update ComfyUI past the upstream H3 CK peak-VRAM fix before treating that report as a Spectrum-only failure.
+
+Do **not** run EasyCache or LazyCache on the same model branch as Spectrum. Those caches can bypass the native H3 observation Spectrum needs. Spectrum detects the active cache and remains inactive for that run.
 
 Multi-GPU parallel sampling remains native because distributed forecast-row transactions have not been validated.
 
-### Other cache/acceleration nodes
+## Memory and storage
 
-Do not run **EasyCache or LazyCache on the same model branch as Spectrum**. Those caches can return an approximate result without entering the native H3 wrapper, which prevents Spectrum from observing the actual feature required by its transaction. Spectrum detects the active cache and remains inactive for that run.
+`history_storage` controls the bounded causal forecast history. `offline_archive_storage` controls replay anchors when offline replay is enabled.
 
-Other downstream patches that intercept `predict_noise` are handled fail-closed: Spectrum accepts the downstream result, disables itself for the rest of that run, and releases retained forecast history.
+Use `system_ram` for both unless you have a specific reason to keep history in VRAM. Large H3 hidden histories can consume multiple GiB at high resolution/duration.
 
-## Attention backends
+v0.2.11 also changes post-run diagnostics so generic-correction report persistence/evaluation runs only after core Spectrum history is released and cannot synchronously block a completed sampler result. Debug teardown logs expose calibration-export and runtime-release boundaries when diagnosing WSL/CUDA shutdown stalls.
 
-Spectrum does not replace ComfyUI's attention implementation.
-
-- On an **actual** Spectrum step, native MiniMax H3 runs with the attention backend selected by ComfyUI.
-- On a **forecast** step, the H3 transformer blocks are skipped, so no transformer attention call is made for that step.
-
-CK / Comfy Kitchen attention works in maintainer testing, including consecutive H3 generations. An open report in [issue #41](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/issues/41) describes a second-generation freeze on two systems when CK and Spectrum are combined. ComfyUI's initial CK integration also had a real H3 peak-VRAM regression that was fixed upstream in commit [`62b3c94`](https://github.com/Comfy-Org/ComfyUI/commit/62b3c94bd45154f6486c7abf1b9efcacee96ea69). Update ComfyUI past that fix before diagnosing a CK + Spectrum memory problem.
-
-If the second generation stalls at `0/N`, enable `debug=true`, keep both Spectrum storage settings on `system_ram`, record VRAM before/after the first run, and test once with `offline_smoothing_replay=false`. Those results distinguish replay lifetime from a broader attention/backend peak-memory condition.
-
-## Installation
-
-### ComfyUI Manager
-
-Install **ComfyUI-Spectrum-MiniMax-H3** through ComfyUI Manager / the Comfy Registry, then restart ComfyUI.
-
-### Git
-
-```bash
-cd ComfyUI/custom_nodes
-git clone https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3.git
-```
-
-Restart ComfyUI. The node appears under:
-
-```text
-sampling/spectrum -> Spectrum Apply MiniMax H3
-sampling/spectrum/research -> Spectrum H3 Objective Media Capture (Sequential - Bounded)
-sampling/spectrum/research -> Spectrum H3 Objective Media Capture Reset
-sampling/spectrum/research -> Spectrum H3 Objective Media Stage (One-Shot / Full Media)
-sampling/spectrum/research -> Spectrum H3 Objective Quality Compare (One-Shot / Full Media)
-sampling/spectrum/research -> Spectrum H3 Objective Quality Compare (Staged One-Shot / Full Media)
-```
-
-The node adds no third-party Python dependency. It uses PyTorch and ComfyUI modules already present in a normal ComfyUI installation.
-
-The research-only objective nodes compare decoded native, legacy-Spectrum, and
-candidate outputs with structural, temporal, motion-detail, and audio metrics.
-They persist reports only and do nothing when unused. See
-[OBJECTIVE_MEDIA_BENCHMARK.md](OBJECTIVE_MEDIA_BENCHMARK.md) for the exact
-three-way workflow, metric definitions, provenance grouping, and verdict rule.
-
-### Updating a Git install
-
-```bash
-cd ComfyUI/custom_nodes/ComfyUI-Spectrum-MiniMax-H3
-git pull --ff-only
-```
-
-Restart ComfyUI after updating.
-
-Workflows saved with v0.2.0 may retain `offline_smoothing_replay=false`. Enable it once if you want the current default replay path. Workflows created before v0.2.0 did not serialize that input and receive the current Python default.
-
-## Workflow placement
-
-Recommended model chain:
-
-```text
-MiniMax H3 model loader
--> LoRA / model patches
--> MiniMax H3 Sigma Shift
--> Spectrum Apply MiniMax H3
--> guider / sampler
-```
-
-Spectrum accepts and returns `MODEL`. Disabled mode returns the original model object unchanged. Enabled mode clones the model and installs clone-local sampler/H3 wrappers.
-
-### Live preview support
-
-With `offline_smoothing_replay=true`, Spectrum performs:
-
-1. a compute-heavy capture pass;
-2. a transformer-free replay pass.
-
-Ordinary sampler callbacks are intentionally replay-only. Invoking arbitrary callbacks during capture and replay could duplicate callback side effects. ComfyUI's built-in preview and callback-based preview nodes can therefore appear only near the end because replay is fast.
-
-The **only capture-pass live-preview integration currently supported explicitly is KJNodes' `Model Preview Override`**, used with Kijai's MiniMax H3 TAE. Spectrum recognizes KJNodes' `kj_preview_override` wrapper as observational and keeps it inside the two-pass wrapper. It updates during both capture and replay and works whether the preview override appears before or after Spectrum in the model chain.
-
-Built-in ComfyUI previews, ComfyUI-bleh Better Previews, VHS Preview, and other callback-based preview implementations are not currently supported for capture-pass live preview.
+No speculative `torch.cuda.empty_cache()` or forced device synchronization is performed during normal teardown.
 
 ## Parameters
 
 | Parameter | Default | Description |
 |---|---:|---|
-| `enabled` | `true` | Enables Spectrum for the cloned model. |
-| `blend_weight` | `0.50` | Maximum direct spectral share for video. Offline replay validates and can attenuate it per forecast. |
-| `degree` | `1` | Maximum Chebyshev degree. Normal polynomial forecasting needs at least `degree + 1` actual anchors. |
-| `ridge_lambda` | `0.10` | Ridge regularization for the small Chebyshev Gram system. |
-| `window_size` | `2.0` | Initial adaptive schedule interval. |
-| `flex_window` | `0.75` | Amount added after a successfully completed scheduled actual step. |
-| `warmup_steps` | `1` | Initial native solver steps. Values above 1 disable the one-point bootstrap at the node boundary. |
-| `tail_actual_steps` | `1` | Requested final native tail. RES enforces 3; ER-SDE replay can promote a forecasted penultimate step. |
-| `max_history` | `8` | Maximum causal actual-feature snapshots. Must be at least `degree + 1`. |
-| `debug` | `false` | Enables run/schedule/fallback/storage/model-aware diagnostics. |
-| `history_storage` | `system_ram` | Storage for the bounded causal history: `system_ram` or `vram`. |
-| `bootstrap_first_forecast` | `true` | Degree-1 one-point hold for step 1 when `warmup_steps <= 1`. Incompatible UI settings disable only this option and log a warning. |
-| `offline_smoothing_replay` | `true` | Default two-pass audio-fidelity path: local-only capture plus transformer-free bidirectional replay. |
-| `audio_blend_weight` | `0.00` | Direct spectral share for audio. Zero keeps replay audio on local interpolation. |
-| `offline_archive_storage` | `system_ram` | Storage for every actual replay anchor. The archive is not capped by `max_history`. |
-| `model_aware_mode` | `off` | `off`, `schedule`, `schedule_confidence`, or `full`. See below. |
-| `model_aware_risk_threshold` | `0.65` | Threshold used by model-aware scheduling to convert a risky prospective forecast into an actual evaluation. |
-| `model_aware_trust_shrinkage` | `false` | Research/reproduction switch. The completed perceptual gate did not support promotion. |
-| `model_aware_replay_generic_correction` | `false` | Legacy/research replay transfer of the causal generic correction. Keep disabled for normal use. |
-| `generic_correction_mode` | `coordinate_rls` | Validated `full` controller using signed coordinate transport and scalar RLS. `legacy` preserves the previous exact path; reliability/regional modes remain research choices. |
-| `generic_correction_attenuation` | `no_attenuation` | Validated coordinate/RLS policy. Use `mode_default` with explicit legacy mode for exact previous behavior. |
-| `generic_correction_limiter` | `hard_clip` | Validated generic gain limiter at `0.40`; `rational` remains available for the legacy reproduction configuration. |
-| `generic_correction_limit` | `0.40` | Validated symmetric gain bound for coordinate/RLS. The exact legacy configuration uses `0.25`. |
-| `anchor_residual_feedback` | `false` | Experimental video-scored actual-refresh guard. Requires single-pass operation. |
-| `selective_rollback_correction` | `false` | Experimental deterministic-Euler rollback path. Requires single-pass operation. |
+| `enabled` | `true` | Enable Spectrum on the cloned model. |
+| `blend_weight` | `0.50` | Video spectral/replay blend ceiling. |
+| `audio_blend_weight` | `0.00` | Audio spectral share; zero is the current safe default. |
+| `degree` | `1` | Maximum Chebyshev forecast degree. |
+| `ridge_lambda` | `0.10` | Ridge regularization for the small forecast fit. |
+| `window_size` | `2.0` | Initial adaptive scheduling interval. |
+| `flex_window` | `0.75` | Interval growth after a completed scheduled actual step. |
+| `warmup_steps` | `1` | Initial actual solver steps. |
+| `tail_actual_steps` | `1` | Requested final actual tail; sampler-specific rules can enforce more. |
+| `max_history` | `8` | Maximum retained causal actual-feature snapshots. |
+| `history_storage` | `system_ram` | Causal history storage: `system_ram` or `vram`. |
+| `debug` | `false` | Detailed schedule, storage, ER-SDE and teardown diagnostics. |
+| `bootstrap_first_forecast` | `true` | Degree-1 step-1 one-point bootstrap when compatible. |
+| `offline_smoothing_replay` | `true` | Two-pass capture + transformer-free replay path. |
+| `offline_archive_storage` | `system_ram` | Offline replay archive storage. |
+| `model_aware_mode` | `off` | `off`, `schedule`, `schedule_confidence`, or `full`. |
+| `model_aware_risk_threshold` | `0.65` | Risk threshold for converting a forecast into an actual step. |
+| `model_aware_trust_shrinkage` | `false` | Research/reproduction switch; not promoted. |
+| `model_aware_replay_generic_correction` | `false` | Research/legacy replay transfer switch. |
+| `generic_correction_mode` | `coordinate_rls` | Validated full-mode scalar controller. |
+| `generic_correction_attenuation` | `no_attenuation` | Validated coordinate/RLS attenuation policy. |
+| `generic_correction_limiter` | `hard_clip` | Validated gain limiter. |
+| `generic_correction_limit` | `0.40` | Validated symmetric gain bound. |
+| `anchor_residual_feedback` | `false` | Experimental actual-refresh guard; single-pass only. |
+| `selective_rollback_correction` | `false` | Experimental deterministic-Euler rollback path; single-pass only. |
 
-## Adaptive scheduling
+## Research / objective media nodes
 
-Warmup and final-tail constraints are actual. After warmup, the schedule gradually increases its interval using `flex_window`. Reviewed samplers also impose a maximum forecast horizon of one logical step and require an actual refresh after each forecast.
+The package also contains research-only nodes under `sampling/spectrum/research` for bounded R/A/B decoded-media evaluation and reset/staging helpers. They do nothing unless explicitly added to a workflow.
 
-The degree-1 one-point bootstrap lets step 1 reuse the actual step-0 packed target hidden state as a zero-order prediction. It does not add a forecast to actual history. Step 2 therefore runs actual, after which normal degree-1 regression can start.
+The sequential objective capture path is bounded and failure-contained so recoverable research/evaluation errors do not abort unrelated output nodes. True host/CUDA OOM conditions are still allowed to propagate normally.
 
-Typical default **Euler** schedules:
+See [OBJECTIVE_MEDIA_BENCHMARK.md](OBJECTIVE_MEDIA_BENCHMARK.md) for the current R/A/B workflow, metrics, provenance grouping and verdict rules.
 
-| Total steps | Actual | Forecast | Typical indices |
-|---:|---:|---:|---|
-| 17 | 9 | 8 | Alternating `A/F` through the final actual step. |
-| 20 | 11 | 9 | `A F` through step 17, then steps 18 and 19 actual. |
+## Debugging
 
-Sampler safeguards, fallbacks, model-aware scheduling, force-actual conditions, branch topology, and saved settings can change these counts. Use `debug=true` when verifying whether Spectrum is active.
-
-## Offline smoothing replay
-
-The default replay path separates trajectory capture from accepted smoothing.
-
-During capture:
-
-- the ordinary Spectrum actual/forecast schedule runs;
-- causal video and audio blend weights are forced to zero;
-- every actual target hidden anchor is retained for replay;
-- normal arbitrary callbacks remain suppressed;
-- KJNodes' supported preview override can still observe the pass.
-
-During replay:
-
-- the sampler restarts from cloned initial inputs;
-- actual coordinates reuse stored anchors;
-- forecast coordinates combine bracketing interpolation with an all-anchor Chebyshev prediction;
-- leave-one-anchor-out validation independently attenuates the video and audio spectral shares;
-- no H3 transformer block runs;
-- the native current-step output heads/reconstruction and sampler update still run.
-
-`audio_blend_weight=0` makes audio local-only during replay. `blend_weight=0.5` remains an upper bound for video; validation can lower it at individual forecasts.
-
-Replay is still an anchor-reuse approximation. Stored anchors came from the capture trajectory, and the replay trajectory can diverge from it. Future anchors improve interpolation without making replay equivalent to native H3 at the new latent.
-
-## Memory
-
-Spectrum keeps two separate storage lifetimes:
-
-- `history_storage`: bounded causal history, capped by `max_history`;
-- `offline_archive_storage`: every actual anchor retained until replay completes.
-
-Both default to `system_ram`. This is the recommended setting for constrained GPUs.
-
-Selecting `vram` avoids repeated CPU/GPU transfers and can reduce forecast overhead. It also retains large H3 hidden states on the GPU. The all-anchor replay archive can consume several GiB independently of `max_history`.
-
-A measured 0.65 MP / 8-second, 11-anchor run retained roughly:
+Enable `debug=true` before reporting a sampler problem. Useful messages include:
 
 ```text
-full replay archive: ~3.89 GiB
-8-entry causal history: ~2.90 GiB
+Spectrum H3 run start ...
+Spectrum H3 step ... decision=actual|forecast ...
+Spectrum H3 ER-SDE stochastic tracking active ...
+Spectrum H3 ER-SDE dense anchor ...
+Spectrum H3 ER-SDE dense output ...
+Spectrum H3 run summary ...
+Spectrum H3 teardown transition ...
+Spectrum H3 run teardown ...
 ```
 
-These figures exclude current-step tensors, prediction buffers, replay-input clones, allocator fragmentation, and normal H3 peak allocations. Keep `offline_archive_storage=system_ram` unless you have ample VRAM headroom and have measured the complete generation peak.
+If Spectrum encounters an unreviewed sampler/wrapper contract it should log the reason and run native rather than silently applying an unsafe approximation.
 
-## Model-aware modes
+For bug reports, include:
 
-`model_aware_mode` is opt-in and defaults to `off`.
+- ComfyUI version/commit;
+- Spectrum version/commit;
+- sampler and scheduler;
+- total steps;
+- relevant Spectrum settings;
+- model/checkpoint and LoRAs;
+- resolution/frame count;
+- the Spectrum debug section from run start through teardown.
 
-| Mode | Behavior |
-|---|---|
-| `off` | Normal Spectrum scheduling and fitting. |
-| `schedule` | Builds a compact model/patch profile and may turn a risky prospective forecast into an actual evaluation. |
-| `schedule_confidence` | Adds adaptive ridge, usable degree, and modality-specific blend confidence. |
-| `full` | Adds the bounded generic latest-delta causal residual correction to `schedule_confidence`. |
+## Compatibility notes for saved workflows
 
-The profile samples bounded statistics from selected final H3 block / `FinalLayer` matrices and active patch metadata. Normal LoRA factors are measured without materializing a full dense update. Cached profiles retain scalar/metadata summaries and no model or GPU tensor references.
+ComfyUI serializes node widget values. Updating Spectrum therefore does not necessarily rewrite old saved settings to current defaults.
 
-The surviving `full` correction is generic trajectory information:
-
-```text
-d = h[-1] - h[-2]
-r = h_actual - h_pred_uncorrected
-g_raw = <r, d> / <d, d>
-```
-
-The gain is confidence-scaled and bounded before it is applied to the latest-delta direction. The correction itself adds no transformer evaluation. The scheduling component can still convert risky forecast steps into actual evaluations.
-
-`generic_correction_mode=coordinate_rls`,
-`generic_correction_attenuation=no_attenuation`,
-`generic_correction_limiter=hard_clip`, and `generic_correction_limit=0.40`
-form the validated full-mode controller. Three independent hidden-space groups
-selected this exact family with about 15.78% lower normalized hidden error than
-exact legacy, 48/0 target wins/losses, and no worst regression. Three controlled
-native ER-SDE decoded-media triads then produced two candidate-favored verdicts,
-one mixed verdict, and no legacy-favored verdict. The hidden-space percentage is
-not a perceptual-quality percentage. Evidence is scoped to native H3, ER-SDE,
-20 steps, 512x768, 192 frames, 24 fps, and three seeds.
-
-Explicit `legacy + mode_default + rational + 0.25` remains numerically
-reproducible. Correction-reliability and coarse temporal VIDEO controllers remain
-research paths. With `debug=true`, full single-pass runs also emit
-scalar-only exact quadratic calibration blocks for the shared CPU evaluator.
-When `offline_smoothing_replay=false`, Spectrum automatically persists each
-completed compatible block, rejects repeated traces/seeds, evaluates its compatible
-whole-run group, prints a concise hidden-space ranking, and refreshes detailed
-Markdown and JSON reports. No log capture or manual evaluator command is required.
-Rankings include the exact attenuation policy and are emitted only when
-the selected offline candidate is reproducible by live settings. Numerically
-equivalent RLS candidates are reported as a tie; the canonical live `lambda=0.90`
-is retained. Research reports state the separately validated runtime default and
-never edit live settings automatically.
-See
-[GENERIC_CORRECTION_RESEARCH.md](GENERIC_CORRECTION_RESEARCH.md) for their causal
-contract, topology proof, offline evaluation discipline, and promotion gate.
-
-The earlier model-specific Feature-3 correction families did not provide material improvement and were retired from normal runtime. The experiment record is preserved in [MODEL_AWARE_BENCHMARK.md](MODEL_AWARE_BENCHMARK.md) and [IMPLEMENTATION_NOTES.md](IMPLEMENTATION_NOTES.md).
-
-### Trust shrinkage and replay calibration research
-
-`model_aware_trust_shrinkage=false` is the supported setting. Hidden-feature improvements were observed during development, followed by a completed perceptual A/B gate that did not show a reliable user-facing benefit.
-
-`model_aware_replay_generic_correction=false` is also the supported setting. Replay traces rejected transplanting the causal latest-delta scalar onto the different future-bracket replay direction.
-
-The repository retains scalar-only replay calibration export and a CPU evaluator for future replay research. No affine, disagreement, coordinate, validation-penalty, tree, neural, AutoML, or other additional replay controller is applied to replay at runtime. Causal generic-correction experiments remain strictly separate. See [FORECAST_TRUST_BENCHMARK.md](FORECAST_TRUST_BENCHMARK.md) and [GENERIC_CORRECTION_RESEARCH.md](GENERIC_CORRECTION_RESEARCH.md).
-
-## Experimental trajectory controls
-
-The following options remain default-off research paths:
-
-- `anchor_residual_feedback`: measures forecast-versus-hold output error at an actual anchor and can force the next step actual when the video score reaches the fixed threshold. It never injects the measured hidden residual.
-- `selective_rollback_correction`: deterministic-Euler-only bounded rollback/recompute after a forecast is shown to have produced a high error score at the following actual anchor.
-
-Disable `offline_smoothing_replay` before enabling either experiment. These modes have narrower sampler contracts and can spend additional transformer evaluations.
-
-## Troubleshooting
-
-### Spectrum appears to do nothing
-
-Enable:
-
-```text
-debug = true
-```
-
-A working run reports nonzero `forecast_steps`. On a single-branch run, `actual_transformer_calls` should also be below the solver-step count when forecasts were accepted.
-
-A zero-forecast run logs the exact sampler, cache, wrapper-bypass, branch-label, topology, prediction, or safety fallback reason.
-
-Reference-heavy `ref2va` workflows can spend substantial time in preprocessing and other work outside the forecasted H3 transformer calls, so end-to-end wall-clock savings can look smaller than the reduction in transformer evaluations.
-
-### No live preview during sampling
-
-This is expected with the default replay path unless you use **KJNodes -> Model Preview Override** with Kijai's MiniMax H3 TAE. Ordinary callbacks are replay-only. See [Live preview support](#live-preview-support).
-
-### Audio sounds worse
-
-Start from:
-
-```text
-offline_smoothing_replay = true
-audio_blend_weight = 0.00
-model_aware_mode = off
-```
-
-Then run the same seed with Spectrum disabled. Include the exact Spectrum version, checkpoint, quantization/precision, sampler, scheduler/shift, steps, resolution, duration, prompt, references, LoRAs, and complete node settings in a bug report.
-
-### CK attention freezes on the next generation
-
-Confirm ComfyUI contains upstream H3 CK memory fix `62b3c94`, keep both Spectrum storage controls on `system_ram`, enable `debug`, and compare one run with `offline_smoothing_replay=false`. See [issue #41](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/issues/41).
-
-### Out of memory with replay
-
-Keep:
-
-```text
-history_storage = system_ram
-offline_archive_storage = system_ram
-```
-
-The replay archive is independent from `max_history`. Choosing `offline_archive_storage=vram` retains every actual anchor until replay teardown.
-
-## Validation and limits
-
-The repository's CI exercises the reviewed MiniMax H3 contract across multiple pinned ComfyUI revisions. Coverage includes forced-actual native equivalence, transformer-free forecast execution, sampler recognition and safety guards, split/reordered conditional labels, audio/video row segmentation, replay storage and callbacks, ER-SDE seeded replay, model-aware profile lifetime, generic correction, decoded-media objective metrics, and replay-calibration tooling.
-
-Real-checkpoint validation remains essential for quality claims. Current evidence includes exact-seed MiniMax H3 runs across Euler and native ER-SDE, reference-conditioned audio investigations, replay A/B tests, Turbo/LightX2V experiments, and community AMD/ROCm testing. These results cover specific configurations and do not establish universal fidelity.
-
-For the detailed current implementation contract, see:
-
-- [IMPLEMENTATION_NOTES.md](IMPLEMENTATION_NOTES.md)
-- [MODEL_AWARE_BENCHMARK.md](MODEL_AWARE_BENCHMARK.md)
-- [FORECAST_TRUST_BENCHMARK.md](FORECAST_TRUST_BENCHMARK.md)
-- [OBJECTIVE_MEDIA_BENCHMARK.md](OBJECTIVE_MEDIA_BENCHMARK.md)
-- [RELEASE_NOTES.md](RELEASE_NOTES.md)
-
-## Tests
-
-Forecaster smoke test in an environment with PyTorch:
-
-```bash
-python tests/smoke_forecaster.py
-```
-
-Full suite against a ComfyUI checkout:
-
-```bash
-COMFYUI_PATH=/path/to/ComfyUI \
-PYTHONPATH=/path/to/ComfyUI \
-python -m pytest -q
-```
-
-## Credits
-
-- Jiaqi Han, Juntong Shi, Puheng Li, Haotian Ye, Qiushan Guo, and Stefano Ermon for [Adaptive Spectral Feature Forecasting for Diffusion Sampling Acceleration](https://arxiv.org/abs/2603.01623) and the [official Spectrum implementation](https://github.com/hanjq17/Spectrum).
-- The [ComfyUI](https://github.com/Comfy-Org/ComfyUI) maintainers for native MiniMax H3, sampler wrappers, model patching, packed latent support, and model-management infrastructure.
-
-This repository is independent from [ComfyUI-Spectrum-Proper](https://github.com/xmarre/ComfyUI-Spectrum-Proper), which remains the dedicated FLUX implementation.
+In particular, workflows saved on older releases may retain old values for `offline_smoothing_replay`, model-aware options, or generic-correction settings. Compare the saved node against the defaults above when reproducing behavior across versions.
 
 ## License
 
-GPL-3.0-or-later. The implementation in this repository is standalone. Spectrum's published mathematics and official implementation were reviewed as primary references; no source file from the official implementation is vendored.
+GPL-3.0-or-later. See [LICENSE](LICENSE).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,63 +1,107 @@
-# Spectrum MiniMax H3 v0.2.10
+# Spectrum MiniMax H3 v0.2.11
 
-v0.2.10 hardens the Objective Sequential Capture research path against host/CUDA memory pressure and makes recoverable capture failures non-fatal to the surrounding ComfyUI workflow. The bounded analysis transform, objective R/A/B semantics, report schema, forecasting behavior, and production Spectrum defaults are unchanged.
+v0.2.11 fixes native ER-SDE forecast-state corruption, removes the characteristic high-frequency/confetti artifact from Spectrum ER-SDE forecast steps, hardens sampler-wrapper compatibility, and prevents optional post-run research from blocking an already-completed generation.
 
-## Memory-safe Objective Sequential Capture
+## Native ER-SDE solver-space fix
 
-Sequential capture now performs validation and memory admission before allocating the retained analysis destination. The preflight accounts for the decoded source media already live, the new bounded VIDEO/AUDIO destinations, existing pending captures, bounded staging workspaces, and explicit host/CUDA safety margins.
+Earlier Spectrum ER-SDE forecast steps predicted H3 hidden/velocity state without evaluating the current stochastic latent, then reconstructed denoised/x0 against ER-SDE's current `x`. Direct subtraction of the pending stochastic increment corrected one real mismatch term but did not remove the visible artifact in real MiniMax H3 testing.
 
-The retained research format remains the same:
+The stronger mismatch was solver-space consistency: ER-SDE consumes and differentiates denoised/x0 values in its update/history, while the skipped H3 hidden forecast was not a valid current-state denoised observation.
 
-- VIDEO is reduced deterministically to the bounded CPU `float16` analysis surface capped at 393,216 pixels per frame;
-- AUDIO is retained as an independent CPU `float32` waveform;
-- at most two incomplete benchmark IDs and 4 GiB of retained analysis media are kept;
-- raw decoded input tensors are never stored in `_PENDING_CAPTURES`.
+v0.2.11 therefore keeps native ER-SDE's stochastic latent trajectory unchanged and reconstructs skipped solver-facing denoised/x0 values from exact actual denoised anchors:
 
-Video staging derives its chunk size from a conservative 64 MiB workspace target, capped at four frames. The approximately 0.7 MP, 192-frame float32 case that exceeded that workspace target at four frames now stages three frames at a time. Audio uses bounded sample chunks as well.
+- the first causal forecast after one exact actual anchor uses the latest exact actual denoised value;
+- later causal forecasts use bounded linear dense output in native ER-SDE lambda coordinate from the two latest exact actual anchors;
+- degenerate, reversed, non-finite, or excessively long extrapolation falls back to the latest exact actual anchor;
+- native `s_noise`, RNG draws, stochastic latent updates, stage-2/stage-3 history and terminal behavior remain intact;
+- there are zero additional H3 transformer/denoiser NFEs.
 
-Finite/range validation no longer materializes a boolean tensor for every source element. It reduces each chunk with `aminmax`, checks only the resulting scalar bounds, clamps the owned work buffer in place, and releases intermediate representations before the next chunk allocation.
+The dense output is substituted before native ER-SDE's callback, integration update, derivative history and `old_denoised` assignment.
 
-Preflight, staging, and pending insertion are serialized under the pending-state lock so concurrent capture nodes cannot both admit themselves from stale accounting.
+## Real MiniMax H3 validation
 
-## Lower bounded-evaluator peak memory
+The solver-space candidate was tested on real native MiniMax H3 ER-SDE generations after the simpler exact-q candidate failed visually.
 
-The bounded VIDEO evaluator now processes legacy and candidate chunks sequentially against one reference chunk instead of materializing both comparison chunks together. Intermediate float32 tensors are released after each comparison.
+Observed result:
 
-This reduces the Spectrum-owned evaluator live set without changing the existing bounded metric profile or verdict calculations.
+- forecast confetti/noise disappeared completely;
+- final fine/low-resolution visual structure improved modestly but visibly across repeated generations;
+- action/motion remained comparable in the tested prompts;
+- audio remained comparable;
+- the normal 20-step Spectrum budget remained 11 actual H3 evaluations + 9 forecasts;
+- no additional H3 transformer NFE was introduced.
 
-## Recoverable failures no longer abort unrelated output nodes
+A later T2V rerun from an older saved workflow also completed normally after the teardown hardening below.
 
-Objective Sequential Capture now converts recoverable capture/evaluation failures into its status output instead of raising through the ComfyUI graph. This includes validation errors, incompatible or duplicate R/A/B roles, preflight rejection, staging failures, report/evaluator failures, and unexpected non-resource-exhaustion exceptions. Earlier accepted R/A roles remain intact when a later role is rejected before completion, while a completed triad is always released after evaluation succeeds or fails.
+## Native stochastic ownership and replay safety
 
-This lets unrelated output nodes, including video saving/combine nodes on the same execution, continue when the research capture itself cannot complete.
+Spectrum still tracks ER-SDE's exact additive stochastic increment so ownership is explicit across actual, forecast and replay paths. The stochastic increment remains part of native ER-SDE's latent `x`; Spectrum does not disable, globally attenuate or rescale native ER-SDE noise.
 
-Actual resource-exhaustion exceptions are deliberately not swallowed. `MemoryError`, CUDA OOM, and non-objective exceptions reporting an out-of-memory condition still propagate so ComfyUI/PyTorch can perform their normal OOM recovery behavior.
+Replay and compatibility paths retain exact stochastic compensation where solver-space dense output is not the reviewed causal path.
 
-## Capture diagnostics and ownership
+`s_noise=0` remains on the untouched native path without stochastic tracker allocation.
 
-Major capture boundaries now emit timestamped diagnostics with elapsed time and available memory telemetry where supported. Logged stages include input receipt, preflight, destination allocation, bounded chunk validation/resize/transfer/copy, pending insertion, evaluation, and report persistence.
+## TiledDiffusion sampler-wrapper compatibility
 
-Host telemetry uses `psutil` when available with platform fallbacks; CUDA captures also report allocator/free-memory state when available. If host telemetry is unavailable, a conservative absolute incremental guard remains in force.
+Real runtime testing exposed ComfyUI-TiledDiffusion's variadic `KSAMPLER_sample(*args, **kwargs)` monkeypatch above ComfyUI's native `KSAMPLER.sample`.
 
-Source ownership is explicit: only newly allocated reduced VIDEO and copied AUDIO tensors enter the pending store. Tests cover source release, reset, eviction, completed-triad teardown, staging failure, and evaluation failure.
+The ER-SDE preflight now supports that audited passthrough structure without broadly trusting arbitrary wrappers. The semantic validator:
+
+- verifies exact `*args/**kwargs` delegation;
+- validates the stored native target recursively;
+- verifies the reviewed TiledDiffusion `model_options` / `sigmas` bookkeeping shape;
+- rejects changed argument forwarding, alias mutation, cycles and unrelated state mutation;
+- still fails closed to untouched native sampling when the wrapper contract cannot be proven.
+
+## Post-run teardown safety
+
+A real saved-workflow run later hard-wedged WSL after all ER-SDE solver steps and the Spectrum run summary had completed, before `Spectrum H3 run teardown` or downstream VAE/video nodes appeared.
+
+The old generic-correction hook performed optional persistence/evaluation synchronously inside `SpectrumH3Runtime.end_run()`. A filesystem/evaluator stall could therefore block a valid completed sampler result from reaching downstream nodes.
+
+v0.2.11 changes the boundary:
+
+- calibration-block export remains synchronous and bounded;
+- core Spectrum runtime/history release remains synchronous;
+- optional generic-correction persistence/evaluation is dispatched only after runtime release;
+- the research worker is daemonized and bounded to one active job;
+- if a previous research job is still active, later diagnostic jobs are skipped rather than accumulating threads;
+- the research worker receives only a tensor-free calibration block and cannot retain Spectrum feature-history VRAM;
+- teardown debug breadcrumbs identify calibration export, runtime release and research dispatch boundaries.
+
+No speculative `torch.cuda.empty_cache()`, forced CUDA synchronization, or history offload was added.
+
+## README refresh
+
+The README has been rewritten around the current production behavior and now documents:
+
+- the v0.2.11 ER-SDE solver-space path;
+- current Python defaults and recommended ER-SDE quality settings;
+- supported samplers and fail-closed behavior;
+- TiledDiffusion compatibility;
+- model-aware/generic-correction defaults;
+- offline replay and live-preview behavior;
+- attention/cache compatibility;
+- memory/storage guidance and teardown diagnostics;
+- research nodes and current debugging information.
 
 ## Compatibility
 
-This release does not alter:
+This release does not change the global Python defaults for:
 
-- the production feature forecaster or sampler schedules;
-- model-aware controller defaults;
-- offline smoothing replay behavior;
-- the validated `coordinate_rls + no_attenuation + hard_clip + 0.40` full-mode generic-correction default;
-- exact legacy generic-correction reproduction;
-- Objective Media schema-v1 verdict thresholds or existing collected reports.
+- `offline_smoothing_replay=true`;
+- `model_aware_mode=off`;
+- `audio_blend_weight=0.0`;
+- the validated full-mode `coordinate_rls + no_attenuation + hard_clip + 0.40` generic correction.
 
-The package and source-checkout calibration provenance versions are advanced to `0.2.10`.
+Saved ComfyUI workflows can retain serialized values from older releases; updating the custom node does not automatically rewrite those widgets.
 
-## Remaining resource boundary
-
-The preflight is conservative admission control, not an atomic reservation of host or device memory. A real OOM can still occur if system/WSL commit availability changes after preflight, another process allocates concurrently, allocator/backend scratch exceeds the estimate, or an accelerator does not expose usable free-memory telemetry. Those true resource failures remain visible and are not converted into a successful capture status.
+Unknown or unreviewed sampler/noise/wrapper contracts continue to fail closed to native execution.
 
 ## Validation
 
-The PR is covered by the repository's pinned four-revision ComfyUI matrix. The matrix builds the wheel, runs the native-H3 forecaster smoke test, scoped Ruff, `compileall`, and the full pytest suite. Focused sequential-capture coverage includes deterministic staging parity across float16/bfloat16/float32/float64 inputs, bounded workspace accounting, preflight rejection before destination allocation, missing-telemetry fallback, duplicate/topology checks before staging, non-fatal recoverable errors, OOM propagation, source ownership, reset/eviction release, completed-triad teardown, and optional CUDA staging.
+The release is covered by the repository's four-revision pinned ComfyUI matrix. It builds the wheel, runs the native-H3 forecaster smoke test, scoped Ruff, `compileall`, and the full pytest suite on every reviewed revision.
+
+Focused v0.2.11 coverage includes ER-SDE stochastic ownership, first/terminal boundaries, seeded RNG/replay parity, stages 1/2/3, solver-space bootstrap hold and lambda extrapolation, extrapolation guards, all-actual parity, replay isolation, TiledDiffusion wrapper validation, bounded denoised-anchor lifetime, post-run release/research ordering, bounded background research dispatch and failure cleanup.
+
+The package and source-checkout calibration provenance versions are advanced to `0.2.11`.

--- a/comfyui_spectrum_h3/__init__.py
+++ b/comfyui_spectrum_h3/__init__.py
@@ -4,6 +4,7 @@ from .forecast import HistoryWeightForecaster
 from .generic_correction import install_generic_residual_correction
 from .minimax_h3 import locate_minimax_h3_inner, require_native_minimax_h3
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+from .postrun_safety import install_postrun_safety
 from .replay_calibration import install_replay_calibration
 from .replay_calibration_provenance import install_replay_calibration_provenance
 from .replay_calibration_validation import install_replay_calibration_validation
@@ -17,6 +18,7 @@ from .runtime import SpectrumH3Runtime
 from .trust_probe import install_forecast_trust_probe
 
 install_generic_residual_correction()
+install_postrun_safety()
 install_forecast_trust_probe()
 install_replay_native_trust_shadow()
 install_replay_component_decomposition()

--- a/comfyui_spectrum_h3/er_sde_ksampler_contract.py
+++ b/comfyui_spectrum_h3/er_sde_ksampler_contract.py
@@ -1,0 +1,727 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import sys
+import textwrap
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .er_sde_stochastic import function_node_ast_digest
+
+
+@dataclass(frozen=True, slots=True)
+class KSamplerSampleProvenance:
+    observed_digest: str | None
+    expected_reference_digest: str
+    module: str | None
+    qualname: str | None
+    source_file: str | None
+    source_inspected: bool
+    source_error: str | None
+    unwrapped_same: bool
+    unwrapped_module: str | None
+    unwrapped_qualname: str | None
+    unwrapped_source_file: str | None
+    comfyui_version: str | None
+
+    def log_fields(self) -> str:
+        return (
+            f"observed_digest={self.observed_digest or 'unavailable'} "
+            f"expected_reference_digest={self.expected_reference_digest} "
+            f"module={self.module or 'unknown'} "
+            f"qualname={self.qualname or 'unknown'} "
+            f"source_file={self.source_file or 'unknown'} "
+            f"source_inspected={self.source_inspected} "
+            f"source_error={self.source_error or 'none'} "
+            f"unwrapped_same={self.unwrapped_same} "
+            f"unwrapped_module={self.unwrapped_module or 'unknown'} "
+            f"unwrapped_qualname={self.unwrapped_qualname or 'unknown'} "
+            f"unwrapped_source_file={self.unwrapped_source_file or 'unknown'} "
+            f"comfyui_version={self.comfyui_version or 'unknown'}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class KSamplerSampleContract:
+    accepted: bool
+    failure: str | None
+    provenance: KSamplerSampleProvenance
+
+
+def _safe_source_file(function: Any) -> str | None:
+    try:
+        return inspect.getsourcefile(function)
+    except (OSError, TypeError):
+        return None
+
+
+def _loaded_comfyui_version() -> str | None:
+    module = sys.modules.get("comfyui_version")
+    value = getattr(module, "__version__", None) if module is not None else None
+    return str(value) if value is not None else None
+
+
+def _function_source_node(
+    function: Callable[..., Any],
+) -> tuple[ast.FunctionDef | ast.AsyncFunctionDef | None, str | None]:
+    try:
+        source = inspect.getsource(function)
+        module = ast.parse(textwrap.dedent(source))
+    except (OSError, TypeError, SyntaxError) as exc:
+        return None, f"{type(exc).__name__}: {exc}"
+    functions = [
+        node
+        for node in module.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    if len(functions) != 1:
+        return None, f"source contains {len(functions)} top-level functions"
+    return functions[0], None
+
+
+def _provenance(
+    function: Callable[..., Any],
+    expected_reference_digest: str,
+    function_node: ast.FunctionDef | ast.AsyncFunctionDef | None,
+    source_error: str | None,
+) -> KSamplerSampleProvenance:
+    try:
+        unwrapped = inspect.unwrap(function)
+    except (TypeError, ValueError):
+        unwrapped = function
+    return KSamplerSampleProvenance(
+        observed_digest=(
+            function_node_ast_digest(function_node)
+            if function_node is not None
+            else None
+        ),
+        expected_reference_digest=expected_reference_digest,
+        module=getattr(function, "__module__", None),
+        qualname=getattr(function, "__qualname__", None),
+        source_file=_safe_source_file(function),
+        source_inspected=function_node is not None,
+        source_error=source_error,
+        unwrapped_same=unwrapped is function,
+        unwrapped_module=getattr(unwrapped, "__module__", None),
+        unwrapped_qualname=getattr(unwrapped, "__qualname__", None),
+        unwrapped_source_file=_safe_source_file(unwrapped),
+        comfyui_version=_loaded_comfyui_version(),
+    )
+
+
+def _name(node: ast.AST, expected: str) -> bool:
+    return isinstance(node, ast.Name) and node.id == expected
+
+
+def _attribute_path(node: ast.AST) -> tuple[str, ...] | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return tuple(reversed(parts))
+
+
+def _subscript(node: ast.AST, name: str, key: str | int) -> bool:
+    if not isinstance(node, ast.Subscript) or not _name(node.value, name):
+        return False
+    slice_node = node.slice
+    if isinstance(key, int) and key < 0:
+        return (
+            isinstance(slice_node, ast.UnaryOp)
+            and isinstance(slice_node.op, ast.USub)
+            and isinstance(slice_node.operand, ast.Constant)
+            and slice_node.operand.value == -key
+        )
+    return isinstance(slice_node, ast.Constant) and slice_node.value == key
+
+
+def _single_assigned_name(root: ast.AST, value: ast.AST) -> str | None:
+    for node in ast.walk(root):
+        if (
+            isinstance(node, ast.Assign)
+            and node.value is value
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            return node.targets[0].id
+    return None
+
+
+def _direct_assignment(
+    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    value: ast.AST,
+) -> ast.Assign | None:
+    return next(
+        (
+            node
+            for node in function_node.body
+            if isinstance(node, ast.Assign) and node.value is value
+        ),
+        None,
+    )
+
+
+def _resolve_global(function: Callable[..., Any], node: ast.AST) -> Any:
+    if isinstance(node, ast.Name):
+        return function.__globals__.get(node.id)
+    if isinstance(node, ast.Attribute):
+        owner = _resolve_global(function, node.value)
+        return getattr(owner, node.attr, None) if owner is not None else None
+    return None
+
+
+def _assignment_line_to_name(node: ast.AST, name: str) -> bool:
+    return isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == name for target in node.targets
+    )
+
+
+def _contract_failure(
+    failure: str,
+    provenance: KSamplerSampleProvenance,
+) -> KSamplerSampleContract:
+    return KSamplerSampleContract(False, failure, provenance)
+
+
+def validate_ksampler_sample(
+    function: Callable[..., Any],
+    *,
+    expected_adapter: type,
+    expected_reference_digest: str,
+) -> KSamplerSampleContract:
+    """Prove only the native adapter flow required by ER-SDE compensation."""
+    function_node, source_error = _function_source_node(function)
+    provenance = _provenance(
+        function,
+        expected_reference_digest,
+        function_node,
+        source_error,
+    )
+    if not inspect.isfunction(function):
+        return _contract_failure(
+            "KSAMPLER.sample is not a plain function descriptor",
+            provenance,
+        )
+    if function_node is None:
+        return _contract_failure(
+            "source is unavailable, so adapter semantics cannot be proven",
+            provenance,
+        )
+    if isinstance(function_node, ast.AsyncFunctionDef):
+        return _contract_failure("KSAMPLER.sample cannot be asynchronous", provenance)
+    if function_node.decorator_list:
+        return _contract_failure(
+            "KSAMPLER.sample decorators have unproven runtime semantics",
+            provenance,
+        )
+
+    try:
+        signature = inspect.signature(function, follow_wrapped=False)
+    except (TypeError, ValueError) as exc:
+        return _contract_failure(f"signature inspection failed: {exc}", provenance)
+    expected_parameters = (
+        "self",
+        "model_wrap",
+        "sigmas",
+        "extra_args",
+        "callback",
+        "noise",
+        "latent_image",
+        "denoise_mask",
+        "disable_pbar",
+    )
+    parameters = list(signature.parameters.values())
+    if len(parameters) < len(expected_parameters) or any(
+        parameter.name != expected
+        or parameter.kind
+        not in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+        for parameter, expected in zip(parameters, expected_parameters, strict=False)
+    ):
+        return _contract_failure(
+            "signature does not preserve the required positional invocation contract",
+            provenance,
+        )
+
+    sampler_calls = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Call)
+        and _attribute_path(node.func) == ("self", "sampler_function")
+    ]
+    if len(sampler_calls) != 1:
+        return _contract_failure(
+            f"expected exactly one self.sampler_function dispatch, found {len(sampler_calls)}",
+            provenance,
+        )
+    dispatch = sampler_calls[0]
+    dispatch_assignment = _direct_assignment(function_node, dispatch)
+    dispatch_result = (
+        _single_assigned_name(function_node, dispatch)
+        if dispatch_assignment is not None
+        else None
+    )
+    if dispatch_result is None or dispatch_assignment is None:
+        return _contract_failure(
+            "sampler dispatch is not a direct method-body assignment",
+            provenance,
+        )
+
+    adapter_calls = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Call)
+        and _resolve_global(function, node.func) is expected_adapter
+    ]
+    if len(adapter_calls) != 1:
+        return _contract_failure(
+            "expected exactly one native KSamplerX0Inpaint adapter construction",
+            provenance,
+        )
+    adapter_call = adapter_calls[0]
+    adapter_assignment = _direct_assignment(function_node, adapter_call)
+    adapter_name = (
+        _single_assigned_name(function_node, adapter_call)
+        if adapter_assignment is not None
+        else None
+    )
+    if (
+        adapter_name is None
+        or adapter_assignment is None
+        or len(adapter_call.args) != 2
+        or adapter_call.keywords
+        or not _name(adapter_call.args[0], "model_wrap")
+        or not _name(adapter_call.args[1], "sigmas")
+    ):
+        return _contract_failure(
+            "native model adapter is not constructed from model_wrap and sigmas",
+            provenance,
+        )
+
+    noise_scaling_calls = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Call)
+        and _attribute_path(node.func)
+        == ("model_wrap", "inner_model", "model_sampling", "noise_scaling")
+    ]
+    if len(noise_scaling_calls) != 1:
+        return _contract_failure(
+            f"expected one native noise_scaling call, found {len(noise_scaling_calls)}",
+            provenance,
+        )
+    noise_scaling = noise_scaling_calls[0]
+    noise_scaling_assignment = _direct_assignment(function_node, noise_scaling)
+    scaled_noise_name = (
+        _single_assigned_name(function_node, noise_scaling)
+        if noise_scaling_assignment is not None
+        else None
+    )
+    expected_max_denoise = (
+        len(noise_scaling.args) == 4
+        and isinstance(noise_scaling.args[3], ast.Call)
+        and _attribute_path(noise_scaling.args[3].func) == ("self", "max_denoise")
+        and len(noise_scaling.args[3].args) == 2
+        and _name(noise_scaling.args[3].args[0], "model_wrap")
+        and _name(noise_scaling.args[3].args[1], "sigmas")
+        and not noise_scaling.args[3].keywords
+    )
+    if (
+        scaled_noise_name is None
+        or noise_scaling_assignment is None
+        or noise_scaling.keywords
+        or len(noise_scaling.args) != 4
+        or not _subscript(noise_scaling.args[0], "sigmas", 0)
+        or not _name(noise_scaling.args[1], "noise")
+        or not _name(noise_scaling.args[2], "latent_image")
+        or not expected_max_denoise
+    ):
+        return _contract_failure(
+            "initial noise_scaling inputs or max_denoise forwarding changed",
+            provenance,
+        )
+
+    adapter_index = function_node.body.index(adapter_assignment)
+    noise_scaling_index = function_node.body.index(noise_scaling_assignment)
+    dispatch_index = function_node.body.index(dispatch_assignment)
+    if not adapter_index < noise_scaling_index < dispatch_index:
+        return _contract_failure(
+            "native adapter/noise_scaling must occur before sampler dispatch",
+            provenance,
+        )
+
+    denoise_mask_assignments = [
+        node
+        for node in function_node.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _subscript(node.targets[0], "extra_args", "denoise_mask")
+        and _name(node.value, "denoise_mask")
+    ]
+    if (
+        len(denoise_mask_assignments) != 1
+        or function_node.body.index(denoise_mask_assignments[0]) >= dispatch_index
+    ):
+        return _contract_failure(
+            "denoise_mask is not forwarded through extra_args before dispatch",
+            provenance,
+        )
+    extra_args_stores = [
+        target
+        for node in ast.walk(function_node)
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+        for target in (
+            node.targets
+            if isinstance(node, ast.Assign)
+            else [node.target]
+        )
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "extra_args"
+        )
+        or (
+            isinstance(target, ast.Subscript)
+            and _name(target.value, "extra_args")
+            and not _subscript(target, "extra_args", "denoise_mask")
+        )
+    ]
+    if extra_args_stores:
+        return _contract_failure(
+            "extra_args are modified beyond native denoise_mask forwarding",
+            provenance,
+        )
+    extra_args_mutating_calls = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and _name(node.func.value, "extra_args")
+        and node.func.attr != "get"
+    ]
+    if extra_args_mutating_calls:
+        return _contract_failure(
+            "extra_args method calls have unproven mutation semantics",
+            provenance,
+        )
+    sigmas_stores = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, (ast.Name, ast.Subscript))
+        and isinstance(getattr(node, "ctx", None), ast.Store)
+        and (
+            (isinstance(node, ast.Name) and node.id == "sigmas")
+            or (isinstance(node, ast.Subscript) and _name(node.value, "sigmas"))
+        )
+    ]
+    if sigmas_stores:
+        return _contract_failure("sigmas are mutated inside KSAMPLER.sample", provenance)
+    extra_options_stores = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, (ast.Attribute, ast.Subscript))
+        and isinstance(getattr(node, "ctx", None), ast.Store)
+        and any(
+            _attribute_path(item) == ("self", "extra_options")
+            for item in ast.walk(node)
+        )
+    ]
+    if extra_options_stores:
+        return _contract_failure(
+            "self.extra_options are mutated before native dispatch",
+            provenance,
+        )
+
+    latent_assignments = [
+        node
+        for node in function_node.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _attribute_path(node.targets[0]) == (adapter_name, "latent_image")
+        and _name(node.value, "latent_image")
+    ]
+    if len(latent_assignments) != 1 or function_node.body.index(latent_assignments[0]) >= dispatch_index:
+        return _contract_failure(
+            "native adapter latent_image assignment is missing or reordered",
+            provenance,
+        )
+    inpaint_branches = [
+        node
+        for node in function_node.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Call)
+        and _attribute_path(node.test.func) == ("self", "inpaint_options", "get")
+        and len(node.test.args) == 2
+        and isinstance(node.test.args[0], ast.Constant)
+        and node.test.args[0].value == "random"
+        and isinstance(node.test.args[1], ast.Constant)
+        and node.test.args[1].value is False
+    ]
+    proven_inpaint_branches = []
+    for branch in inpaint_branches:
+        normal_noise_assignments = [
+            node
+            for node in ast.walk(ast.Module(body=branch.orelse, type_ignores=[]))
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and _attribute_path(node.targets[0]) == (adapter_name, "noise")
+            and _name(node.value, "noise")
+        ]
+        random_noise_assignments = [
+            node
+            for node in ast.walk(ast.Module(body=branch.body, type_ignores=[]))
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and _attribute_path(node.targets[0]) == (adapter_name, "noise")
+        ]
+        if len(normal_noise_assignments) == 1 and len(random_noise_assignments) == 1:
+            proven_inpaint_branches.append(branch)
+    if len(proven_inpaint_branches) != 1:
+        return _contract_failure(
+            "native model adapter noise ownership is not preserved",
+            provenance,
+        )
+
+    if (
+        len(dispatch.args) != 3
+        or not _name(dispatch.args[0], adapter_name)
+        or not _name(dispatch.args[1], scaled_noise_name)
+        or not _name(dispatch.args[2], "sigmas")
+    ):
+        return _contract_failure(
+            "sampler dispatch does not receive the native adapter, scaled noise, and sigmas",
+            provenance,
+        )
+    keyword_map = {keyword.arg: keyword.value for keyword in dispatch.keywords if keyword.arg}
+    star_keywords = [keyword.value for keyword in dispatch.keywords if keyword.arg is None]
+    if set(keyword_map) != {"extra_args", "callback", "disable"}:
+        return _contract_failure(
+            "sampler dispatch keyword forwarding changed",
+            provenance,
+        )
+    if not _name(keyword_map["extra_args"], "extra_args"):
+        return _contract_failure(
+            "sampler dispatch does not forward extra_args unchanged",
+            provenance,
+        )
+    if not _name(keyword_map["disable"], "disable_pbar"):
+        return _contract_failure(
+            "sampler dispatch does not forward disable_pbar as disable",
+            provenance,
+        )
+    if (
+        len(star_keywords) != 1
+        or _attribute_path(star_keywords[0]) != ("self", "extra_options")
+    ):
+        return _contract_failure(
+            "self.extra_options are not forwarded unchanged",
+            provenance,
+        )
+
+    callback_name_node = keyword_map["callback"]
+    if not isinstance(callback_name_node, ast.Name):
+        return _contract_failure(
+            "sampler callback is not the local KSAMPLER callback adapter",
+            provenance,
+        )
+    callbacks = [
+        node
+        for node in function_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node is not function_node
+        and node.name == callback_name_node.id
+    ]
+    if len(callbacks) != 1:
+        return _contract_failure(
+            "local KSAMPLER callback adapter cannot be identified uniquely",
+            provenance,
+        )
+    callback_function = callbacks[0]
+    callback_parameters = [
+        *callback_function.args.posonlyargs,
+        *callback_function.args.args,
+    ]
+    if len(callback_parameters) != 1:
+        return _contract_failure(
+            "local KSAMPLER callback adapter signature changed",
+            provenance,
+        )
+    callback_state = callback_parameters[0].arg
+    total_step_assignments = [
+        node
+        for node in function_node.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and isinstance(node.value, ast.BinOp)
+        and isinstance(node.value.op, ast.Sub)
+        and isinstance(node.value.left, ast.Call)
+        and _name(node.value.left.func, "len")
+        and len(node.value.left.args) == 1
+        and _name(node.value.left.args[0], "sigmas")
+        and isinstance(node.value.right, ast.Constant)
+        and node.value.right.value == 1
+    ]
+    total_steps_names = {node.targets[0].id for node in total_step_assignments}
+    if not total_steps_names:
+        return _contract_failure("native total_steps calculation changed", provenance)
+    all_forwarded_callbacks = [
+        node
+        for node in ast.walk(callback_function)
+        if isinstance(node, ast.Call) and _name(node.func, "callback")
+    ]
+    callback_guards = [
+        node
+        for node in callback_function.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and _name(node.test.left, "callback")
+        and len(node.test.ops) == 1
+        and isinstance(node.test.ops[0], ast.IsNot)
+        and len(node.test.comparators) == 1
+        and isinstance(node.test.comparators[0], ast.Constant)
+        and node.test.comparators[0].value is None
+        and any(call in set(ast.walk(node)) for call in all_forwarded_callbacks)
+    ]
+    if len(callback_guards) != 1:
+        return _contract_failure(
+            "external callback forwarding guard changed",
+            provenance,
+        )
+    forwarded_callbacks = [
+        node
+        for node in ast.walk(callback_guards[0])
+        if isinstance(node, ast.Call) and _name(node.func, "callback")
+    ]
+    if len(forwarded_callbacks) != 1 or len(all_forwarded_callbacks) != 1:
+        return _contract_failure(
+            "expected one guarded external callback forwarding call",
+            provenance,
+        )
+    forwarded_callback = forwarded_callbacks[0]
+    expected_callback_keys = ("i", "denoised", "x")
+    forwarded_total_steps = (
+        forwarded_callback.args[3]
+        if len(forwarded_callback.args) == 4
+        else None
+    )
+    if (
+        len(forwarded_callback.args) != 4
+        or forwarded_callback.keywords
+        or any(
+            not _subscript(argument, callback_state, key)
+            for argument, key in zip(
+                forwarded_callback.args[:3], expected_callback_keys, strict=True
+            )
+        )
+        or not isinstance(forwarded_total_steps, ast.Name)
+        or forwarded_total_steps.id not in total_steps_names
+    ):
+        return _contract_failure(
+            "callback does not forward native i/denoised/x/total_steps values",
+            provenance,
+        )
+    callback_state_stores = [
+        node
+        for node in ast.walk(callback_function)
+        if isinstance(node, (ast.Name, ast.Attribute, ast.Subscript))
+        and isinstance(getattr(node, "ctx", None), ast.Store)
+        and (
+            (isinstance(node, ast.Name) and node.id == callback_state)
+            or (
+                isinstance(node, (ast.Attribute, ast.Subscript))
+                and any(_name(item, callback_state) for item in ast.walk(node))
+            )
+        )
+    ]
+    if callback_state_stores:
+        return _contract_failure(
+            "local callback mutates the native ER-SDE callback state",
+            provenance,
+        )
+
+    inverse_calls = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Call)
+        and _attribute_path(node.func)
+        == (
+            "model_wrap",
+            "inner_model",
+            "model_sampling",
+            "inverse_noise_scaling",
+        )
+    ]
+    if len(inverse_calls) != 1:
+        return _contract_failure(
+            f"expected one final inverse_noise_scaling call, found {len(inverse_calls)}",
+            provenance,
+        )
+    inverse = inverse_calls[0]
+    inverse_assignment = _direct_assignment(function_node, inverse)
+    final_result = (
+        _single_assigned_name(function_node, inverse)
+        if inverse_assignment is not None
+        else None
+    )
+    if (
+        final_result is None
+        or inverse_assignment is None
+        or inverse.keywords
+        or len(inverse.args) != 2
+        or not _subscript(inverse.args[0], "sigmas", -1)
+        or not _name(inverse.args[1], dispatch_result)
+        or function_node.body.index(inverse_assignment) <= dispatch_index
+    ):
+        return _contract_failure(
+            "final inverse_noise_scaling inputs or ordering changed",
+            provenance,
+        )
+    returns = [node for node in function_node.body if isinstance(node, ast.Return)]
+    if (
+        len(returns) != 1
+        or not _name(returns[0].value, final_result)
+        or function_node.body.index(returns[0])
+        <= function_node.body.index(inverse_assignment)
+    ):
+        return _contract_failure(
+            "KSAMPLER.sample does not return the final inverse-scaled result",
+            provenance,
+        )
+
+    scaled_noise_reassignments = [
+        node
+        for node in ast.walk(function_node)
+        if _assignment_line_to_name(node, scaled_noise_name)
+        and noise_scaling.lineno < node.lineno < dispatch.lineno
+    ]
+    result_reassignments = [
+        node
+        for node in ast.walk(function_node)
+        if _assignment_line_to_name(node, dispatch_result)
+        and dispatch.lineno < node.lineno < inverse.lineno
+    ]
+    adapter_reassignments = [
+        node
+        for node in ast.walk(function_node)
+        if _assignment_line_to_name(node, adapter_name)
+        and adapter_call.lineno < node.lineno < dispatch.lineno
+    ]
+    if scaled_noise_reassignments or result_reassignments or adapter_reassignments:
+        return _contract_failure(
+            "adapter, scaled noise, or sampler result is reassigned before its required consumer",
+            provenance,
+        )
+
+    return KSamplerSampleContract(True, None, provenance)
+
+
+__all__ = [
+    "KSamplerSampleContract",
+    "KSamplerSampleProvenance",
+    "validate_ksampler_sample",
+]

--- a/comfyui_spectrum_h3/er_sde_ksampler_contract.py
+++ b/comfyui_spectrum_h3/er_sde_ksampler_contract.py
@@ -127,6 +127,13 @@ def _attribute_path(node: ast.AST) -> tuple[str, ...] | None:
     return tuple(reversed(parts))
 
 
+def _root_name(node: ast.AST) -> str | None:
+    current = node
+    while isinstance(current, (ast.Attribute, ast.Subscript)):
+        current = current.value
+    return current.id if isinstance(current, ast.Name) else None
+
+
 def _subscript(node: ast.AST, name: str, key: str | int) -> bool:
     if not isinstance(node, ast.Subscript) or not _name(node.value, name):
         return False
@@ -189,11 +196,235 @@ def _contract_failure(
     return KSamplerSampleContract(False, failure, provenance)
 
 
+def _contains_loaded_name(node: ast.AST, names: set[str]) -> bool:
+    return any(
+        isinstance(item, ast.Name)
+        and isinstance(item.ctx, ast.Load)
+        and item.id in names
+        for item in ast.walk(node)
+    )
+
+
+def _resolve_variadic_passthrough_target(
+    function: Callable[..., Any],
+    function_node: ast.FunctionDef,
+) -> tuple[Callable[..., Any] | None, str | None, bool]:
+    """Resolve the audited TiledDiffusion-style *args/**kwargs KSAMPLER shim."""
+    try:
+        signature = inspect.signature(function, follow_wrapped=False)
+    except (TypeError, ValueError) as exc:
+        return None, f"signature inspection failed: {exc}", False
+    parameters = list(signature.parameters.values())
+    if not (
+        len(parameters) == 2
+        and parameters[0].kind is parameters[0].VAR_POSITIONAL
+        and parameters[1].kind is parameters[1].VAR_KEYWORD
+    ):
+        return None, None, False
+
+    vararg_name = parameters[0].name
+    varkw_name = parameters[1].name
+    if function_node.name != "KSAMPLER_sample":
+        return None, "variadic KSAMPLER.sample wrapper is not a reviewed passthrough form", True
+    if any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
+        and node is not function_node
+        for node in ast.walk(function_node)
+    ):
+        return None, "variadic KSAMPLER.sample wrapper defines nested callables", True
+
+    returns = [node for node in function_node.body if isinstance(node, ast.Return)]
+    if len(returns) != 1 or not isinstance(returns[0].value, ast.Call):
+        return None, "variadic KSAMPLER.sample wrapper must have one direct passthrough return", True
+    delegate_call = returns[0].value
+    if not isinstance(delegate_call.func, ast.Name):
+        return None, "variadic KSAMPLER.sample wrapper delegate is not a local alias", True
+    alias_name = delegate_call.func.id
+    if not (
+        len(delegate_call.args) == 1
+        and isinstance(delegate_call.args[0], ast.Starred)
+        and _name(delegate_call.args[0].value, vararg_name)
+        and len(delegate_call.keywords) == 1
+        and delegate_call.keywords[0].arg is None
+        and _name(delegate_call.keywords[0].value, varkw_name)
+    ):
+        return None, "variadic KSAMPLER.sample wrapper does not forward *args/**kwargs unchanged", True
+
+    alias_assignments = [
+        node
+        for node in function_node.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _name(node.targets[0], alias_name)
+    ]
+    if (
+        len(alias_assignments) != 1
+        or not isinstance(alias_assignments[0].value, ast.Attribute)
+        or alias_assignments[0].value.attr != "KSAMPLER_sample"
+    ):
+        return None, "variadic KSAMPLER.sample wrapper original-method ownership is unproven", True
+    alias_assignment = alias_assignments[0]
+    state_root = _root_name(alias_assignment.value)
+    if state_root is None:
+        return None, "variadic KSAMPLER.sample wrapper state owner cannot be identified", True
+    target = _resolve_global(function, alias_assignment.value)
+    if not inspect.isfunction(target):
+        return None, "variadic KSAMPLER.sample wrapper target is not a plain function", True
+    if target is function:
+        return None, "variadic KSAMPLER.sample wrapper delegates to itself", True
+
+    alias_stores = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Name)
+        and isinstance(node.ctx, ast.Store)
+        and node.id == alias_name
+    ]
+    if len(alias_stores) != 1:
+        return None, "variadic KSAMPLER.sample wrapper delegate alias is reassigned", True
+
+    input_names = {vararg_name, varkw_name}
+    for node in ast.walk(function_node):
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Store)
+            and node.id in input_names
+        ):
+            return None, "variadic KSAMPLER.sample wrapper reassigns its argument containers", True
+        if (
+            isinstance(node, (ast.Attribute, ast.Subscript))
+            and isinstance(getattr(node, "ctx", None), ast.Store)
+            and _root_name(node) in input_names
+        ):
+            return None, "variadic KSAMPLER.sample wrapper mutates its argument containers", True
+
+    extra_args_reads = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _name(node.targets[0], "extra_args")
+        and isinstance(node.value, ast.IfExp)
+        and isinstance(node.value.test, ast.Compare)
+        and isinstance(node.value.test.left, ast.Constant)
+        and node.value.test.left.value == "extra_args"
+        and len(node.value.test.ops) == 1
+        and isinstance(node.value.test.ops[0], ast.In)
+        and len(node.value.test.comparators) == 1
+        and _name(node.value.test.comparators[0], varkw_name)
+        and _subscript(node.value.body, varkw_name, "extra_args")
+        and _subscript(node.value.orelse, vararg_name, 3)
+    ]
+    model_options_reads = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and _name(node.targets[0], "model_options")
+        and _subscript(node.value, "extra_args", "model_options")
+    ]
+    if len(extra_args_reads) != 1 or len(model_options_reads) != 1:
+        return None, "variadic KSAMPLER.sample wrapper does not recover native extra_args/model_options", True
+
+    pop_calls = [
+        node
+        for node in ast.walk(function_node)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and _name(node.func.value, "model_options")
+        and node.func.attr == "pop"
+    ]
+    if not (
+        len(pop_calls) == 1
+        and len(pop_calls[0].args) == 2
+        and isinstance(pop_calls[0].args[0], ast.Constant)
+        and pop_calls[0].args[0].value == "sigmas"
+        and isinstance(pop_calls[0].args[1], ast.Constant)
+        and pop_calls[0].args[1].value is None
+        and not pop_calls[0].keywords
+    ):
+        return None, "variadic KSAMPLER.sample wrapper model_options mutation is not the reviewed TiledDiffusion sigmas handoff", True
+    pop_call = pop_calls[0]
+    guarded_branches = [
+        node
+        for node in function_node.body
+        if isinstance(node, ast.If)
+        and pop_call in set(ast.walk(ast.Module(body=node.body, type_ignores=[])))
+        and any(
+            isinstance(item, ast.Constant) and item.value == "tiled_diffusion"
+            for item in ast.walk(node.test)
+        )
+        and any(
+            isinstance(item, ast.Name) and item.id == "model_options"
+            for item in ast.walk(node.test)
+        )
+    ]
+    if len(guarded_branches) != 1:
+        return None, "variadic KSAMPLER.sample wrapper sigmas handoff is not guarded by tiled_diffusion model state", True
+
+    tainted_names = {
+        vararg_name,
+        varkw_name,
+        "extra_args",
+        "model_options",
+        "sigmas_",
+        "sigmas_all",
+        "sigmas",
+    }
+    allowed_calls = {delegate_call, pop_call}
+    for call in [node for node in ast.walk(function_node) if isinstance(node, ast.Call)]:
+        if call in allowed_calls:
+            continue
+        if (
+            isinstance(call.func, ast.Name)
+            and call.func.id == "_delattr"
+            and len(call.args) == 2
+            and _name(call.args[0], state_root)
+            and not call.keywords
+        ):
+            continue
+        receiver = call.func.value if isinstance(call.func, ast.Attribute) else None
+        if receiver is not None and _root_name(receiver) in tainted_names:
+            return None, "variadic KSAMPLER.sample wrapper performs an unreviewed call on sampler inputs", True
+        if any(_contains_loaded_name(argument, tainted_names) for argument in call.args) or any(
+            _contains_loaded_name(keyword.value, tainted_names) for keyword in call.keywords
+        ):
+            return None, "variadic KSAMPLER.sample wrapper exposes sampler inputs to an unreviewed call", True
+
+    for node in ast.walk(function_node):
+        if (
+            isinstance(node, (ast.Attribute, ast.Subscript))
+            and isinstance(getattr(node, "ctx", None), ast.Store)
+            and _root_name(node) != state_root
+        ):
+            return None, "variadic KSAMPLER.sample wrapper mutates state outside its reviewed bookkeeping owner", True
+
+    expansions = [
+        node
+        for node in ast.walk(function_node)
+        if (
+            isinstance(node, ast.Starred)
+            and _name(node.value, vararg_name)
+        )
+        or (
+            isinstance(node, ast.keyword)
+            and node.arg is None
+            and _name(node.value, varkw_name)
+        )
+    ]
+    expected_expansions = {delegate_call.args[0], delegate_call.keywords[0]}
+    if set(expansions) != expected_expansions:
+        return None, "variadic KSAMPLER.sample wrapper forwards argument containers more than once", True
+
+    return target, None, True
+
+
 def validate_ksampler_sample(
     function: Callable[..., Any],
     *,
     expected_adapter: type,
     expected_reference_digest: str,
+    _visited: frozenset[int] | None = None,
 ) -> KSamplerSampleContract:
     """Prove only the native adapter flow required by ER-SDE compensation."""
     function_node, source_error = _function_source_node(function)
@@ -208,6 +439,12 @@ def validate_ksampler_sample(
             "KSAMPLER.sample is not a plain function descriptor",
             provenance,
         )
+    visited = set(_visited or ())
+    if id(function) in visited:
+        return _contract_failure("KSAMPLER.sample wrapper chain contains a cycle", provenance)
+    if len(visited) >= 4:
+        return _contract_failure("KSAMPLER.sample wrapper chain exceeds reviewed depth", provenance)
+    visited.add(id(function))
     if function_node is None:
         return _contract_failure(
             "source is unavailable, so adapter semantics cannot be proven",
@@ -220,6 +457,28 @@ def validate_ksampler_sample(
             "KSAMPLER.sample decorators have unproven runtime semantics",
             provenance,
         )
+
+    passthrough_target, passthrough_failure, variadic_wrapper = (
+        _resolve_variadic_passthrough_target(function, function_node)
+    )
+    if variadic_wrapper:
+        if passthrough_failure is not None or passthrough_target is None:
+            return _contract_failure(
+                passthrough_failure or "variadic KSAMPLER.sample wrapper target is unavailable",
+                provenance,
+            )
+        wrapped_contract = validate_ksampler_sample(
+            passthrough_target,
+            expected_adapter=expected_adapter,
+            expected_reference_digest=expected_reference_digest,
+            _visited=frozenset(visited),
+        )
+        if not wrapped_contract.accepted:
+            return _contract_failure(
+                f"variadic KSAMPLER.sample wrapper target rejected: {wrapped_contract.failure}",
+                provenance,
+            )
+        return KSamplerSampleContract(True, None, provenance)
 
     try:
         signature = inspect.signature(function, follow_wrapped=False)

--- a/comfyui_spectrum_h3/er_sde_stochastic.py
+++ b/comfyui_spectrum_h3/er_sde_stochastic.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
 import inspect
 import logging
 import math
 import textwrap
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 import torch
 
@@ -33,10 +35,26 @@ class _PendingIncrement:
     value: torch.Tensor
 
 
-def function_ast_digest(function: Callable[..., Any]) -> str | None:
+def function_node_ast_digest(
+    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str:
+    """Return the normalized digest shared by runtime and source-contract tests."""
+    normalized = copy.deepcopy(function_node)
+    normalized.decorator_list = []
+    return hashlib.sha256(
+        ast.dump(normalized, include_attributes=False).encode("utf-8")
+    ).hexdigest()
+
+
+def function_ast_digest(
+    function: Callable[..., Any],
+    *,
+    unwrap: bool = True,
+) -> str | None:
     """Return a stable semantic-source digest, or None when source is unavailable."""
     try:
-        source = inspect.getsource(inspect.unwrap(function))
+        inspected = inspect.unwrap(function) if unwrap else function
+        source = inspect.getsource(inspected)
         module = ast.parse(textwrap.dedent(source))
     except (OSError, TypeError, SyntaxError):
         return None
@@ -44,10 +62,7 @@ def function_ast_digest(function: Callable[..., Any]) -> str | None:
         module.body[0], (ast.FunctionDef, ast.AsyncFunctionDef)
     ):
         return None
-    function_node = module.body[0]
-    function_node.decorator_list = []
-    normalized = ast.dump(function_node, include_attributes=False)
-    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return function_node_ast_digest(module.body[0])
 
 
 def native_default_er_sde_noise_scaler(value: torch.Tensor) -> torch.Tensor:
@@ -245,5 +260,6 @@ __all__ = [
     "ERSDEStochasticTracker",
     "ERSDETrackingError",
     "function_ast_digest",
+    "function_node_ast_digest",
     "native_default_er_sde_noise_scaler",
 ]

--- a/comfyui_spectrum_h3/er_sde_stochastic.py
+++ b/comfyui_spectrum_h3/er_sde_stochastic.py
@@ -20,7 +20,7 @@ class ERSDETrackingError(RuntimeError):
     """The reviewed ER-SDE stochastic-state contract could not be maintained."""
 
 
-class ERSDEDenseOutputError(RuntimeError):
+class ERSDEDenseOutputError(ERSDETrackingError):
     """The causal ER-SDE solver-space dense-output contract could not be maintained."""
 
 
@@ -50,7 +50,7 @@ class ERSDEDenseOutputPrediction:
     value: torch.Tensor
     mode: str
     anchor_steps: tuple[int, ...]
-    alpha: float
+    alpha: float | torch.Tensor
 
 
 def function_node_ast_digest(
@@ -113,7 +113,7 @@ class ERSDEStochasticTracker:
         self._scaler_calls = 0
         self._noise_calls = 0
         self._pending: _PendingIncrement | None = None
-        self._solver_coordinates: dict[int, float] = {}
+        self._solver_coordinates: dict[int, torch.Tensor] = {}
         self._denoised_anchors: list[_DenoisedAnchor] = []
 
     @property
@@ -144,29 +144,26 @@ class ERSDEStochasticTracker:
         return result
 
     @staticmethod
-    def _scalar_coordinate(value: torch.Tensor, *, label: str) -> float:
+    def _coordinate_tensor(value: torch.Tensor, *, label: str) -> torch.Tensor:
         if not torch.is_tensor(value) or value.numel() != 1:
             raise ERSDETrackingError(f"ER-SDE {label} is not a scalar tensor")
-        coordinate = float(value.detach().item())
-        if not math.isfinite(coordinate) or coordinate <= 0.0:
-            raise ERSDETrackingError(
-                f"ER-SDE {label} must be a positive finite solver coordinate"
-            )
-        return coordinate
+        return value.detach().clone()
 
-    def _record_solver_coordinate(self, step_id: int, coordinate: float) -> None:
+    def _record_solver_coordinate(
+        self,
+        step_id: int,
+        coordinate: torch.Tensor,
+    ) -> None:
         existing = self._solver_coordinates.get(int(step_id))
-        if existing is not None and not math.isclose(
-            existing,
-            coordinate,
-            rel_tol=1e-6,
-            abs_tol=1e-9,
+        if existing is None:
+            self._solver_coordinates[int(step_id)] = coordinate
+            return
+        if self.debug and not bool(
+            torch.isclose(existing, coordinate, rtol=1e-6, atol=1e-9).item()
         ):
             raise ERSDETrackingError(
-                "ER-SDE solver coordinate changed for step "
-                f"{step_id}: {existing:.9g} != {coordinate:.9g}"
+                f"ER-SDE solver coordinate changed for step {step_id}"
             )
-        self._solver_coordinates[int(step_id)] = float(coordinate)
 
     def noise_sampler(
         self,
@@ -193,11 +190,11 @@ class ERSDEStochasticTracker:
         target_step_id = source_step_id + 1
         self._record_solver_coordinate(
             source_step_id,
-            self._scalar_coordinate(er_lambda_s, label="er_lambda_s"),
+            self._coordinate_tensor(er_lambda_s, label="er_lambda_s"),
         )
         self._record_solver_coordinate(
             target_step_id,
-            self._scalar_coordinate(er_lambda_t, label="er_lambda_t"),
+            self._coordinate_tensor(er_lambda_t, label="er_lambda_t"),
         )
 
         r = scaled_t / scaled_s
@@ -455,38 +452,34 @@ class ERSDEStochasticTracker:
             )
         denominator = latest_coordinate - previous_coordinate
         advance = target_coordinate - latest_coordinate
-        scale = max(abs(previous_coordinate), abs(latest_coordinate), 1.0)
-        # A constant extension is the bounded first-order fallback whenever the
-        # two-anchor lambda extrapolation is not trustworthy. It stays inside the
-        # exact actual-denoised manifold and cannot reintroduce x-sigma*v noise.
-        if abs(denominator) <= 1e-12 * scale or denominator * advance < 0.0:
-            predicted = latest.value.clone(memory_format=torch.contiguous_format)
-            return ERSDEDenseOutputPrediction(
-                value=predicted,
-                mode="latest_actual_hold_coordinate_guard",
-                anchor_steps=(latest.step_id,),
-                alpha=0.0,
-            )
         alpha = advance / denominator
-        # The target is one solver step ahead. Do not extrapolate farther in lambda
-        # than the complete interval represented by the two exact actual anchors.
-        if alpha < -1e-6 or alpha > 1.0 + 1e-6:
-            predicted = latest.value.clone(memory_format=torch.contiguous_format)
-            return ERSDEDenseOutputPrediction(
-                value=predicted,
-                mode="latest_actual_hold_extrapolation_guard",
-                anchor_steps=(latest.step_id,),
-                alpha=0.0,
-            )
-        alpha = float(max(0.0, min(1.0, alpha)))
-        predicted = torch.lerp(latest.value, previous.value, -alpha)
-        if not bool(torch.isfinite(predicted).all().item()):
-            raise ERSDEDenseOutputError("ER-SDE dense-output prediction is nonfinite")
+        scale = torch.maximum(
+            torch.maximum(previous_coordinate.abs(), latest_coordinate.abs()),
+            torch.ones_like(latest_coordinate),
+        )
+        # Build the trust guard entirely on-device. Invalid or overlong
+        # extrapolation becomes weight zero, i.e. a latest-actual hold, without a
+        # CUDA synchronization in the non-debug hot path.
+        valid = (
+            torch.isfinite(alpha)
+            & torch.isfinite(denominator)
+            & (denominator.abs() > 1e-12 * scale)
+            & (denominator * advance >= 0.0)
+            & (alpha >= -1e-6)
+            & (alpha <= 1.0 + 1e-6)
+        )
+        bounded_alpha = alpha.clamp(0.0, 1.0)
+        weight = torch.where(valid, bounded_alpha, torch.zeros_like(bounded_alpha))
+        weight = weight.to(device=latest.value.device, dtype=latest.value.dtype)
+        predicted = torch.lerp(latest.value, previous.value, -weight)
+        mode = "lambda_bounded_extrapolation"
+        if self.debug and not bool(valid.item()):
+            mode = "latest_actual_hold_extrapolation_guard"
         return ERSDEDenseOutputPrediction(
             value=predicted,
-            mode="lambda_linear_extrapolation",
+            mode=mode,
             anchor_steps=(previous.step_id, latest.step_id),
-            alpha=alpha,
+            alpha=weight,
         )
 
     def clear(self) -> None:
@@ -547,6 +540,11 @@ class ERSDEStochasticTracker:
         raw_rms = self._rms(raw_denoised)
         dense_rms = self._rms(dense)
         q_rms = self._rms(increment)
+        alpha = (
+            float(prediction.alpha.detach().item())
+            if torch.is_tensor(prediction.alpha)
+            else float(prediction.alpha)
+        )
         LOG.warning(
             "Spectrum H3 ER-SDE dense output step=%s mode=%s anchor_steps=%s "
             "alpha=%.8f q_pending=true q_rms=%.8f raw_denoised_rms=%.8f "
@@ -555,7 +553,7 @@ class ERSDEStochasticTracker:
             descriptor.step_id,
             prediction.mode,
             prediction.anchor_steps,
-            prediction.alpha,
+            alpha,
             q_rms,
             raw_rms,
             dense_rms,

--- a/comfyui_spectrum_h3/er_sde_stochastic.py
+++ b/comfyui_spectrum_h3/er_sde_stochastic.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import logging
+import math
+import textwrap
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+
+LOG = logging.getLogger(__name__)
+
+
+class ERSDETrackingError(RuntimeError):
+    """The reviewed ER-SDE stochastic-state contract could not be maintained."""
+
+
+@dataclass(frozen=True, slots=True)
+class ERSDEStepDescriptor:
+    run_id: int
+    step_id: int
+    mode: str
+    replay_source_actual: bool | None
+    requires_compensation: bool
+
+
+@dataclass(slots=True)
+class _PendingIncrement:
+    target_step_id: int
+    value: torch.Tensor
+
+
+def function_ast_digest(function: Callable[..., Any]) -> str | None:
+    """Return a stable semantic-source digest, or None when source is unavailable."""
+    try:
+        source = inspect.getsource(inspect.unwrap(function))
+        module = ast.parse(textwrap.dedent(source))
+    except (OSError, TypeError, SyntaxError):
+        return None
+    if len(module.body) != 1 or not isinstance(
+        module.body[0], (ast.FunctionDef, ast.AsyncFunctionDef)
+    ):
+        return None
+    function_node = module.body[0]
+    function_node.decorator_list = []
+    normalized = ast.dump(function_node, include_attributes=False)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def native_default_er_sde_noise_scaler(value: torch.Tensor) -> torch.Tensor:
+    """Reviewed native sample_er_sde default, kept byte-for-byte mathematically equal."""
+    return value * ((value ** 0.3).exp() + 10.0)
+
+
+class ERSDEStochasticTracker:
+    """Own exactly one ER-SDE increment until the following model result consumes it."""
+
+    def __init__(
+        self,
+        *,
+        noise_sampler: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+        noise_scaler: Callable[[torch.Tensor], torch.Tensor],
+        effective_s_noise: float,
+        max_stage: int,
+        debug: bool,
+        run_id: int,
+    ) -> None:
+        if not math.isfinite(float(effective_s_noise)) or effective_s_noise <= 0.0:
+            raise ValueError("ER-SDE stochastic tracking requires positive finite s_noise")
+        self._base_noise_sampler = noise_sampler
+        self._base_noise_scaler = noise_scaler
+        self.effective_s_noise = float(effective_s_noise)
+        self.max_stage = int(max_stage)
+        self.debug = bool(debug)
+        self.run_id = int(run_id)
+        self._scaler_prefix: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self._scaler_calls = 0
+        self._noise_calls = 0
+        self._pending: _PendingIncrement | None = None
+
+    @property
+    def has_pending(self) -> bool:
+        return self._pending is not None
+
+    @property
+    def pending_step_id(self) -> int | None:
+        return None if self._pending is None else self._pending.target_step_id
+
+    @property
+    def noise_calls(self) -> int:
+        return self._noise_calls
+
+    def noise_scaler(self, value: torch.Tensor) -> torch.Tensor:
+        result = self._base_noise_scaler(value)
+        if self._scaler_calls < 2:
+            if not torch.is_tensor(value) or not torch.is_tensor(result):
+                raise ERSDETrackingError(
+                    "reviewed ER-SDE noise_scaler did not preserve tensor semantics"
+                )
+            self._scaler_prefix.append((value, result))
+        self._scaler_calls += 1
+        return result
+
+    def noise_sampler(
+        self,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+    ) -> torch.Tensor:
+        noise = self._base_noise_sampler(sigma, sigma_next)
+        if not torch.is_tensor(noise):
+            raise ERSDETrackingError("ER-SDE noise_sampler did not return a tensor")
+        if self._pending is not None:
+            raise ERSDETrackingError(
+                "ER-SDE produced a second stochastic increment before the first was consumed"
+            )
+        if len(self._scaler_prefix) != 2:
+            raise ERSDETrackingError(
+                "ER-SDE noise_scaler call ordering no longer matches the reviewed solver"
+            )
+
+        # Native sample_er_sde evaluates r's numerator first:
+        # noise_scaler(er_lambda_t) / noise_scaler(er_lambda_s).
+        er_lambda_t, scaled_t = self._scaler_prefix[0]
+        er_lambda_s, scaled_s = self._scaler_prefix[1]
+        r = scaled_t / scaled_s
+        alpha_t = sigma_next / er_lambda_t
+        stochastic_scale = (
+            er_lambda_t ** 2 - er_lambda_s ** 2 * r ** 2
+        ).sqrt().nan_to_num(nan=0.0)
+
+        # Collapse scalar terms before the only latent-sized multiply. The retained
+        # tensor owns only the packed increment needed by the following model call.
+        coefficient = alpha_t * self.effective_s_noise * stochastic_scale
+        increment = noise * coefficient
+        if increment.shape != noise.shape:
+            raise ERSDETrackingError(
+                "ER-SDE stochastic increment shape changed through scalar scaling"
+            )
+        self._noise_calls += 1
+        self._pending = _PendingIncrement(self._noise_calls, increment)
+        self._scaler_prefix.clear()
+        self._scaler_calls = 0
+        return noise
+
+    def consume(
+        self,
+        denoised: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+    ) -> torch.Tensor:
+        if not torch.is_tensor(denoised):
+            raise ERSDETrackingError("ER-SDE model result is not a packed tensor")
+        if descriptor.run_id != self.run_id:
+            self.clear()
+            raise ERSDETrackingError(
+                f"stale ER-SDE tracker belongs to run {self.run_id}, current run is "
+                f"{descriptor.run_id}"
+            )
+        pending = self._pending
+        if pending is None:
+            if descriptor.step_id == 0:
+                self._debug_log(denoised, descriptor, None, False, "first_step")
+                return denoised
+            if descriptor.requires_compensation:
+                raise ERSDETrackingError(
+                    f"forecast step {descriptor.step_id} has no preceding ER-SDE increment"
+                )
+            self._debug_log(denoised, descriptor, None, False, "no_pending_increment")
+            return denoised
+
+        # Transfer ownership immediately. Every exit below leaves no stale tensor.
+        self._pending = None
+        if pending.target_step_id != descriptor.step_id:
+            raise ERSDETrackingError(
+                "stale ER-SDE increment targets step "
+                f"{pending.target_step_id}, current step is {descriptor.step_id}"
+            )
+        increment = pending.value
+        if (
+            increment.shape != denoised.shape
+            or increment.device != denoised.device
+            or increment.dtype != denoised.dtype
+        ):
+            raise ERSDETrackingError(
+                "ER-SDE increment does not exactly match the packed denoised tensor "
+                f"(q={tuple(increment.shape)}/{increment.dtype}/{increment.device}, "
+                f"denoised={tuple(denoised.shape)}/{denoised.dtype}/{denoised.device})"
+            )
+        if not descriptor.requires_compensation:
+            self._debug_log(denoised, descriptor, increment, False, "state_aware_step")
+            return denoised
+
+        corrected = denoised - increment
+        self._debug_log(corrected, descriptor, increment, True, "forecast_state_mismatch")
+        return corrected
+
+    def clear(self) -> None:
+        self._pending = None
+        self._scaler_prefix.clear()
+        self._scaler_calls = 0
+
+    @staticmethod
+    def _rms(value: torch.Tensor) -> float:
+        if value.numel() == 0:
+            return 0.0
+        norm = torch.linalg.vector_norm(value.detach(), dtype=torch.float32)
+        return float((norm / math.sqrt(value.numel())).item())
+
+    def _debug_log(
+        self,
+        denoised: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+        increment: torch.Tensor | None,
+        applied: bool,
+        reason: str,
+    ) -> None:
+        if not self.debug:
+            return
+        denoised_rms = self._rms(denoised)
+        q_rms = 0.0 if increment is None else self._rms(increment)
+        ratio = q_rms / denoised_rms if denoised_rms > 0.0 else float("inf")
+        LOG.warning(
+            "Spectrum H3 ER-SDE compensation step=%s step_type=%s "
+            "replay_source_actual=%s q_pending=%s q_rms=%.8f denoised_rms=%.8f "
+            "correction_rms=%.8f correction_ratio=%.8f applied=%s reason=%s "
+            "max_stage=%s stochastic=true",
+            descriptor.step_id,
+            descriptor.mode,
+            descriptor.replay_source_actual,
+            increment is not None,
+            q_rms,
+            denoised_rms,
+            q_rms if applied else 0.0,
+            ratio if applied else 0.0,
+            applied,
+            reason,
+            self.max_stage,
+        )
+
+
+__all__ = [
+    "ERSDEStepDescriptor",
+    "ERSDEStochasticTracker",
+    "ERSDETrackingError",
+    "function_ast_digest",
+    "native_default_er_sde_noise_scaler",
+]

--- a/comfyui_spectrum_h3/er_sde_stochastic.py
+++ b/comfyui_spectrum_h3/er_sde_stochastic.py
@@ -20,6 +20,10 @@ class ERSDETrackingError(RuntimeError):
     """The reviewed ER-SDE stochastic-state contract could not be maintained."""
 
 
+class ERSDEDenseOutputError(RuntimeError):
+    """The causal ER-SDE solver-space dense-output contract could not be maintained."""
+
+
 @dataclass(frozen=True, slots=True)
 class ERSDEStepDescriptor:
     run_id: int
@@ -33,6 +37,20 @@ class ERSDEStepDescriptor:
 class _PendingIncrement:
     target_step_id: int
     value: torch.Tensor
+
+
+@dataclass(slots=True)
+class _DenoisedAnchor:
+    step_id: int
+    value: torch.Tensor
+
+
+@dataclass(frozen=True, slots=True)
+class ERSDEDenseOutputPrediction:
+    value: torch.Tensor
+    mode: str
+    anchor_steps: tuple[int, ...]
+    alpha: float
 
 
 def function_node_ast_digest(
@@ -71,7 +89,7 @@ def native_default_er_sde_noise_scaler(value: torch.Tensor) -> torch.Tensor:
 
 
 class ERSDEStochasticTracker:
-    """Own exactly one ER-SDE increment until the following model result consumes it."""
+    """Track native ER-SDE stochastic increments and bounded solver-space anchors."""
 
     def __init__(
         self,
@@ -95,6 +113,8 @@ class ERSDEStochasticTracker:
         self._scaler_calls = 0
         self._noise_calls = 0
         self._pending: _PendingIncrement | None = None
+        self._solver_coordinates: dict[int, float] = {}
+        self._denoised_anchors: list[_DenoisedAnchor] = []
 
     @property
     def has_pending(self) -> bool:
@@ -108,6 +128,10 @@ class ERSDEStochasticTracker:
     def noise_calls(self) -> int:
         return self._noise_calls
 
+    @property
+    def denoised_anchor_steps(self) -> tuple[int, ...]:
+        return tuple(anchor.step_id for anchor in self._denoised_anchors)
+
     def noise_scaler(self, value: torch.Tensor) -> torch.Tensor:
         result = self._base_noise_scaler(value)
         if self._scaler_calls < 2:
@@ -118,6 +142,31 @@ class ERSDEStochasticTracker:
             self._scaler_prefix.append((value, result))
         self._scaler_calls += 1
         return result
+
+    @staticmethod
+    def _scalar_coordinate(value: torch.Tensor, *, label: str) -> float:
+        if not torch.is_tensor(value) or value.numel() != 1:
+            raise ERSDETrackingError(f"ER-SDE {label} is not a scalar tensor")
+        coordinate = float(value.detach().item())
+        if not math.isfinite(coordinate) or coordinate <= 0.0:
+            raise ERSDETrackingError(
+                f"ER-SDE {label} must be a positive finite solver coordinate"
+            )
+        return coordinate
+
+    def _record_solver_coordinate(self, step_id: int, coordinate: float) -> None:
+        existing = self._solver_coordinates.get(int(step_id))
+        if existing is not None and not math.isclose(
+            existing,
+            coordinate,
+            rel_tol=1e-6,
+            abs_tol=1e-9,
+        ):
+            raise ERSDETrackingError(
+                "ER-SDE solver coordinate changed for step "
+                f"{step_id}: {existing:.9g} != {coordinate:.9g}"
+            )
+        self._solver_coordinates[int(step_id)] = float(coordinate)
 
     def noise_sampler(
         self,
@@ -140,6 +189,17 @@ class ERSDEStochasticTracker:
         # noise_scaler(er_lambda_t) / noise_scaler(er_lambda_s).
         er_lambda_t, scaled_t = self._scaler_prefix[0]
         er_lambda_s, scaled_s = self._scaler_prefix[1]
+        source_step_id = self._noise_calls
+        target_step_id = source_step_id + 1
+        self._record_solver_coordinate(
+            source_step_id,
+            self._scalar_coordinate(er_lambda_s, label="er_lambda_s"),
+        )
+        self._record_solver_coordinate(
+            target_step_id,
+            self._scalar_coordinate(er_lambda_t, label="er_lambda_t"),
+        )
+
         r = scaled_t / scaled_s
         alpha_t = sigma_next / er_lambda_t
         stochastic_scale = (
@@ -155,35 +215,33 @@ class ERSDEStochasticTracker:
                 "ER-SDE stochastic increment shape changed through scalar scaling"
             )
         self._noise_calls += 1
-        self._pending = _PendingIncrement(self._noise_calls, increment)
+        self._pending = _PendingIncrement(target_step_id, increment)
         self._scaler_prefix.clear()
         self._scaler_calls = 0
         return noise
 
-    def consume(
-        self,
-        denoised: torch.Tensor,
-        descriptor: ERSDEStepDescriptor,
-    ) -> torch.Tensor:
-        if not torch.is_tensor(denoised):
-            raise ERSDETrackingError("ER-SDE model result is not a packed tensor")
+    def _validate_descriptor(self, descriptor: ERSDEStepDescriptor) -> None:
         if descriptor.run_id != self.run_id:
             self.clear()
             raise ERSDETrackingError(
                 f"stale ER-SDE tracker belongs to run {self.run_id}, current run is "
                 f"{descriptor.run_id}"
             )
+
+    def _take_pending(
+        self,
+        denoised: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+    ) -> torch.Tensor | None:
         pending = self._pending
         if pending is None:
             if descriptor.step_id == 0:
-                self._debug_log(denoised, descriptor, None, False, "first_step")
-                return denoised
+                return None
             if descriptor.requires_compensation:
                 raise ERSDETrackingError(
                     f"forecast step {descriptor.step_id} has no preceding ER-SDE increment"
                 )
-            self._debug_log(denoised, descriptor, None, False, "no_pending_increment")
-            return denoised
+            return None
 
         # Transfer ownership immediately. Every exit below leaves no stale tensor.
         self._pending = None
@@ -203,18 +261,240 @@ class ERSDEStochasticTracker:
                 f"(q={tuple(increment.shape)}/{increment.dtype}/{increment.device}, "
                 f"denoised={tuple(denoised.shape)}/{denoised.dtype}/{denoised.device})"
             )
+        return increment
+
+    def _causal_dense_output_ready(self, descriptor: ERSDEStepDescriptor) -> bool:
+        """Enable dense output only once exact actual-anchor cadence proves it safe."""
+        if descriptor.mode != "forecast" or not self._denoised_anchors:
+            return False
+        latest = self._denoised_anchors[-1]
+        if descriptor.step_id != latest.step_id + 1:
+            return False
+        if len(self._denoised_anchors) == 1:
+            # The reviewed one-point bootstrap is exactly actual step 0 -> forecast step 1.
+            return latest.step_id == 0 and descriptor.step_id == 1
+        previous = self._denoised_anchors[-2]
+        # After any causal forecast, ER-SDE forces an actual refresh. A gap of at
+        # least two between exact anchors proves that this history has crossed a
+        # forecast interval rather than being only warmup/all-actual history.
+        return latest.step_id - previous.step_id >= 2
+
+    def consume(
+        self,
+        denoised: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+    ) -> torch.Tensor:
+        """Return the sampler-space denoised value with ER-SDE-specific ownership.
+
+        Causal forecasts use bounded dense output from exact actual denoised anchors
+        whenever the reviewed cadence proves that history is available. Replay keeps
+        the original exact-q compensation contract.
+        """
+        if not torch.is_tensor(denoised):
+            raise ERSDETrackingError("ER-SDE model result is not a packed tensor")
+        self._validate_descriptor(descriptor)
+
+        dense_prediction = None
+        if self._causal_dense_output_ready(descriptor):
+            try:
+                dense_prediction = self.predict_causal_denoised(denoised, descriptor)
+            except ERSDEDenseOutputError as exc:
+                # Fail closed to the already-reviewed direct-q correction. The dense
+                # path is an ER-SDE forecast refinement, not a prerequisite for the
+                # existing stochastic ownership contract.
+                if self.debug:
+                    LOG.warning(
+                        "Spectrum H3 ER-SDE dense output unavailable step=%s reason=%s; "
+                        "using exact-q forecast compensation",
+                        descriptor.step_id,
+                        exc,
+                    )
+
+        increment = self._take_pending(denoised, descriptor)
+        if increment is None:
+            reason = "first_step" if descriptor.step_id == 0 else "no_pending_increment"
+            self._debug_log(denoised, descriptor, None, False, reason)
+            if descriptor.mode == "actual":
+                self.observe_actual_denoised(denoised, descriptor)
+            return denoised
+
+        if dense_prediction is not None:
+            dense = dense_prediction.value
+            if (
+                dense.shape != denoised.shape
+                or dense.device != denoised.device
+                or dense.dtype != denoised.dtype
+            ):
+                raise ERSDEDenseOutputError(
+                    "ER-SDE dense-output prediction does not match the current packed result"
+                )
+            self._debug_dense_log(
+                denoised, dense, descriptor, increment, dense_prediction
+            )
+            return dense
+
         if not descriptor.requires_compensation:
             self._debug_log(denoised, descriptor, increment, False, "state_aware_step")
+            if descriptor.mode == "actual":
+                self.observe_actual_denoised(denoised, descriptor)
             return denoised
 
         corrected = denoised - increment
         self._debug_log(corrected, descriptor, increment, True, "forecast_state_mismatch")
         return corrected
 
+    def observe_actual_denoised(
+        self,
+        denoised: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+    ) -> None:
+        """Retain at most two causal actual solver-space denoised anchors."""
+        if descriptor.mode != "actual":
+            return
+        if not torch.is_tensor(denoised):
+            raise ERSDEDenseOutputError("ER-SDE actual denoised anchor is not a tensor")
+        if descriptor.run_id != self.run_id:
+            raise ERSDEDenseOutputError(
+                f"dense-output anchor belongs to stale run {descriptor.run_id}"
+            )
+        if self._denoised_anchors and descriptor.step_id <= self._denoised_anchors[-1].step_id:
+            raise ERSDEDenseOutputError(
+                "ER-SDE actual denoised anchors are not strictly increasing in step order"
+            )
+        if self._denoised_anchors:
+            previous = self._denoised_anchors[-1].value
+            if (
+                previous.shape != denoised.shape
+                or previous.device != denoised.device
+                or previous.dtype != denoised.dtype
+            ):
+                raise ERSDEDenseOutputError(
+                    "ER-SDE actual denoised anchor shape/device/dtype changed within the run"
+                )
+        retained = denoised.detach().clone(memory_format=torch.contiguous_format)
+        self._denoised_anchors.append(
+            _DenoisedAnchor(step_id=int(descriptor.step_id), value=retained)
+        )
+        if len(self._denoised_anchors) > 2:
+            del self._denoised_anchors[:-2]
+        if self.debug:
+            LOG.warning(
+                "Spectrum H3 ER-SDE dense anchor step=%s anchors=%s retained_bytes=%s",
+                descriptor.step_id,
+                self.denoised_anchor_steps,
+                sum(a.value.numel() * a.value.element_size() for a in self._denoised_anchors),
+            )
+
+    def predict_causal_denoised(
+        self,
+        raw_denoised: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+    ) -> ERSDEDenseOutputPrediction | None:
+        """Predict ER-SDE's denoised variable directly from clean actual anchors."""
+        if descriptor.mode != "forecast":
+            return None
+        if descriptor.run_id != self.run_id:
+            raise ERSDEDenseOutputError(
+                f"dense-output forecast belongs to stale run {descriptor.run_id}"
+            )
+        if not torch.is_tensor(raw_denoised):
+            raise ERSDEDenseOutputError("ER-SDE forecast result is not a packed tensor")
+        if not self._denoised_anchors:
+            return None
+
+        latest = self._denoised_anchors[-1]
+        if latest.step_id >= descriptor.step_id:
+            raise ERSDEDenseOutputError(
+                "ER-SDE dense-output anchor is not strictly earlier than the forecast"
+            )
+        if descriptor.step_id != latest.step_id + 1:
+            raise ERSDEDenseOutputError(
+                "ER-SDE dense output requires the latest actual anchor immediately before "
+                f"the forecast (anchor={latest.step_id}, forecast={descriptor.step_id})"
+            )
+        if (
+            latest.value.shape != raw_denoised.shape
+            or latest.value.device != raw_denoised.device
+            or latest.value.dtype != raw_denoised.dtype
+        ):
+            raise ERSDEDenseOutputError(
+                "ER-SDE dense-output anchor does not match the current packed denoised tensor"
+            )
+
+        latest_coordinate = self._solver_coordinates.get(latest.step_id)
+        target_coordinate = self._solver_coordinates.get(descriptor.step_id)
+        if latest_coordinate is None or target_coordinate is None:
+            return None
+
+        if len(self._denoised_anchors) == 1:
+            predicted = latest.value.clone(memory_format=torch.contiguous_format)
+            return ERSDEDenseOutputPrediction(
+                value=predicted,
+                mode="latest_actual_hold",
+                anchor_steps=(latest.step_id,),
+                alpha=0.0,
+            )
+
+        previous = self._denoised_anchors[-2]
+        if (
+            previous.value.shape != latest.value.shape
+            or previous.value.device != latest.value.device
+            or previous.value.dtype != latest.value.dtype
+        ):
+            raise ERSDEDenseOutputError(
+                "ER-SDE dense-output actual anchor tensors are incompatible"
+            )
+        previous_coordinate = self._solver_coordinates.get(previous.step_id)
+        if previous_coordinate is None:
+            predicted = latest.value.clone(memory_format=torch.contiguous_format)
+            return ERSDEDenseOutputPrediction(
+                value=predicted,
+                mode="latest_actual_hold_missing_coordinate",
+                anchor_steps=(latest.step_id,),
+                alpha=0.0,
+            )
+        denominator = latest_coordinate - previous_coordinate
+        advance = target_coordinate - latest_coordinate
+        scale = max(abs(previous_coordinate), abs(latest_coordinate), 1.0)
+        # A constant extension is the bounded first-order fallback whenever the
+        # two-anchor lambda extrapolation is not trustworthy. It stays inside the
+        # exact actual-denoised manifold and cannot reintroduce x-sigma*v noise.
+        if abs(denominator) <= 1e-12 * scale or denominator * advance < 0.0:
+            predicted = latest.value.clone(memory_format=torch.contiguous_format)
+            return ERSDEDenseOutputPrediction(
+                value=predicted,
+                mode="latest_actual_hold_coordinate_guard",
+                anchor_steps=(latest.step_id,),
+                alpha=0.0,
+            )
+        alpha = advance / denominator
+        # The target is one solver step ahead. Do not extrapolate farther in lambda
+        # than the complete interval represented by the two exact actual anchors.
+        if alpha < -1e-6 or alpha > 1.0 + 1e-6:
+            predicted = latest.value.clone(memory_format=torch.contiguous_format)
+            return ERSDEDenseOutputPrediction(
+                value=predicted,
+                mode="latest_actual_hold_extrapolation_guard",
+                anchor_steps=(latest.step_id,),
+                alpha=0.0,
+            )
+        alpha = float(max(0.0, min(1.0, alpha)))
+        predicted = torch.lerp(latest.value, previous.value, -alpha)
+        if not bool(torch.isfinite(predicted).all().item()):
+            raise ERSDEDenseOutputError("ER-SDE dense-output prediction is nonfinite")
+        return ERSDEDenseOutputPrediction(
+            value=predicted,
+            mode="lambda_linear_extrapolation",
+            anchor_steps=(previous.step_id, latest.step_id),
+            alpha=alpha,
+        )
+
     def clear(self) -> None:
         self._pending = None
         self._scaler_prefix.clear()
         self._scaler_calls = 0
+        self._solver_coordinates.clear()
+        self._denoised_anchors.clear()
 
     @staticmethod
     def _rms(value: torch.Tensor) -> float:
@@ -254,8 +534,38 @@ class ERSDEStochasticTracker:
             self.max_stage,
         )
 
+    def _debug_dense_log(
+        self,
+        raw_denoised: torch.Tensor,
+        dense: torch.Tensor,
+        descriptor: ERSDEStepDescriptor,
+        increment: torch.Tensor,
+        prediction: ERSDEDenseOutputPrediction,
+    ) -> None:
+        if not self.debug:
+            return
+        raw_rms = self._rms(raw_denoised)
+        dense_rms = self._rms(dense)
+        q_rms = self._rms(increment)
+        LOG.warning(
+            "Spectrum H3 ER-SDE dense output step=%s mode=%s anchor_steps=%s "
+            "alpha=%.8f q_pending=true q_rms=%.8f raw_denoised_rms=%.8f "
+            "dense_denoised_rms=%.8f q_applied=false reason=solver_space_dense_output "
+            "max_stage=%s stochastic=true",
+            descriptor.step_id,
+            prediction.mode,
+            prediction.anchor_steps,
+            prediction.alpha,
+            q_rms,
+            raw_rms,
+            dense_rms,
+            self.max_stage,
+        )
+
 
 __all__ = [
+    "ERSDEDenseOutputError",
+    "ERSDEDenseOutputPrediction",
     "ERSDEStepDescriptor",
     "ERSDEStochasticTracker",
     "ERSDETrackingError",

--- a/comfyui_spectrum_h3/generic_correction_calibration.py
+++ b/comfyui_spectrum_h3/generic_correction_calibration.py
@@ -130,6 +130,8 @@ def exact_segment_moments(
     if len({key for key, *_ in normalized}) != len(normalized):
         raise ValueError("exact moment segment keys must be unique")
 
+    # MPS does not support float64 reductions. Other backends use five float64
+    # accumulators per segment to minimize drift across large chunked streams.
     accumulator_dtype = torch.float32 if target_device.type == "mps" else torch.float64
     accumulators = {
         key: torch.zeros(5, device=target_device, dtype=accumulator_dtype)

--- a/comfyui_spectrum_h3/generic_correction_calibration.py
+++ b/comfyui_spectrum_h3/generic_correction_calibration.py
@@ -20,7 +20,7 @@ SCHEMA_VERSION = 1
 SOURCE_SCHEMA_REVISION = "generic-correction-v1"
 LOG_PREFIX = "SPECTRUM_GENERIC_CORRECTION_CALIBRATION_JSON="
 PACKAGE_NAME = "comfyui-spectrum-minimax-h3"
-FALLBACK_PACKAGE_VERSION = "0.2.10"
+FALLBACK_PACKAGE_VERSION = "0.2.11"
 MAX_SERIALIZED_BYTES = 512 * 1024
 MAX_RETAINED_ROWS = 4096
 
@@ -130,8 +130,6 @@ def exact_segment_moments(
     if len({key for key, *_ in normalized}) != len(normalized):
         raise ValueError("exact moment segment keys must be unique")
 
-    # MPS does not support float64 reductions. Other backends use five float64
-    # accumulators per segment to minimize drift across large chunked streams.
     accumulator_dtype = torch.float32 if target_device.type == "mps" else torch.float64
     accumulators = {
         key: torch.zeros(5, device=target_device, dtype=accumulator_dtype)

--- a/comfyui_spectrum_h3/postrun_safety.py
+++ b/comfyui_spectrum_h3/postrun_safety.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+from . import generic_correction as _generic
+from .generic_correction_calibration import GenericCalibrationState
+from .runtime import SpectrumH3Runtime
+
+LOG = logging.getLogger(__name__)
+
+# Generic-correction research is diagnostic-only. A single daemon worker is enough:
+# if one report job ever wedges, later jobs are skipped rather than accumulating
+# threads or blocking completed generations.
+_RESEARCH_SLOT = threading.BoundedSemaphore(1)
+_CORE_RUNTIME_END = _generic._ORIGINAL_RUNTIME_END
+
+
+def _teardown_log(runtime: Any, event: str, **fields: Any) -> None:
+    config = getattr(runtime, "config", None)
+    if not bool(getattr(config, "debug", False)):
+        return
+    rendered = " ".join(f"{key}={value}" for key, value in fields.items())
+    LOG.warning(
+        "Spectrum H3 teardown transition ts=%.6f event=%s%s",
+        time.time(),
+        event,
+        f" {rendered}" if rendered else "",
+    )
+
+
+def _research_worker(block: dict[str, Any]) -> None:
+    try:
+        result = _generic.persist_and_analyze(block)
+        duplicate_note = " (duplicate ignored)" if result.duplicate else ""
+        LOG.warning("\n%s%s", result.console_summary, duplicate_note)
+        LOG.warning(
+            "Spectrum H3 generic-correction post-run analysis completed in %.3f s",
+            result.elapsed_seconds,
+        )
+    except Exception as exc:  # noqa: BLE001 - research must never affect generation
+        LOG.warning(
+            "Spectrum H3 generic-correction background research failed; "
+            "the completed generation remains valid: %s",
+            exc,
+        )
+    finally:
+        _RESEARCH_SLOT.release()
+
+
+def _dispatch_research(block: dict[str, Any]) -> bool:
+    """Start one bounded daemon research job without joining the sampling path."""
+    if not _RESEARCH_SLOT.acquire(blocking=False):
+        LOG.warning(
+            "Spectrum H3 generic-correction post-run research skipped because a "
+            "previous background analysis is still active"
+        )
+        return False
+    try:
+        worker = threading.Thread(
+            target=_research_worker,
+            args=(block,),
+            name="SpectrumH3GenericResearch",
+            daemon=True,
+        )
+        worker.start()
+    except Exception as exc:  # noqa: BLE001 - thread creation must not affect generation
+        _RESEARCH_SLOT.release()
+        LOG.warning(
+            "Spectrum H3 generic-correction post-run research could not be dispatched; "
+            "the completed generation remains valid: %s",
+            exc,
+        )
+        return False
+    return True
+
+
+def _safe_end_run(self: SpectrumH3Runtime, run_id: int) -> None:
+    """End a run before any optional research and expose teardown crash boundaries.
+
+    The previous generic-correction hook performed persistence/evaluation inline in
+    ``SpectrumH3Runtime.end_run``. That made diagnostic research part of the sampler
+    critical path: a filesystem/evaluator hang after the native sampler had already
+    returned could prevent downstream VAE/video nodes from ever receiving the valid
+    result. Keep calibration export synchronous and bounded, release runtime/VRAM
+    state synchronously, then transfer the tensor-free calibration block to at most
+    one daemon research worker.
+    """
+    active = getattr(self, "_run", None)
+    if active is None or active.run_id != int(run_id):
+        _CORE_RUNTIME_END(self, run_id)
+        return
+
+    calibration = getattr(self, "_generic_correction_calibration", None)
+    block: dict[str, Any] | None = None
+    if isinstance(calibration, GenericCalibrationState):
+        _teardown_log(
+            self,
+            "calibration_export_begin",
+            run_id=run_id,
+            rows=len(calibration.rows),
+            failures=calibration.failures,
+        )
+        try:
+            block = _generic.emit_calibration_block(self, calibration)
+        except Exception as exc:  # noqa: BLE001 - diagnostic export is non-critical
+            calibration.failures += 1
+            LOG.warning(
+                "Spectrum H3 generic-correction calibration export failed; "
+                "the completed generation remains valid: %s",
+                exc,
+            )
+        _teardown_log(
+            self,
+            "calibration_export_end",
+            run_id=run_id,
+            compatible=bool(block is not None and block.get("compatible")),
+        )
+
+    forecaster = self.forecaster
+    history_bytes = int(forecaster.history_tensor_bytes)
+    persistent_bytes = int(forecaster.persistent_tensor_bytes)
+    history_device = forecaster.history_device
+    _teardown_log(
+        self,
+        "runtime_release_begin",
+        run_id=run_id,
+        history_entries=forecaster.history_length,
+        history_bytes=history_bytes,
+        persistent_bytes=persistent_bytes,
+        history_device=history_device,
+    )
+    try:
+        _CORE_RUNTIME_END(self, run_id)
+    finally:
+        # Generic-correction controller/calibration state must never retain a run
+        # after the core runtime has been asked to tear it down.
+        self._generic_correction_controller = None
+        self._generic_correction_calibration = None
+        self.model_aware._generic_correction_controller = None
+        self.forecaster._generic_correction_capture_mode = None
+    _teardown_log(
+        self,
+        "runtime_release_end",
+        run_id=run_id,
+        released_history_bytes=history_bytes,
+    )
+
+    if block is not None and block.get("compatible"):
+        dispatched = _dispatch_research(block)
+        _teardown_log(
+            self,
+            "research_dispatch",
+            run_id=run_id,
+            dispatched=dispatched,
+        )
+
+
+def install_postrun_safety() -> None:
+    """Replace the synchronous generic-correction end hook once per interpreter."""
+    if getattr(SpectrumH3Runtime, "_postrun_safety_installed", False):
+        return
+    current = SpectrumH3Runtime.end_run
+    if current is not _generic._end_run:
+        raise RuntimeError(
+            "post-run safety must be installed immediately after generic correction"
+        )
+    SpectrumH3Runtime.end_run = _safe_end_run
+    SpectrumH3Runtime._postrun_safety_installed = True
+
+
+__all__ = ["install_postrun_safety"]

--- a/comfyui_spectrum_h3/postrun_safety.py
+++ b/comfyui_spectrum_h3/postrun_safety.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from types import SimpleNamespace
 from typing import Any
 
 from . import generic_correction as _generic

--- a/comfyui_spectrum_h3/replay_calibration.py
+++ b/comfyui_spectrum_h3/replay_calibration.py
@@ -244,6 +244,7 @@ def _calibration_row(
     if torch.any(effective_blends <= 0):
         raise RuntimeError("replay calibration received nonpositive video blend")
 
+    # Predictor/deployable values are frozen before the withheld target is read.
     predictors = _predictor_snapshot(
         record=record,
         candidates=candidates,
@@ -257,6 +258,8 @@ def _calibration_row(
         raise RuntimeError("replay calibration bracket has duplicate coordinates")
     bracket_fraction = (float(record.coordinate) - float(left.coordinate)) / spacing
 
+    # Post-target scoring starts here. None of these values may feed a deployable
+    # predictor or a production replay path.
     actual = samples[target_index]
     e = (candidates.local - actual).to(torch.float32)
     d = (candidates.spectral - candidates.local).to(torch.float32)

--- a/comfyui_spectrum_h3/replay_calibration.py
+++ b/comfyui_spectrum_h3/replay_calibration.py
@@ -22,7 +22,7 @@ _SOURCE_SCHEMA_REVISION = "pr45-replay-calibration-v1"
 _LOG_PREFIX = "SPECTRUM_REPLAY_CALIBRATION_JSON="
 _ARCHIVE_STATE_ATTR = "_spectrum_replay_calibration_state"
 _PACKAGE_NAME = "comfyui-spectrum-minimax-h3"
-_FALLBACK_PACKAGE_VERSION = "0.2.10"
+_FALLBACK_PACKAGE_VERSION = "0.2.11"
 _PARITY_TOLERANCE = 2e-5
 _MAX_SERIALIZED_BYTES = 96 * 1024
 _FIXED_WEIGHTS = (0.0, 0.25, 0.50, 0.75, 1.0)
@@ -244,7 +244,6 @@ def _calibration_row(
     if torch.any(effective_blends <= 0):
         raise RuntimeError("replay calibration received nonpositive video blend")
 
-    # Predictor/deployable values are frozen before the withheld target is read.
     predictors = _predictor_snapshot(
         record=record,
         candidates=candidates,
@@ -258,8 +257,6 @@ def _calibration_row(
         raise RuntimeError("replay calibration bracket has duplicate coordinates")
     bracket_fraction = (float(record.coordinate) - float(left.coordinate)) / spacing
 
-    # Post-target scoring starts here. None of these values may feed a deployable
-    # predictor or a production replay path.
     actual = samples[target_index]
     e = (candidates.local - actual).to(torch.float32)
     d = (candidates.spectral - candidates.local).to(torch.float32)

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -16,6 +16,7 @@ from .experiments import (
     measure_stream_residual,
     tensor_all_finite,
 )
+from .er_sde_stochastic import ERSDEStepDescriptor
 from .forecast import ForecasterSnapshot, HistoryWeightForecaster
 from .model_aware import (
     ModelAwareController,
@@ -1066,6 +1067,40 @@ class SpectrumH3Runtime:
         if self._offline_phase == "first_pass" and self._offline_archive is not None:
             self._offline_archive.invalidate(reason)
         return newly_disabled
+
+    def disable_forecasting_for_run(self, reason: str) -> bool:
+        """Fail closed before a solver step when a sampler contract is unproven."""
+        if self._run is None or self._step is not None:
+            raise RuntimeError(
+                "forecasting can only be disabled between steps of an active run"
+            )
+        return self._disable_forecasting(reason)
+
+    def describe_current_er_sde_step(
+        self,
+        run_id: int,
+        step_id: int,
+    ) -> ERSDEStepDescriptor:
+        """Classify the active result before ER-SDE consumes it."""
+        step = self._require_step(run_id, step_id)
+        replay_source_actual = None
+        if step.mode == "replay":
+            archive = self._offline_archive
+            if archive is None or step.step_id >= len(archive.steps):
+                raise OfflineReplayAbort(
+                    "offline replay source classification is unavailable"
+                )
+            replay_source_actual = bool(archive.steps[step.step_id].actual)
+        requires_compensation = step.mode == "forecast" or (
+            step.mode == "replay" and replay_source_actual is False
+        )
+        return ERSDEStepDescriptor(
+            run_id=int(run_id),
+            step_id=step.step_id,
+            mode=step.mode,
+            replay_source_actual=replay_source_actual,
+            requires_compensation=requires_compensation,
+        )
 
     def _fallback_or_retry(self, step: _StepState, reason: str) -> None:
         if step.mode == "replay":

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import sys
 import time
@@ -8,6 +9,12 @@ from typing import Any
 
 import torch
 
+from .er_sde_stochastic import (
+    ERSDEStochasticTracker,
+    ERSDETrackingError,
+    function_ast_digest,
+    native_default_er_sde_noise_scaler,
+)
 from .model_aware import get_model_forecastability_profile
 from .rollback import run_selective_rollback_euler
 from .runtime import ForecastRetryActual, OfflineReplayAbort, SpectrumH3Runtime
@@ -21,6 +28,7 @@ STEP_ID_KEY = "spectrum_h3_step_id"
 COORDINATE_KEY = "spectrum_h3_coordinate"
 ACTUAL_KEY = "spectrum_h3_actual"
 REASON_KEY = "spectrum_h3_reason"
+ER_SDE_TRACKER_KEY = "spectrum_h3_er_sde_stochastic_tracker"
 WRAPPER_KEY = "spectrum_minimax_h3"
 KJ_PREVIEW_WRAPPER_KEY = "kj_preview_override"
 
@@ -48,6 +56,18 @@ ER_SDE_NATIVE_SCALER_FREEVARS = {
     "SamplerER_SDE.execute.<locals>.reverse_time_sde_noise_scaler": ("eta",),
     "SamplerER_SDE.execute.<locals>.ode_noise_scaler": (),
 }
+ER_SDE_NATIVE_FUNCTION_DIGEST = (
+    "55b76bd3a76d44fbd363de39f2ab3ea672c78de9f001f47168b47ec6ff6d2447"
+)
+ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST = (
+    "11cfe81f36f0b43e96c12eff32a4f074f35227a53ca116e837bf268b6383f9ad"
+)
+ER_SDE_KSAMPLER_SAMPLE_DIGEST = (
+    "cacf00387fb2b9d0e076c68e0bd3f75d104801aa8d34239115b3208153ed8dac"
+)
+ER_SDE_TRACKED_OPTIONS = frozenset(
+    {"s_noise", "noise_sampler", "noise_scaler", "max_stage"}
+)
 
 
 @dataclass(slots=True)
@@ -116,6 +136,79 @@ def sampler_supports_seeded_replay(sampler: Any) -> bool:
     if options.get("noise_sampler") is not None:
         return False
     return _er_sde_noise_scaler_supports_replay(options.get("noise_scaler"))
+
+
+def _er_sde_tracking_contract(sampler: Any) -> tuple[bool, str | None]:
+    """Accept only the native solver/wrapper semantics reviewed by this project."""
+    import comfy.k_diffusion.sampling as native_sampling
+    import comfy.samplers
+
+    function = getattr(sampler, "sampler_function", None)
+    if function is not native_sampling.sample_er_sde:
+        return False, "sampler function is not native ComfyUI sample_er_sde"
+    if function_ast_digest(function) != ER_SDE_NATIVE_FUNCTION_DIGEST:
+        return False, "native sample_er_sde implementation is not a reviewed revision"
+    if type(sampler) is not comfy.samplers.KSAMPLER:
+        return False, "ER-SDE sampler object is not native ComfyUI KSAMPLER"
+    if (
+        function_ast_digest(type(sampler).sample)
+        != ER_SDE_KSAMPLER_SAMPLE_DIGEST
+    ):
+        return False, "native KSAMPLER.sample implementation is not a reviewed revision"
+    if (
+        function_ast_digest(native_sampling.default_noise_sampler)
+        != ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST
+    ):
+        return False, "native default_noise_sampler implementation is not a reviewed revision"
+
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return False, "ER-SDE sampler options are not a dictionary"
+    unknown = set(options) - ER_SDE_TRACKED_OPTIONS
+    if unknown:
+        return False, f"ER-SDE sampler has unreviewed options: {sorted(unknown)}"
+    try:
+        s_noise = float(options.get("s_noise", 1.0))
+    except (TypeError, ValueError):
+        return False, "ER-SDE s_noise is not numeric"
+    if not torch.isfinite(torch.tensor(s_noise)) or s_noise < 0.0:
+        return False, "ER-SDE s_noise must be finite and nonnegative"
+    max_stage = options.get("max_stage", 3)
+    if isinstance(max_stage, bool) or not isinstance(max_stage, int) or not 1 <= max_stage <= 3:
+        return False, "ER-SDE max_stage must be an integer in [1, 3]"
+    if s_noise > 0.0:
+        if options.get("noise_sampler") is not None:
+            return False, "custom ER-SDE noise_sampler provenance is unreviewed"
+        if not _er_sde_noise_scaler_supports_replay(options.get("noise_scaler")):
+            return False, "custom ER-SDE noise_scaler provenance is unreviewed"
+    return True, None
+
+
+def _native_er_sde_preflight_reason(
+    sampler: Any,
+    model_options: dict[str, Any] | None,
+) -> str | None:
+    """Resolve native ER-SDE failures before Spectrum starts retaining state."""
+    function = getattr(sampler, "sampler_function", None)
+    if getattr(function, "__module__", None) != "comfy.k_diffusion.sampling":
+        return None
+    supported, reason = _er_sde_tracking_contract(sampler)
+    if not supported:
+        return reason or "native ER-SDE compensation contract is unproven"
+    options = getattr(sampler, "extra_options", {}) or {}
+    if float(options.get("s_noise", 1.0)) == 0.0:
+        return None
+
+    import comfy.patcher_extension
+
+    wrappers = comfy.patcher_extension.get_all_wrappers(
+        comfy.patcher_extension.WrappersMP.SAMPLER_SAMPLE,
+        model_options or {},
+        is_model_options=True,
+    )
+    if len(wrappers) != 1 or wrappers[0] is not sampler_sample_wrapper:
+        return "another SAMPLER_SAMPLE wrapper makes ER-SDE ordering unproven"
+    return None
 
 
 def max_consecutive_forecasts(sampler: Any) -> int | None:
@@ -240,6 +333,28 @@ def outer_sample_wrapper(
 
     runtime = binding.runtime
     name = sampler_name(sampler)
+    if name in ER_SDE_SAMPLERS:
+        preflight_reason = _native_er_sde_preflight_reason(
+            sampler,
+            getattr(guider, "model_options", None),
+        )
+        if preflight_reason is not None:
+            LOG.warning(
+                "Spectrum H3 disabled for this ER-SDE run; running the untouched "
+                "native sampler because stochastic compensation is unavailable: %s",
+                preflight_reason,
+            )
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
     profile_eligible = sampler_is_supported(sampler) and (
         not runtime.config.offline_smoothing_replay
         or sampler_supports_seeded_replay(sampler)
@@ -579,6 +694,40 @@ def predict_noise_wrapper(executor, x, timestep, model_options=None, seed=None):
         patched = copy_model_options_with_step(model_options, runtime, attempt_decision)
         return executor(x, timestep, patched, seed)
 
+    def consume_er_sde_increment(
+        result: torch.Tensor,
+        attempt_decision: dict[str, Any],
+    ) -> torch.Tensor:
+        transformer_options = (model_options or {}).get("transformer_options") or {}
+        tracker = transformer_options.get(ER_SDE_TRACKER_KEY)
+        if not isinstance(tracker, ERSDEStochasticTracker):
+            return result
+        descriptor = None
+        try:
+            descriptor = runtime.describe_current_er_sde_step(
+                int(attempt_decision["run_id"]),
+                int(attempt_decision["step_id"]),
+            )
+            return tracker.consume(result, descriptor)
+        except ERSDETrackingError as exc:
+            tracker.clear()
+            if descriptor is not None and descriptor.mode == "replay":
+                raise OfflineReplayAbort(
+                    f"ER-SDE stochastic-state compensation failed during replay: {exc}"
+                ) from exc
+            if not bool(attempt_decision["actual"]):
+                raise ForecastRetryActual(
+                    f"ER-SDE stochastic-state compensation failed: {exc}"
+                ) from exc
+            if runtime.config.debug:
+                LOG.warning(
+                    "Spectrum H3 ER-SDE tracker discarded on state-aware actual "
+                    "step=%s reason=%s",
+                    attempt_decision["step_id"],
+                    exc,
+                )
+            return result
+
     try:
         try:
             result = execute_attempt(decision)
@@ -587,6 +736,7 @@ def predict_noise_wrapper(executor, x, timestep, model_options=None, seed=None):
                 run_id=decision["run_id"],
                 step=decision["step_id"],
             )
+            result = consume_er_sde_increment(result, decision)
             runtime.finalize_step(decision["run_id"], decision["step_id"])
             return result
         except ForecastRetryActual as retry:
@@ -610,12 +760,150 @@ def predict_noise_wrapper(executor, x, timestep, model_options=None, seed=None):
                 step=decision["step_id"],
                 retry=True,
             )
+            result = consume_er_sde_increment(result, retry_decision)
             runtime.finalize_step(decision["run_id"], decision["step_id"])
             return result
     except BaseException:
         if runtime.active_step_id == decision["step_id"]:
             runtime.abort_step(decision["run_id"], decision["step_id"])
         raise
+
+
+def _run_tracked_er_sde(
+    executor,
+    runtime: SpectrumH3Runtime,
+    model_wrap,
+    sigmas,
+    extra_args,
+    callback,
+    noise,
+    latent_image,
+    denoise_mask,
+    disable_pbar,
+):
+    supported, reason = _er_sde_tracking_contract(executor.class_obj)
+    if len(executor.wrappers) != 1:
+        supported = False
+        reason = "another SAMPLER_SAMPLE wrapper makes ER-SDE ordering unproven"
+    if not supported:
+        assert reason is not None
+        runtime.disable_forecasting_for_run(reason)
+        LOG.warning(
+            "Spectrum H3 disabled for this ER-SDE run; preserving native all-actual "
+            "sampling because stochastic compensation is unavailable: %s",
+            reason,
+        )
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+
+    sampler = executor.class_obj
+    options = dict(getattr(sampler, "extra_options", {}) or {})
+    configured_s_noise = float(options.get("s_noise", 1.0))
+    model_sampling = model_wrap.model_patcher.get_model_object("model_sampling")
+    noise_scale = float(getattr(model_sampling, "noise_scale", 1.0))
+    effective_s_noise = configured_s_noise * noise_scale
+    if not torch.isfinite(torch.tensor(effective_s_noise)) or effective_s_noise < 0.0:
+        reason = "effective ER-SDE s_noise is not finite and nonnegative"
+        runtime.disable_forecasting_for_run(reason)
+        LOG.warning(
+            "Spectrum H3 disabled for this ER-SDE run; preserving native all-actual "
+            "sampling because %s",
+            reason,
+        )
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+    if effective_s_noise == 0.0:
+        if runtime.config.debug:
+            LOG.warning(
+                "Spectrum H3 ER-SDE compensation q_pending=false applied=false "
+                "reason=no_stochastic_increment max_stage=%s stochastic=false",
+                options.get("max_stage", 3),
+            )
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+    if not torch.is_tensor(noise):
+        reason = "ER-SDE sampler noise is not a packed tensor"
+        runtime.disable_forecasting_for_run(reason)
+        LOG.warning("Spectrum H3 disabled for this ER-SDE run: %s", reason)
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+
+    import comfy.k_diffusion.sampling as native_sampling
+
+    base_noise_sampler = native_sampling.default_noise_sampler(
+        noise,
+        seed=extra_args.get("seed"),
+    )
+    base_noise_scaler = options.get("noise_scaler")
+    if base_noise_scaler is None:
+        base_noise_scaler = native_default_er_sde_noise_scaler
+    tracker = ERSDEStochasticTracker(
+        noise_sampler=base_noise_sampler,
+        noise_scaler=base_noise_scaler,
+        effective_s_noise=effective_s_noise,
+        max_stage=int(options.get("max_stage", 3)),
+        debug=runtime.config.debug,
+        run_id=int(runtime.active_run_id),
+    )
+    tracked_options = dict(options)
+    tracked_options["noise_sampler"] = tracker.noise_sampler
+    tracked_options["noise_scaler"] = tracker.noise_scaler
+    tracked_sampler = copy.copy(sampler)
+    tracked_sampler.extra_options = tracked_options
+
+    tracked_extra_args = dict(extra_args)
+    tracked_model_options = dict(tracked_extra_args.get("model_options") or {})
+    tracked_transformer_options = dict(
+        tracked_model_options.get("transformer_options") or {}
+    )
+    tracked_transformer_options[ER_SDE_TRACKER_KEY] = tracker
+    tracked_model_options["transformer_options"] = tracked_transformer_options
+    tracked_extra_args["model_options"] = tracked_model_options
+    try:
+        return tracked_sampler.sample(
+            model_wrap,
+            sigmas,
+            tracked_extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+    finally:
+        tracker.clear()
 
 
 def sampler_sample_wrapper(
@@ -644,6 +932,20 @@ def sampler_sample_wrapper(
             disable_pbar,
         )
     runtime = binding.runtime
+    sampler = executor.class_obj
+    if sampler_name(sampler) in ER_SDE_SAMPLERS:
+        return _run_tracked_er_sde(
+            executor,
+            runtime,
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
     if (
         not runtime.config.selective_rollback_correction
         or runtime.experiment_disabled_reason is not None
@@ -661,7 +963,6 @@ def sampler_sample_wrapper(
 
     import comfy.k_diffusion.sampling as native_sampling
 
-    sampler = executor.class_obj
     function = getattr(sampler, "sampler_function", None)
     options = dict(getattr(sampler, "extra_options", {}) or {})
     unsupported_reason = None

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import logging
 import sys
 import time
@@ -9,6 +10,10 @@ from typing import Any
 
 import torch
 
+from .er_sde_ksampler_contract import (
+    KSamplerSampleContract,
+    validate_ksampler_sample,
+)
 from .er_sde_stochastic import (
     ERSDEStochasticTracker,
     ERSDETrackingError,
@@ -138,6 +143,52 @@ def sampler_supports_seeded_replay(sampler: Any) -> bool:
     return _er_sde_noise_scaler_supports_replay(options.get("noise_scaler"))
 
 
+def _ksampler_sample_contract(sampler: Any) -> KSamplerSampleContract:
+    import comfy.samplers
+
+    sample_method = vars(type(sampler)).get("sample")
+    return validate_ksampler_sample(
+        sample_method,
+        expected_adapter=comfy.samplers.KSamplerX0Inpaint,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+
+def _copy_ksampler_with_options(
+    sampler: Any,
+    options: dict[str, Any],
+) -> tuple[Any | None, str | None]:
+    """Prove and perform the shallow copy used to isolate tracked options."""
+    if not inspect.isfunction(vars(type(sampler)).get("sample")):
+        return None, "KSAMPLER.sample is not a plain function descriptor"
+    if vars(type(sampler)).get("__copy__") is not None:
+        return None, "KSAMPLER defines an unreviewed custom __copy__ method"
+    try:
+        original_state = vars(sampler)
+        original_options = sampler.extra_options
+        copied = copy.copy(sampler)
+    except Exception as exc:  # noqa: BLE001 - fail closed on custom runtime state
+        return None, f"KSAMPLER state/copy inspection failed: {type(exc).__name__}: {exc}"
+    if copied is sampler or type(copied) is not type(sampler):
+        return None, "KSAMPLER shallow copy did not create a distinct native instance"
+    try:
+        for name, value in original_state.items():
+            if getattr(copied, name, object()) is not value:
+                return None, f"KSAMPLER shallow copy changed instance field {name!r}"
+        copied.extra_options = options
+        if sampler.extra_options is not original_options:
+            return None, "KSAMPLER shallow copy mutated the original extra_options"
+        if copied.extra_options is not options:
+            return None, "KSAMPLER shallow copy did not accept invocation-local options"
+        if copied.sampler_function is not sampler.sampler_function:
+            return None, "KSAMPLER shallow copy changed sampler_function binding"
+        if copied.inpaint_options is not sampler.inpaint_options:
+            return None, "KSAMPLER shallow copy changed inpaint_options ownership"
+    except Exception as exc:  # noqa: BLE001 - fail closed on custom runtime state
+        return None, f"KSAMPLER copied-state validation failed: {type(exc).__name__}: {exc}"
+    return copied, None
+
+
 def _er_sde_tracking_contract(sampler: Any) -> tuple[bool, str | None]:
     """Accept only the native solver/wrapper semantics reviewed by this project."""
     import comfy.k_diffusion.sampling as native_sampling
@@ -151,10 +202,24 @@ def _er_sde_tracking_contract(sampler: Any) -> tuple[bool, str | None]:
     if type(sampler) is not comfy.samplers.KSAMPLER:
         return False, "ER-SDE sampler object is not native ComfyUI KSAMPLER"
     if (
-        function_ast_digest(type(sampler).sample)
-        != ER_SDE_KSAMPLER_SAMPLE_DIGEST
+        comfy.samplers.KSAMPLER.__module__ != "comfy.samplers"
+        or comfy.samplers.KSAMPLER.__name__ != "KSAMPLER"
     ):
-        return False, "native KSAMPLER.sample implementation is not a reviewed revision"
+        return False, "native ComfyUI KSAMPLER class provenance is unreviewed"
+    if (
+        comfy.samplers.KSamplerX0Inpaint.__module__ != "comfy.samplers"
+        or comfy.samplers.KSamplerX0Inpaint.__name__ != "KSamplerX0Inpaint"
+    ):
+        return False, "native KSamplerX0Inpaint adapter provenance is unreviewed"
+    sample_contract = _ksampler_sample_contract(sampler)
+    if not sample_contract.accepted:
+        return False, (
+            f"KSAMPLER.sample contract rejected: {sample_contract.failure}; "
+            f"{sample_contract.provenance.log_fields()}"
+        )
+    _, copy_failure = _copy_ksampler_with_options(sampler, {})
+    if copy_failure is not None:
+        return False, f"KSAMPLER copy contract rejected: {copy_failure}"
     if (
         function_ast_digest(native_sampling.default_noise_sampler)
         != ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST
@@ -880,8 +945,43 @@ def _run_tracked_er_sde(
     tracked_options = dict(options)
     tracked_options["noise_sampler"] = tracker.noise_sampler
     tracked_options["noise_scaler"] = tracker.noise_scaler
-    tracked_sampler = copy.copy(sampler)
-    tracked_sampler.extra_options = tracked_options
+    tracked_sampler, copy_failure = _copy_ksampler_with_options(
+        sampler,
+        tracked_options,
+    )
+    if copy_failure is not None:
+        tracker.clear()
+        runtime.disable_forecasting_for_run(copy_failure)
+        LOG.warning(
+            "Spectrum H3 disabled for this ER-SDE run; preserving native all-actual "
+            "sampling because KSAMPLER copy validation failed: %s",
+            copy_failure,
+        )
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+    assert tracked_sampler is not None
+
+    if runtime.config.debug:
+        sample_contract = _ksampler_sample_contract(sampler)
+        LOG.warning(
+            "Spectrum H3 ER-SDE stochastic tracking active run_id=%s sampler=%s "
+            "max_stage=%s configured_s_noise=%.8f effective_s_noise=%.8f "
+            "ksampler_contract=accepted %s",
+            runtime.active_run_id,
+            sampler_name(sampler),
+            options.get("max_stage", 3),
+            configured_s_noise,
+            effective_s_noise,
+            sample_contract.provenance.log_fields(),
+        )
 
     tracked_extra_args = dict(extra_args)
     tracked_model_options = dict(tracked_extra_args.get("model_options") or {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.10"
+version = "0.2.11"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_er_sde_solver_dense_output.py
+++ b/tests/test_er_sde_solver_dense_output.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import torch
+
+from comfyui_spectrum_h3.er_sde_stochastic import (
+    ERSDEStepDescriptor,
+    ERSDEStochasticTracker,
+)
+
+
+def _descriptor(step_id: int, *, mode: str = "forecast", replay_source_actual=None):
+    return ERSDEStepDescriptor(
+        run_id=7,
+        step_id=step_id,
+        mode=mode,
+        replay_source_actual=replay_source_actual,
+        requires_compensation=(
+            mode == "forecast"
+            or (mode == "replay" and replay_source_actual is False)
+        ),
+    )
+
+
+def _tracker(*, debug: bool = False):
+    return ERSDEStochasticTracker(
+        noise_sampler=lambda _sigma, _sigma_next: torch.tensor([[0.75, -0.5]]),
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=1.0,
+        max_stage=3,
+        debug=debug,
+        run_id=7,
+    )
+
+
+def _produce_pending(
+    tracker: ERSDEStochasticTracker,
+    *,
+    lambda_source: float,
+    lambda_target: float,
+    sigma_next: float,
+):
+    # Native sample_er_sde calls noise_scaler(er_lambda_t) first, then er_lambda_s.
+    er_lambda_t = torch.tensor(lambda_target)
+    er_lambda_s = torch.tensor(lambda_source)
+    tracker.noise_scaler(er_lambda_t)
+    tracker.noise_scaler(er_lambda_s)
+    noise = tracker.noise_sampler(torch.tensor(0.9), torch.tensor(sigma_next))
+    r = er_lambda_t**2 / er_lambda_s**2
+    return (
+        (torch.tensor(sigma_next) / er_lambda_t)
+        * noise
+        * (er_lambda_t**2 - er_lambda_s**2 * r**2).sqrt().nan_to_num(nan=0.0)
+    )
+
+
+def test_bootstrap_forecast_uses_latest_actual_solver_space_denoised():
+    tracker = _tracker()
+    actual0 = torch.tensor([[1.25, -0.75]])
+    returned0 = tracker.consume(actual0, _descriptor(0, mode="actual"))
+    assert returned0 is actual0
+
+    q1 = _produce_pending(
+        tracker,
+        lambda_source=10.0,
+        lambda_target=4.0,
+        sigma_next=0.8,
+    )
+    raw_forecast = torch.tensor([[100.0, -100.0]]) + q1
+    returned1 = tracker.consume(raw_forecast, _descriptor(1))
+
+    torch.testing.assert_close(returned1, actual0, rtol=0, atol=0)
+    assert not tracker.has_pending
+    assert tracker.denoised_anchor_steps == (0,)
+
+
+def test_two_anchor_forecast_extrapolates_denoised_in_native_er_lambda_space():
+    tracker = _tracker()
+    actual0 = torch.tensor([[1.0, 2.0]])
+    tracker.consume(actual0, _descriptor(0, mode="actual"))
+
+    _produce_pending(
+        tracker,
+        lambda_source=10.0,
+        lambda_target=7.0,
+        sigma_next=0.8,
+    )
+    # Bootstrap forecast: exact latest-actual hold.
+    tracker.consume(torch.tensor([[90.0, -90.0]]), _descriptor(1))
+
+    _produce_pending(
+        tracker,
+        lambda_source=7.0,
+        lambda_target=4.0,
+        sigma_next=0.6,
+    )
+    actual2 = torch.tensor([[3.0, 4.0]])
+    tracker.consume(actual2, _descriptor(2, mode="actual"))
+
+    q3 = _produce_pending(
+        tracker,
+        lambda_source=4.0,
+        lambda_target=2.5,
+        sigma_next=0.4,
+    )
+    raw_forecast = torch.tensor([[80.0, -80.0]]) + q3
+    returned3 = tracker.consume(raw_forecast, _descriptor(3))
+
+    alpha = (2.5 - 4.0) / (4.0 - 10.0)
+    expected = actual2 + alpha * (actual2 - actual0)
+    torch.testing.assert_close(returned3, expected, rtol=0, atol=1e-6)
+    assert not tracker.has_pending
+    assert tracker.denoised_anchor_steps == (0, 2)
+
+
+def test_extrapolation_guard_uses_latest_actual_hold_instead_of_noisy_raw_forecast():
+    tracker = _tracker()
+    actual0 = torch.tensor([[1.0, 2.0]])
+    tracker.consume(actual0, _descriptor(0, mode="actual"))
+    _produce_pending(
+        tracker,
+        lambda_source=10.0,
+        lambda_target=9.5,
+        sigma_next=0.8,
+    )
+    tracker.consume(torch.tensor([[90.0, -90.0]]), _descriptor(1))
+
+    _produce_pending(
+        tracker,
+        lambda_source=9.5,
+        lambda_target=9.0,
+        sigma_next=0.6,
+    )
+    actual2 = torch.tensor([[5.0, 6.0]])
+    tracker.consume(actual2, _descriptor(2, mode="actual"))
+
+    q3 = _produce_pending(
+        tracker,
+        lambda_source=9.0,
+        lambda_target=1.0,
+        sigma_next=0.4,
+    )
+    raw_forecast = torch.tensor([[1000.0, -1000.0]]) + q3
+    returned3 = tracker.consume(raw_forecast, _descriptor(3))
+
+    torch.testing.assert_close(returned3, actual2, rtol=0, atol=0)
+    assert not tracker.has_pending
+
+
+def test_consecutive_warmup_anchors_preserve_existing_exact_q_path_for_first_forecast():
+    tracker = _tracker()
+    tracker.consume(torch.tensor([[1.0, 2.0]]), _descriptor(0, mode="actual"))
+    _produce_pending(
+        tracker,
+        lambda_source=10.0,
+        lambda_target=7.0,
+        sigma_next=0.8,
+    )
+    tracker.consume(torch.tensor([[2.0, 3.0]]), _descriptor(1, mode="actual"))
+
+    q2 = _produce_pending(
+        tracker,
+        lambda_source=7.0,
+        lambda_target=4.0,
+        sigma_next=0.6,
+    )
+    base = torch.tensor([[4.0, 5.0]])
+    returned2 = tracker.consume(base + q2, _descriptor(2))
+
+    torch.testing.assert_close(returned2, base, rtol=0, atol=1e-6)
+    assert tracker.denoised_anchor_steps == (0, 1)
+
+
+def test_replay_keeps_exact_q_compensation_and_does_not_use_causal_dense_output():
+    tracker = _tracker()
+    tracker.consume(torch.tensor([[1.0, 2.0]]), _descriptor(0, mode="actual"))
+    q1 = _produce_pending(
+        tracker,
+        lambda_source=10.0,
+        lambda_target=4.0,
+        sigma_next=0.8,
+    )
+    base = torch.tensor([[7.0, 8.0]])
+    returned = tracker.consume(
+        base + q1,
+        _descriptor(1, mode="replay", replay_source_actual=False),
+    )
+
+    torch.testing.assert_close(returned, base, rtol=0, atol=1e-6)
+
+
+def test_dense_anchor_storage_is_bounded_and_clear_releases_it():
+    tracker = _tracker()
+    tracker.consume(torch.tensor([[0.0, 0.0]]), _descriptor(0, mode="actual"))
+    for step_id, (source, target) in enumerate(
+        ((10.0, 7.0), (7.0, 4.0), (4.0, 2.0)),
+        start=1,
+    ):
+        _produce_pending(
+            tracker,
+            lambda_source=source,
+            lambda_target=target,
+            sigma_next=max(0.1, 0.9 - 0.2 * step_id),
+        )
+        tracker.consume(
+            torch.full((1, 2), float(step_id)),
+            _descriptor(step_id, mode="actual"),
+        )
+
+    assert tracker.denoised_anchor_steps == (2, 3)
+    tracker.clear()
+    assert tracker.denoised_anchor_steps == ()
+    assert not tracker.has_pending

--- a/tests/test_er_sde_stochastic_compensation.py
+++ b/tests/test_er_sde_stochastic_compensation.py
@@ -403,7 +403,10 @@ def test_native_stage_one_callback_exposes_direct_leak_and_compensation_removes_
 
     assert not torch.equal(raw_callbacks[1], control_callbacks[1])
     torch.testing.assert_close(
-        corrected_callbacks[1], control_callbacks[1], rtol=0, atol=2e-8
+        corrected_callbacks[1],
+        control_callbacks[1],
+        rtol=0,
+        atol=torch.finfo(torch.float32).eps / 2,
     )
     torch.testing.assert_close(corrected_result, control_result, rtol=0, atol=0)
     assert not torch.equal(raw_result, control_result)
@@ -420,7 +423,12 @@ def test_corrected_denoised_enters_higher_order_history(max_stage):
 
     torch.testing.assert_close(corrected_result, control_result, rtol=0, atol=0)
     for corrected, control in zip(corrected_callbacks, control_callbacks, strict=True):
-        torch.testing.assert_close(corrected, control, rtol=0, atol=2e-8)
+        torch.testing.assert_close(
+            corrected,
+            control,
+            rtol=0,
+            atol=torch.finfo(torch.float32).eps / 2,
+        )
 
 
 def test_native_s_noise_zero_is_exact_noop_without_noise_or_q_allocation():

--- a/tests/test_er_sde_stochastic_compensation.py
+++ b/tests/test_er_sde_stochastic_compensation.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import comfyui_spectrum_h3.sampling as sampling_module
 from comfyui_spectrum_h3.config import SpectrumH3Config
 from comfyui_spectrum_h3.er_sde_stochastic import (
     ERSDEStepDescriptor,
@@ -23,12 +24,12 @@ from comfyui_spectrum_h3.sampling import (
     RUN_ID_KEY,
     STEP_ID_KEY,
     SpectrumH3Binding,
+    _copy_ksampler_with_options,
     _er_sde_tracking_contract,
     outer_sample_wrapper,
     predict_noise_wrapper,
     sampler_sample_wrapper,
 )
-import comfyui_spectrum_h3.sampling as sampling_module
 
 
 def _descriptor(
@@ -993,6 +994,60 @@ def test_effective_s_noise_zero_uses_untouched_native_path_without_tracker(monke
     assert ER_SDE_TRACKER_KEY not in observed_model_options[0]["transformer_options"]
     assert runtime.disabled_reason is None
     runtime.end_run(run_id)
+
+
+def test_ksampler_shallow_copies_are_isolated_and_preserve_instance_state():
+    sampler_function = lambda *_args: None
+    original_options = {"s_noise": 1.0}
+    inpaint_options = {"random": False}
+    retained_state = object()
+
+    class NativeSampler:
+        def __init__(self):
+            self.sampler_function = sampler_function
+            self.extra_options = original_options
+            self.inpaint_options = inpaint_options
+            self.retained_state = retained_state
+
+        def sample(self, *_args):
+            raise AssertionError("copy validation must not invoke the sampler")
+
+    sampler = NativeSampler()
+    first_options = {"noise_sampler": object()}
+    second_options = {"noise_sampler": object()}
+
+    first, first_failure = _copy_ksampler_with_options(sampler, first_options)
+    second, second_failure = _copy_ksampler_with_options(sampler, second_options)
+
+    assert first_failure is None
+    assert second_failure is None
+    assert first is not None and second is not None
+    assert first is not second and first is not sampler and second is not sampler
+    assert first.extra_options is first_options
+    assert second.extra_options is second_options
+    assert sampler.extra_options is original_options
+    assert first.inpaint_options is second.inpaint_options is inpaint_options
+    assert first.retained_state is second.retained_state is retained_state
+    assert first.sampler_function is second.sampler_function is sampler_function
+
+
+def test_ksampler_custom_copy_descriptor_fails_closed():
+    class CustomCopySampler:
+        def __init__(self):
+            self.sampler_function = lambda *_args: None
+            self.extra_options = {}
+            self.inpaint_options = {}
+
+        def __copy__(self):
+            return self
+
+        def sample(self, *_args):
+            return None
+
+    copied, failure = _copy_ksampler_with_options(CustomCopySampler(), {})
+
+    assert copied is None
+    assert failure == "KSAMPLER defines an unreviewed custom __copy__ method"
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")

--- a/tests/test_er_sde_stochastic_compensation.py
+++ b/tests/test_er_sde_stochastic_compensation.py
@@ -1,0 +1,997 @@
+from __future__ import annotations
+
+import ast
+import copy
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.er_sde_stochastic import (
+    ERSDEStepDescriptor,
+    ERSDEStochasticTracker,
+    ERSDETrackingError,
+)
+from comfyui_spectrum_h3.runtime import OfflineReplayAbort, SpectrumH3Runtime
+from comfyui_spectrum_h3.sampling import (
+    ACTUAL_KEY,
+    BINDING_KEY,
+    ER_SDE_TRACKER_KEY,
+    RUN_ID_KEY,
+    STEP_ID_KEY,
+    SpectrumH3Binding,
+    _er_sde_tracking_contract,
+    outer_sample_wrapper,
+    predict_noise_wrapper,
+    sampler_sample_wrapper,
+)
+import comfyui_spectrum_h3.sampling as sampling_module
+
+
+def _descriptor(
+    step_id: int,
+    *,
+    mode: str = "forecast",
+    replay_source_actual: bool | None = None,
+) -> ERSDEStepDescriptor:
+    return ERSDEStepDescriptor(
+        run_id=7,
+        step_id=step_id,
+        mode=mode,
+        replay_source_actual=replay_source_actual,
+        requires_compensation=(
+            mode == "forecast"
+            or (mode == "replay" and replay_source_actual is False)
+        ),
+    )
+
+
+def _tracker(
+    noise: torch.Tensor | None = None,
+    *,
+    dtype: torch.dtype = torch.float32,
+) -> ERSDEStochasticTracker:
+    sample = torch.tensor([[2.0, -3.0]], dtype=dtype) if noise is None else noise
+    return ERSDEStochasticTracker(
+        noise_sampler=lambda _sigma, _sigma_next: sample,
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=0.5,
+        max_stage=3,
+        debug=False,
+        run_id=7,
+    )
+
+
+def _produce_pending(tracker: ERSDEStochasticTracker) -> torch.Tensor:
+    er_lambda_t = torch.tensor(0.5)
+    er_lambda_s = torch.tensor(1.0)
+    tracker.noise_scaler(er_lambda_t)
+    tracker.noise_scaler(er_lambda_s)
+    noise = tracker.noise_sampler(torch.tensor(0.8), torch.tensor(0.4))
+    r = er_lambda_t**2 / er_lambda_s**2
+    expected = (torch.tensor(0.4) / er_lambda_t) * noise
+    expected = expected * 0.5
+    expected = expected * (
+        er_lambda_t**2 - er_lambda_s**2 * r**2
+    ).sqrt().nan_to_num(nan=0.0)
+    return expected
+
+
+def test_first_model_result_has_no_pending_noise_and_is_unchanged():
+    tracker = _tracker()
+    denoised = torch.tensor([[4.0, 5.0]])
+
+    assert tracker.consume(denoised, _descriptor(0)) is denoised
+
+
+def test_forecast_subtracts_exact_pending_increment_once():
+    tracker = _tracker()
+    expected_q = _produce_pending(tracker)
+    raw = torch.tensor([[4.0, 5.0]]) + expected_q
+
+    corrected = tracker.consume(raw, _descriptor(1))
+
+    torch.testing.assert_close(corrected, torch.tensor([[4.0, 5.0]]), rtol=0, atol=0)
+    assert not tracker.has_pending
+    with pytest.raises(ERSDETrackingError, match="no preceding"):
+        tracker.consume(raw, _descriptor(1))
+
+
+@pytest.mark.parametrize(
+    ("mode", "replay_source_actual"),
+    (("actual", None), ("replay", True)),
+)
+def test_state_aware_actual_or_replay_anchor_consumes_without_correction(
+    mode, replay_source_actual
+):
+    tracker = _tracker()
+    _produce_pending(tracker)
+    denoised = torch.tensor([[4.0, 5.0]])
+
+    result = tracker.consume(
+        denoised,
+        _descriptor(
+            1,
+            mode=mode,
+            replay_source_actual=replay_source_actual,
+        ),
+    )
+
+    assert result is denoised
+    assert not tracker.has_pending
+
+
+def test_replay_of_smoothed_step_is_compensated():
+    tracker = _tracker()
+    expected_q = _produce_pending(tracker)
+    base = torch.tensor([[4.0, 5.0]])
+
+    corrected = tracker.consume(
+        base + expected_q,
+        _descriptor(1, mode="replay", replay_source_actual=False),
+    )
+
+    torch.testing.assert_close(corrected, base, rtol=0, atol=0)
+
+
+def test_stale_step_cannot_consume_pending_increment():
+    tracker = _tracker()
+    _produce_pending(tracker)
+
+    with pytest.raises(ERSDETrackingError, match="targets step 1"):
+        tracker.consume(torch.ones((1, 2)), _descriptor(2))
+
+    assert not tracker.has_pending
+
+
+def test_packed_shape_dtype_and_device_must_match_without_broadcasting():
+    tracker = _tracker(dtype=torch.float16)
+    _produce_pending(tracker)
+
+    with pytest.raises(ERSDETrackingError, match="exactly match"):
+        tracker.consume(torch.ones((1, 2, 1), dtype=torch.float16), _descriptor(1))
+
+    assert not tracker.has_pending
+
+
+def test_noise_sample_is_returned_unchanged_and_pending_owns_new_storage():
+    noise = torch.tensor([[2.0, -3.0]])
+    tracker = _tracker(noise)
+
+    _produce_pending(tracker)
+
+    assert tracker.has_pending
+    assert noise.tolist() == [[2.0, -3.0]]
+    assert tracker._pending is not None
+    assert tracker._pending.value.data_ptr() != noise.data_ptr()
+
+
+def test_clear_releases_pending_state_between_generations():
+    tracker = _tracker()
+    _produce_pending(tracker)
+    tracker.clear()
+
+    assert not tracker.has_pending
+    assert tracker.consume(torch.ones((1, 2)), _descriptor(0)) is not None
+
+
+def test_second_noise_interval_before_consumption_fails_without_overwriting_q():
+    tracker = _tracker()
+    _produce_pending(tracker)
+    tracker.noise_scaler(torch.tensor(0.25))
+    tracker.noise_scaler(torch.tensor(0.5))
+
+    with pytest.raises(ERSDETrackingError, match="second stochastic increment"):
+        tracker.noise_sampler(torch.tensor(0.4), torch.tensor(0.2))
+
+    assert tracker.pending_step_id == 1
+    tracker.clear()
+
+
+def _native_er_sde_function():
+    comfyui_path = os.environ.get("COMFYUI_PATH")
+    if not comfyui_path:
+        pytest.skip("COMFYUI_PATH is required for the synthetic native ER-SDE test")
+    source_path = Path(comfyui_path) / "comfy/k_diffusion/sampling.py"
+    module = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    function = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and node.name == "sample_er_sde"
+    )
+    function = copy.deepcopy(function)
+    function.decorator_list = []
+    compiled = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {
+        "torch": torch,
+        "trange": lambda count, disable=None: range(count),
+        "default_noise_sampler": object(),
+        "offset_first_sigma_for_snr": lambda sigmas, _sampling: sigmas,
+        "sigma_to_half_log_snr": lambda sigmas, _sampling: -torch.log(sigmas.sqrt()),
+    }
+    exec(  # noqa: S102 - execute the reviewed native function in a closed test namespace
+        compile(compiled, "<native sample_er_sde>", "exec"), namespace
+    )
+    return namespace["sample_er_sde"]
+
+
+def _seeded_native_run(descriptor_factory=None):
+    native_er_sde = _native_er_sde_function()
+    model_sampling = SimpleNamespace(noise_scale=1.0)
+    generator = torch.Generator(device="cpu").manual_seed(8675309)
+    noise_draws = []
+    callbacks = []
+
+    class Patcher:
+        def get_model_object(self, name):
+            assert name == "model_sampling"
+            return model_sampling
+
+    def base_noise_sampler(_sigma, _sigma_next):
+        noise = torch.randn((1, 2), generator=generator, dtype=torch.float32)
+        noise_draws.append(noise.clone())
+        return noise
+
+    tracker = None
+    if descriptor_factory is not None:
+        tracker = ERSDEStochasticTracker(
+            noise_sampler=base_noise_sampler,
+            noise_scaler=lambda value: value**2,
+            effective_s_noise=0.7,
+            max_stage=3,
+            debug=False,
+            run_id=7,
+        )
+    model_calls = 0
+
+    class Model:
+        inner_model = SimpleNamespace(model_patcher=Patcher())
+
+        def __call__(self, x, sigma, **_extra_args):
+            nonlocal model_calls
+            sigma_view = sigma.reshape(-1, *([1] * (x.ndim - 1)))
+            denoised = x * 0.25 + sigma_view * 0.05
+            if tracker is not None:
+                descriptor = descriptor_factory(model_calls)
+                if descriptor.requires_compensation:
+                    assert tracker._pending is not None
+                    denoised = denoised + tracker._pending.value
+                denoised = tracker.consume(denoised, descriptor)
+            model_calls += 1
+            return denoised
+
+    result = native_er_sde(
+        Model(),
+        torch.ones((1, 2), dtype=torch.float32),
+        torch.tensor([0.9, 0.7, 0.5, 0.3, 0.0]),
+        callback=lambda state: callbacks.append(state["denoised"].clone()),
+        disable=True,
+        s_noise=0.7,
+        noise_sampler=(tracker.noise_sampler if tracker is not None else base_noise_sampler),
+        noise_scaler=(tracker.noise_scaler if tracker is not None else lambda value: value**2),
+        max_stage=3,
+    )
+    if tracker is not None:
+        assert not tracker.has_pending
+        assert tracker.noise_calls == len(noise_draws)
+        tracker.clear()
+    return result, callbacks, noise_draws
+
+
+def test_all_actual_tracking_is_bitwise_identical_to_native_er_sde():
+    native = _seeded_native_run()
+    tracked = _seeded_native_run(
+        lambda step_id: _descriptor(step_id, mode="actual")
+    )
+
+    assert torch.equal(native[0], tracked[0])
+    assert all(
+        torch.equal(native_value, tracked_value)
+        for native_value, tracked_value in zip(native[1], tracked[1], strict=True)
+    )
+    assert all(
+        torch.equal(native_value, tracked_value)
+        for native_value, tracked_value in zip(native[2], tracked[2], strict=True)
+    )
+
+
+def test_seeded_first_pass_and_replay_consume_identical_stochastic_streams():
+    source_actual = (True, True, False, True)
+    first_pass = _seeded_native_run(
+        lambda step_id: _descriptor(
+            step_id,
+            mode="actual" if source_actual[step_id] else "forecast",
+        )
+    )
+    replay = _seeded_native_run(
+        lambda step_id: _descriptor(
+            step_id,
+            mode="replay",
+            replay_source_actual=source_actual[step_id],
+        )
+    )
+
+    assert torch.equal(first_pass[0], replay[0])
+    assert len(first_pass[2]) == len(replay[2]) == 3
+    assert all(
+        torch.equal(first_value, replay_value)
+        for first_value, replay_value in zip(first_pass[1], replay[1], strict=True)
+    )
+    assert all(
+        torch.equal(first_value, replay_value)
+        for first_value, replay_value in zip(first_pass[2], replay[2], strict=True)
+    )
+
+
+def _synthetic_solver_run(max_stage: int, *, compensate: bool, state_aware: bool = False):
+    native_er_sde = _native_er_sde_function()
+    model_sampling = SimpleNamespace(noise_scale=1.0)
+    latest_q = None
+    callbacks = []
+
+    class Patcher:
+        def get_model_object(self, name):
+            assert name == "model_sampling"
+            return model_sampling
+
+    deterministic_noise = torch.tensor([[0.75, -0.5]], dtype=torch.float32)
+
+    def base_noise_sampler(sigma, sigma_next):
+        nonlocal latest_q
+        er_lambda_s = sigma.sqrt()
+        er_lambda_t = sigma_next.sqrt()
+        r = er_lambda_t**2 / er_lambda_s**2
+        latest_q = (sigma_next / er_lambda_t) * deterministic_noise
+        latest_q = latest_q * (
+            er_lambda_t**2 - er_lambda_s**2 * r**2
+        ).sqrt().nan_to_num(nan=0.0)
+        return deterministic_noise
+
+    tracker = ERSDEStochasticTracker(
+        noise_sampler=base_noise_sampler,
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=1.0,
+        max_stage=max_stage,
+        debug=False,
+        run_id=7,
+    )
+    model_calls = 0
+
+    class Model:
+        inner_model = SimpleNamespace(model_patcher=Patcher())
+
+        def __call__(self, x, _sigma, **_extra_args):
+            nonlocal model_calls
+            base = torch.full_like(x, 0.125)
+            if model_calls > 0 and not state_aware:
+                assert latest_q is not None
+                raw = base + latest_q
+            else:
+                raw = base
+            if compensate or state_aware:
+                mode = "forecast" if compensate else "actual"
+                raw = tracker.consume(raw, _descriptor(model_calls, mode=mode))
+            model_calls += 1
+            return raw
+
+    tracked = compensate or state_aware
+    result = native_er_sde(
+        Model(),
+        torch.zeros((1, 2), dtype=torch.float32),
+        torch.tensor([0.9, 0.7, 0.5, 0.3, 0.0]),
+        callback=lambda state: callbacks.append(state["denoised"].clone()),
+        disable=True,
+        noise_sampler=tracker.noise_sampler if tracked else base_noise_sampler,
+        noise_scaler=tracker.noise_scaler if tracked else (lambda value: value**2),
+        max_stage=max_stage,
+    )
+    if tracked:
+        assert not tracker.has_pending
+    tracker.clear()
+    return result, callbacks
+
+
+def test_native_stage_one_callback_exposes_direct_leak_and_compensation_removes_it():
+    raw_result, raw_callbacks = _synthetic_solver_run(1, compensate=False)
+    corrected_result, corrected_callbacks = _synthetic_solver_run(1, compensate=True)
+    control_result, control_callbacks = _synthetic_solver_run(
+        1, compensate=False, state_aware=True
+    )
+
+    assert not torch.equal(raw_callbacks[1], control_callbacks[1])
+    torch.testing.assert_close(
+        corrected_callbacks[1], control_callbacks[1], rtol=0, atol=2e-8
+    )
+    torch.testing.assert_close(corrected_result, control_result, rtol=0, atol=0)
+    assert not torch.equal(raw_result, control_result)
+
+
+@pytest.mark.parametrize("max_stage", (2, 3))
+def test_corrected_denoised_enters_higher_order_history(max_stage):
+    corrected_result, corrected_callbacks = _synthetic_solver_run(
+        max_stage, compensate=True
+    )
+    control_result, control_callbacks = _synthetic_solver_run(
+        max_stage, compensate=False, state_aware=True
+    )
+
+    torch.testing.assert_close(corrected_result, control_result, rtol=0, atol=0)
+    for corrected, control in zip(corrected_callbacks, control_callbacks, strict=True):
+        torch.testing.assert_close(corrected, control, rtol=0, atol=2e-8)
+
+
+def test_native_s_noise_zero_is_exact_noop_without_noise_or_q_allocation():
+    native_er_sde = _native_er_sde_function()
+    model_sampling = SimpleNamespace(noise_scale=1.0)
+    noise_calls = []
+
+    class Patcher:
+        def get_model_object(self, _name):
+            return model_sampling
+
+    class Model:
+        inner_model = SimpleNamespace(model_patcher=Patcher())
+
+        def __call__(self, x, _sigma, **_extra_args):
+            return torch.full_like(x, 0.25)
+
+    result = native_er_sde(
+        Model(),
+        torch.zeros((1, 2)),
+        torch.tensor([0.9, 0.6, 0.3, 0.0]),
+        disable=True,
+        s_noise=0.0,
+        noise_sampler=lambda *_args: noise_calls.append(True),
+        noise_scaler=lambda value: value**2,
+    )
+
+    assert torch.isfinite(result).all()
+    assert noise_calls == []
+
+
+def test_current_native_er_sde_runtime_contract_is_accepted():
+    if not os.environ.get("COMFYUI_PATH"):
+        pytest.skip("COMFYUI_PATH is required for the native runtime contract")
+    try:
+        import comfy.samplers
+    except ModuleNotFoundError as exc:
+        pytest.skip(f"optional ComfyUI runtime dependency is unavailable: {exc}")
+
+    supported, reason = _er_sde_tracking_contract(
+        comfy.samplers.ksampler("er_sde")
+    )
+
+    assert supported, reason
+
+
+def _complete_runtime_step(runtime: SpectrumH3Runtime, decision, feature_value: float):
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=(("target_audio_rows", 1), ("target_video_rows", 1)),
+        labels=((0, "positive"),),
+        expected_shape=(1, 2, 1),
+    )
+    if actual:
+        runtime.observe_actual(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            torch.full((1, 2, 1), feature_value),
+        )
+    else:
+        assert runtime.predict(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        ) is not None
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+
+def test_runtime_classifies_causal_actual_and_forecast_steps():
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            warmup_steps=1,
+            tail_actual_steps=0,
+            max_history=4,
+            window_size=3.0,
+            offline_smoothing_replay=False,
+            model_aware_mode="off",
+            bootstrap_first_forecast=False,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.8, 0.6, 0.4, 0.0]),
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    first = runtime.begin_step(torch.tensor(1.0))
+    first_descriptor = runtime.describe_current_er_sde_step(run_id, first["step_id"])
+    assert first_descriptor.mode == "actual"
+    assert not first_descriptor.requires_compensation
+    _complete_runtime_step(runtime, first, 1.0)
+
+    second = runtime.begin_step(torch.tensor(0.8))
+    _complete_runtime_step(runtime, second, 0.8)
+    third = runtime.begin_step(torch.tensor(0.6))
+    third_descriptor = runtime.describe_current_er_sde_step(run_id, third["step_id"])
+    assert third_descriptor.mode == "forecast"
+    assert third_descriptor.requires_compensation
+    runtime.abort_step(run_id, third["step_id"])
+    runtime.end_run(run_id)
+
+
+def _runtime_ready_for_step_two_forecast():
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            warmup_steps=1,
+            tail_actual_steps=0,
+            max_history=4,
+            window_size=3.0,
+            offline_smoothing_replay=False,
+            model_aware_mode="off",
+            bootstrap_first_forecast=False,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.8, 0.6, 0.0]),
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    first = runtime.begin_step(torch.tensor(1.0))
+    _complete_runtime_step(runtime, first, 1.0)
+    second = runtime.begin_step(torch.tensor(0.8))
+    _complete_runtime_step(runtime, second, 0.8)
+    return runtime, run_id
+
+
+def _tracker_targeting_step_two(run_id: int):
+    tracker = ERSDEStochasticTracker(
+        noise_sampler=lambda _sigma, _sigma_next: torch.tensor([[2.0, -3.0]]),
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=0.5,
+        max_stage=3,
+        debug=False,
+        run_id=run_id,
+    )
+    _produce_pending(tracker)
+    tracker.consume(torch.zeros((1, 2)), ERSDEStepDescriptor(run_id, 1, "actual", None, False))
+    q = _produce_pending(tracker)
+    return tracker, q
+
+
+def test_predict_wrapper_corrects_before_returning_forecast_to_sampler():
+    runtime, run_id = _runtime_ready_for_step_two_forecast()
+    tracker, q = _tracker_targeting_step_two(run_id)
+    guider = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime)}
+    )
+    base = torch.tensor([[4.0, 5.0]])
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, _x, _timestep, model_options, _seed):
+            options = model_options["transformer_options"]
+            call_id, actual = runtime.begin_model_call(
+                options[RUN_ID_KEY],
+                options[STEP_ID_KEY],
+                topology=(("target_audio_rows", 1), ("target_video_rows", 1)),
+                labels=((0, "positive"),),
+                expected_shape=(1, 2, 1),
+            )
+            assert not actual
+            assert runtime.predict(
+                options[RUN_ID_KEY],
+                options[STEP_ID_KEY],
+                call_id,
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            ) is not None
+            return base + q
+
+    result = predict_noise_wrapper(
+        Executor(),
+        torch.zeros((1, 2)),
+        torch.tensor(0.6),
+        {"transformer_options": {ER_SDE_TRACKER_KEY: tracker}},
+        seed=9,
+    )
+
+    torch.testing.assert_close(result, base, rtol=0, atol=0)
+    assert runtime.last_completed_mode == "forecast"
+    assert not tracker.has_pending
+    runtime.end_run(run_id)
+
+
+def test_missing_pending_increment_retries_same_step_as_actual():
+    runtime, run_id = _runtime_ready_for_step_two_forecast()
+    tracker = ERSDEStochasticTracker(
+        noise_sampler=lambda *_args: torch.zeros((1, 2)),
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=0.5,
+        max_stage=3,
+        debug=False,
+        run_id=run_id,
+    )
+    guider = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime)}
+    )
+    attempts = []
+    actual_result = torch.tensor([[7.0, 8.0]])
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, _x, _timestep, model_options, _seed):
+            options = model_options["transformer_options"]
+            call_id, actual = runtime.begin_model_call(
+                options[RUN_ID_KEY],
+                options[STEP_ID_KEY],
+                topology=(("target_audio_rows", 1), ("target_video_rows", 1)),
+                labels=((0, "positive"),),
+                expected_shape=(1, 2, 1),
+            )
+            attempts.append(bool(options[ACTUAL_KEY]))
+            if actual:
+                runtime.observe_actual(
+                    options[RUN_ID_KEY],
+                    options[STEP_ID_KEY],
+                    call_id,
+                    torch.ones((1, 2, 1)),
+                )
+            else:
+                assert runtime.predict(
+                    options[RUN_ID_KEY],
+                    options[STEP_ID_KEY],
+                    call_id,
+                    device=torch.device("cpu"),
+                    dtype=torch.float32,
+                ) is not None
+            return actual_result
+
+    result = predict_noise_wrapper(
+        Executor(),
+        torch.zeros((1, 2)),
+        torch.tensor(0.6),
+        {"transformer_options": {ER_SDE_TRACKER_KEY: tracker}},
+        seed=9,
+    )
+
+    assert result is actual_result
+    assert attempts == [False, True]
+    assert runtime.last_completed_mode == "actual"
+    assert runtime.stats.forecast_fallbacks == 1
+    runtime.end_run(run_id)
+
+
+def test_runtime_classifies_replay_anchor_and_smoothed_source():
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            warmup_steps=1,
+            tail_actual_steps=1,
+            max_history=6,
+            window_size=3.0,
+            offline_smoothing_replay=True,
+            model_aware_mode="off",
+            bootstrap_first_forecast=False,
+        )
+    )
+    sigmas = torch.tensor([1.0, 0.8, 0.6, 0.4, 0.2, 0.0])
+    runtime.begin_offline_capture(total_steps=5, sampler_name="sample_er_sde")
+    capture_run = runtime.start_run(
+        sigmas,
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    source_actual = []
+    for index, sigma in enumerate(sigmas[:-1]):
+        decision = runtime.begin_step(sigma)
+        source_actual.append(bool(decision["actual"]))
+        _complete_runtime_step(runtime, decision, float(index))
+    runtime.end_run(capture_run)
+    assert source_actual == [True, True, False, True, True]
+    assert runtime.complete_offline_capture()
+    runtime.begin_offline_replay()
+
+    replay_run = runtime.start_run(
+        sigmas,
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    descriptors = []
+    for index, sigma in enumerate(sigmas[:-1]):
+        decision = runtime.begin_step(sigma)
+        descriptors.append(
+            runtime.describe_current_er_sde_step(replay_run, decision["step_id"])
+        )
+        _complete_runtime_step(runtime, decision, float(index))
+    runtime.end_run(replay_run)
+    runtime.release_offline_archive()
+
+    assert descriptors[0].mode == "replay"
+    assert descriptors[0].replay_source_actual is True
+    assert not descriptors[0].requires_compensation
+    assert descriptors[2].replay_source_actual is False
+    assert descriptors[2].requires_compensation
+
+
+def test_replay_tracking_failure_aborts_to_first_pass_instead_of_retrying_actual():
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            warmup_steps=1,
+            tail_actual_steps=1,
+            max_history=6,
+            window_size=3.0,
+            offline_smoothing_replay=True,
+            model_aware_mode="off",
+            bootstrap_first_forecast=False,
+        )
+    )
+    sigmas = torch.tensor([1.0, 0.8, 0.6, 0.4, 0.2, 0.0])
+    runtime.begin_offline_capture(total_steps=5, sampler_name="sample_er_sde")
+    capture_run = runtime.start_run(
+        sigmas,
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    for index, sigma in enumerate(sigmas[:-1]):
+        decision = runtime.begin_step(sigma)
+        _complete_runtime_step(runtime, decision, float(index))
+    runtime.end_run(capture_run)
+    assert runtime.complete_offline_capture()
+    runtime.begin_offline_replay()
+    replay_run = runtime.start_run(
+        sigmas,
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    for sigma in sigmas[:2]:
+        decision = runtime.begin_step(sigma)
+        _complete_runtime_step(runtime, decision, 0.0)
+
+    tracker = ERSDEStochasticTracker(
+        noise_sampler=lambda *_args: torch.zeros((1, 2)),
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=0.5,
+        max_stage=3,
+        debug=False,
+        run_id=replay_run,
+    )
+    guider = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime)}
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, _x, _timestep, model_options, _seed):
+            options = model_options["transformer_options"]
+            call_id, actual = runtime.begin_model_call(
+                options[RUN_ID_KEY],
+                options[STEP_ID_KEY],
+                topology=(("target_audio_rows", 1), ("target_video_rows", 1)),
+                labels=((0, "positive"),),
+                expected_shape=(1, 2, 1),
+            )
+            assert not actual
+            assert runtime.predict(
+                options[RUN_ID_KEY],
+                options[STEP_ID_KEY],
+                call_id,
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            ) is not None
+            return torch.zeros((1, 2))
+
+    with pytest.raises(OfflineReplayAbort, match="failed during replay"):
+        predict_noise_wrapper(
+            Executor(),
+            torch.zeros((1, 2)),
+            torch.tensor(0.6),
+            {"transformer_options": {ER_SDE_TRACKER_KEY: tracker}},
+            seed=9,
+        )
+
+    assert runtime.active_step_id is None
+    runtime.end_run(replay_run)
+    runtime.release_offline_archive()
+
+
+def test_exception_cleanup_cannot_contaminate_next_tracker():
+    first = _tracker()
+    _produce_pending(first)
+    first.clear()
+    second = _tracker()
+
+    assert not first.has_pending
+    assert second.consume(torch.ones((1, 2)), _descriptor(0)) is not None
+
+
+def _active_er_sde_runtime():
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            offline_smoothing_replay=False,
+            model_aware_mode="off",
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+    )
+    return runtime, run_id
+
+
+def test_unreviewed_er_sde_contract_fails_closed_to_native_all_actual(
+    monkeypatch, caplog
+):
+    runtime, run_id = _active_er_sde_runtime()
+    model_wrap = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime)}
+    )
+    sampler = SimpleNamespace(
+        sampler_function=SimpleNamespace(__name__="sample_er_sde"),
+        extra_options={"noise_sampler": object()},
+    )
+    calls = []
+
+    class Executor:
+        class_obj = sampler
+
+        def __init__(self):
+            self.wrappers = [sampler_sample_wrapper]
+
+        def __call__(self, *args):
+            calls.append(args)
+            return "native-all-actual"
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_er_sde_tracking_contract",
+        lambda _sampler: (False, "custom ER-SDE noise_sampler provenance is unreviewed"),
+    )
+    with caplog.at_level("WARNING"):
+        result = sampler_sample_wrapper(
+            Executor(),
+            model_wrap,
+            torch.tensor([1.0, 0.5, 0.0]),
+            {"model_options": {}},
+            None,
+            torch.ones((1, 2)),
+            torch.zeros((1, 2)),
+            None,
+            True,
+        )
+
+    assert result == "native-all-actual"
+    assert len(calls) == 1
+    assert runtime.disabled_reason == "custom ER-SDE noise_sampler provenance is unreviewed"
+    assert "preserving native all-actual sampling" in caplog.text
+    runtime.end_run(run_id)
+
+
+def test_native_preflight_failure_bypasses_spectrum_before_run_start(
+    monkeypatch, caplog
+):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(offline_smoothing_replay=False, model_aware_mode="off")
+    )
+    guider = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime), "transformer_options": {}}
+    )
+    sampler = SimpleNamespace(
+        sampler_function=SimpleNamespace(__name__="sample_er_sde"),
+        extra_options={},
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            assert runtime.active_run_id is None
+            return "untouched-native"
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_er_sde_preflight_reason",
+        lambda _sampler, _options: "reviewed source digest changed",
+    )
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones((1, 2)),
+            torch.zeros((1, 2)),
+            sampler,
+            torch.tensor([1.0, 0.0]),
+            seed=9,
+        )
+
+    assert result == "untouched-native"
+    assert runtime.active_run_id is None
+    assert "untouched native sampler" in caplog.text
+
+
+def test_effective_s_noise_zero_uses_untouched_native_path_without_tracker(monkeypatch):
+    runtime, run_id = _active_er_sde_runtime()
+
+    class Patcher:
+        def get_model_object(self, name):
+            assert name == "model_sampling"
+            return SimpleNamespace(noise_scale=1.0)
+
+    model_wrap = SimpleNamespace(
+        model_options={BINDING_KEY: SpectrumH3Binding(runtime)},
+        model_patcher=Patcher(),
+    )
+    sampler = SimpleNamespace(
+        sampler_function=SimpleNamespace(__name__="sample_er_sde"),
+        extra_options={"s_noise": 0.0, "max_stage": 3},
+    )
+    observed_model_options = []
+
+    class Executor:
+        class_obj = sampler
+
+        def __init__(self):
+            self.wrappers = [sampler_sample_wrapper]
+
+        def __call__(self, *args):
+            observed_model_options.append(args[2]["model_options"])
+            return args[4]
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_er_sde_tracking_contract",
+        lambda _sampler: (True, None),
+    )
+    noise = torch.ones((1, 2))
+    result = sampler_sample_wrapper(
+        Executor(),
+        model_wrap,
+        torch.tensor([1.0, 0.5, 0.0]),
+        {"model_options": {"transformer_options": {}}},
+        None,
+        noise,
+        torch.zeros((1, 2)),
+        None,
+        True,
+    )
+
+    assert result is noise
+    assert ER_SDE_TRACKER_KEY not in observed_model_options[0]["transformer_options"]
+    assert runtime.disabled_reason is None
+    runtime.end_run(run_id)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")
+def test_cuda_increment_stays_on_device_without_dtype_promotion():
+    noise = torch.tensor([[2.0, -3.0]], device="cuda", dtype=torch.float16)
+    tracker = _tracker(noise, dtype=torch.float16)
+    _produce_pending(tracker)
+    assert tracker._pending is not None
+    assert tracker._pending.value.device.type == "cuda"
+    assert tracker._pending.value.dtype == torch.float16

--- a/tests/test_postrun_safety.py
+++ b/tests/test_postrun_safety.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+
+from comfyui_spectrum_h3 import postrun_safety as postrun
+from comfyui_spectrum_h3.generic_correction_calibration import GenericCalibrationState
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
+
+
+def _fake_runtime(run_id: int = 7):
+    calibration = GenericCalibrationState(
+        enabled=True,
+        run_id=run_id,
+        sampler_name="sample_er_sde",
+        total_steps=2,
+        schedule=(1.0, 0.0),
+        config_snapshot={},
+        rows=[{"scalar": 1.0}],
+    )
+    forecaster = SimpleNamespace(
+        history_tensor_bytes=3_400_000_000,
+        persistent_tensor_bytes=3_400_262_144,
+        history_device="cuda:0",
+        history_length=8,
+        _generic_correction_capture_mode="full",
+    )
+    return SimpleNamespace(
+        _run=SimpleNamespace(run_id=run_id),
+        config=SimpleNamespace(debug=False),
+        forecaster=forecaster,
+        model_aware=SimpleNamespace(_generic_correction_controller=object()),
+        _generic_correction_calibration=calibration,
+        _generic_correction_controller=object(),
+    )
+
+
+def test_safe_end_releases_runtime_before_dispatching_research(monkeypatch):
+    runtime = _fake_runtime()
+    events = []
+
+    def emit(_runtime, _state):
+        events.append("emit")
+        return {"compatible": True}
+
+    def core_end(instance, run_id):
+        events.append("core_end")
+        assert run_id == 7
+        instance._run = None
+
+    def dispatch(block):
+        events.append("dispatch")
+        assert block == {"compatible": True}
+        assert runtime._run is None
+        return True
+
+    monkeypatch.setattr(postrun._generic, "emit_calibration_block", emit)
+    monkeypatch.setattr(postrun, "_CORE_RUNTIME_END", core_end)
+    monkeypatch.setattr(postrun, "_dispatch_research", dispatch)
+
+    postrun._safe_end_run(runtime, 7)
+
+    assert events == ["emit", "core_end", "dispatch"]
+    assert runtime._generic_correction_controller is None
+    assert runtime._generic_correction_calibration is None
+    assert runtime.model_aware._generic_correction_controller is None
+    assert runtime.forecaster._generic_correction_capture_mode is None
+
+
+def test_dispatch_research_never_waits_for_worker_completion(monkeypatch):
+    monkeypatch.setattr(postrun, "_RESEARCH_SLOT", threading.BoundedSemaphore(1))
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def persist(_block):
+        started.set()
+        assert release.wait(timeout=2.0)
+        finished.set()
+        return SimpleNamespace(
+            duplicate=False,
+            console_summary="synthetic research",
+            elapsed_seconds=0.01,
+        )
+
+    monkeypatch.setattr(postrun._generic, "persist_and_analyze", persist)
+
+    began = time.perf_counter()
+    assert postrun._dispatch_research({"compatible": True})
+    elapsed = time.perf_counter() - began
+
+    assert elapsed < 0.25
+    assert started.wait(timeout=1.0)
+    assert not finished.is_set()
+    assert not postrun._dispatch_research({"compatible": True})
+
+    release.set()
+    assert finished.wait(timeout=1.0)
+    deadline = time.monotonic() + 1.0
+    acquired = False
+    while time.monotonic() < deadline:
+        if postrun._RESEARCH_SLOT.acquire(blocking=False):
+            acquired = True
+            break
+        time.sleep(0.01)
+    assert acquired
+    postrun._RESEARCH_SLOT.release()
+
+
+def test_background_research_failure_releases_single_worker_slot(monkeypatch):
+    monkeypatch.setattr(postrun, "_RESEARCH_SLOT", threading.BoundedSemaphore(1))
+    attempted = threading.Event()
+
+    def persist(_block):
+        attempted.set()
+        raise OSError("synthetic report failure")
+
+    monkeypatch.setattr(postrun._generic, "persist_and_analyze", persist)
+
+    assert postrun._dispatch_research({"compatible": True})
+    assert attempted.wait(timeout=1.0)
+
+    deadline = time.monotonic() + 1.0
+    acquired = False
+    while time.monotonic() < deadline:
+        if postrun._RESEARCH_SLOT.acquire(blocking=False):
+            acquired = True
+            break
+        time.sleep(0.01)
+    assert acquired
+    postrun._RESEARCH_SLOT.release()
+
+
+def test_installed_runtime_end_run_uses_postrun_safety():
+    assert SpectrumH3Runtime.end_run is postrun._safe_end_run

--- a/tests/test_sampler_contract.py
+++ b/tests/test_sampler_contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import copy
-import hashlib
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +9,8 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from comfyui_spectrum_h3.er_sde_ksampler_contract import validate_ksampler_sample
+from comfyui_spectrum_h3.er_sde_stochastic import function_node_ast_digest
 from comfyui_spectrum_h3.sampling import (
     ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST,
     ER_SDE_KSAMPLER_SAMPLE_DIGEST,
@@ -71,11 +72,222 @@ def _loaded_names(node: ast.AST) -> set[str]:
 
 
 def _ast_digest(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
-    normalized = copy.deepcopy(node)
-    normalized.decorator_list = []
-    return hashlib.sha256(
-        ast.dump(normalized, include_attributes=False).encode("utf-8")
-    ).hexdigest()
+    return function_node_ast_digest(node)
+
+
+def _native_ksampler_sample() -> ast.FunctionDef:
+    samplers_tree = _native_tree("comfy/samplers.py")
+    ksampler = next(
+        node
+        for node in samplers_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "KSAMPLER"
+    )
+    return copy.deepcopy(
+        next(
+            node
+            for node in ksampler.body
+            if isinstance(node, ast.FunctionDef) and node.name == "sample"
+        )
+    )
+
+
+def _call_path(node: ast.AST) -> tuple[str, ...] | None:
+    parts = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return tuple(reversed(parts))
+
+
+def _sampler_dispatch(function: ast.FunctionDef) -> ast.Call:
+    return next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and _call_path(node.func) == ("self", "sampler_function")
+    )
+
+
+def _assignment_for_call(function: ast.FunctionDef, call: ast.Call) -> ast.Assign:
+    return next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign) and node.value is call
+    )
+
+
+def _compile_ksampler_method(
+    tmp_path: Path,
+    function: ast.FunctionDef,
+    *,
+    name: str,
+):
+    source_path = tmp_path / f"{name}.py"
+    source = ast.unparse(ast.fix_missing_locations(function)) + "\n"
+    source_path.write_text(source, encoding="utf-8")
+    adapter = type("KSamplerX0Inpaint", (), {})
+    namespace = {
+        "KSamplerX0Inpaint": adapter,
+        "AlternativeAdapter": type("AlternativeAdapter", (), {}),
+        "logging": SimpleNamespace(info=lambda *_args: None),
+        "torch": torch,
+        "detail": lambda *_args: None,
+    }
+    exec(compile(source, str(source_path), "exec"), namespace)  # noqa: S102
+    method = namespace["sample"]
+    method.__module__ = "runtime_ksampler_patch"
+    method.__qualname__ = "KSAMPLER.sample"
+    return method, adapter
+
+
+def _mutate_ksampler_contract(function: ast.FunctionDef, case: str) -> None:
+    dispatch = _sampler_dispatch(function)
+    dispatch_assignment = _assignment_for_call(function, dispatch)
+    noise_scaling = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and _call_path(node.func)
+        == ("model_wrap", "inner_model", "model_sampling", "noise_scaling")
+    )
+    noise_scaling_assignment = _assignment_for_call(function, noise_scaling)
+    adapter = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "KSamplerX0Inpaint"
+    )
+    inverse = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and _call_path(node.func)
+        == (
+            "model_wrap",
+            "inner_model",
+            "model_sampling",
+            "inverse_noise_scaling",
+        )
+    )
+    inverse_assignment = _assignment_for_call(function, inverse)
+
+    if case == "signature":
+        function.args.args[2].arg = "different_sigmas_parameter"
+    elif case == "logging":
+        function.body.insert(
+            0,
+            ast.Expr(
+                ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="logging", ctx=ast.Load()),
+                        attr="info",
+                        ctx=ast.Load(),
+                    ),
+                    args=[ast.Constant(value="KSAMPLER diagnostic")],
+                    keywords=[],
+                )
+            ),
+        )
+    elif case == "bookkeeping":
+        function.body.insert(
+            0,
+            ast.Assign(
+                targets=[ast.Name(id="diagnostic_counter", ctx=ast.Store())],
+                value=ast.Constant(value=1),
+            ),
+        )
+    elif case == "callback_instrumentation":
+        callback_function = next(
+            node
+            for node in function.body
+            if isinstance(node, ast.FunctionDef) and node.name == "k_callback"
+        )
+        callback_function.body.insert(
+            -1,
+            ast.If(
+                test=ast.Compare(
+                    left=ast.Name(id="callback", ctx=ast.Load()),
+                    ops=[ast.IsNot()],
+                    comparators=[ast.Constant(value=None)],
+                ),
+                body=[
+                    ast.Expr(
+                        ast.Call(
+                            func=ast.Attribute(
+                                value=ast.Name(id="logging", ctx=ast.Load()),
+                                attr="info",
+                                ctx=ast.Load(),
+                            ),
+                            args=[ast.Constant(value="callback active")],
+                            keywords=[],
+                        )
+                    )
+                ],
+                orelse=[],
+            ),
+        )
+        function.body.insert(
+            function.body.index(callback_function),
+            ast.Assign(
+                targets=[ast.Name(id="diagnostic_total_steps", ctx=ast.Store())],
+                value=ast.BinOp(
+                    left=ast.Call(
+                        func=ast.Name(id="len", ctx=ast.Load()),
+                        args=[ast.Name(id="sigmas", ctx=ast.Load())],
+                        keywords=[],
+                    ),
+                    op=ast.Sub(),
+                    right=ast.Constant(value=1),
+                ),
+            ),
+        )
+    elif case == "drop_extra_options":
+        dispatch.keywords = [keyword for keyword in dispatch.keywords if keyword.arg is not None]
+    elif case == "different_sigmas":
+        dispatch.args[2] = ast.Name(id="modified_sigmas", ctx=ast.Load())
+    elif case == "different_noise":
+        dispatch.args[1] = ast.Name(id="different_noise", ctx=ast.Load())
+    elif case == "different_extra_args":
+        next(keyword for keyword in dispatch.keywords if keyword.arg == "extra_args").value = ast.Name(
+            id="different_extra_args", ctx=ast.Load()
+        )
+    elif case == "different_callback":
+        next(keyword for keyword in dispatch.keywords if keyword.arg == "callback").value = ast.Name(
+            id="callback", ctx=ast.Load()
+        )
+    elif case == "double_dispatch":
+        index = function.body.index(dispatch_assignment)
+        function.body.insert(index, copy.deepcopy(dispatch_assignment))
+    elif case == "missing_noise_scaling":
+        function.body.remove(noise_scaling_assignment)
+    elif case == "late_noise_scaling":
+        function.body.remove(noise_scaling_assignment)
+        function.body.insert(function.body.index(dispatch_assignment) + 1, noise_scaling_assignment)
+    elif case == "conditional_noise_scaling":
+        index = function.body.index(noise_scaling_assignment)
+        function.body[index] = ast.If(
+            test=ast.Constant(value=False),
+            body=[noise_scaling_assignment],
+            orelse=[],
+        )
+    elif case == "conditional_dispatch":
+        index = function.body.index(dispatch_assignment)
+        function.body[index] = ast.If(
+            test=ast.Constant(value=True),
+            body=[dispatch_assignment],
+            orelse=[],
+        )
+    elif case == "bypass_adapter":
+        adapter.func = ast.Name(id="AlternativeAdapter", ctx=ast.Load())
+    elif case == "missing_inverse_scaling":
+        function.body.remove(inverse_assignment)
+    else:
+        raise AssertionError(f"unknown contract mutation {case}")
 
 
 def _delegates_to_ancestral_res(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
@@ -187,7 +399,7 @@ def test_native_er_sde_makes_one_model_call_per_outer_solver_iteration():
     assert len(_named_calls(function, "model")) == 1
 
 
-def test_native_er_sde_runtime_sources_match_reviewed_compensation_contract():
+def test_native_er_sde_math_sources_match_reviewed_compensation_contract():
     functions = _native_sampling_functions()
     assert _ast_digest(functions["sample_er_sde"]) == ER_SDE_NATIVE_FUNCTION_DIGEST
     assert (
@@ -195,18 +407,159 @@ def test_native_er_sde_runtime_sources_match_reviewed_compensation_contract():
         == ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST
     )
 
-    samplers_tree = _native_tree("comfy/samplers.py")
-    ksampler = next(
-        node
-        for node in samplers_tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "KSAMPLER"
+
+def test_official_ksampler_sample_satisfies_semantic_contract(tmp_path):
+    method, adapter = _compile_ksampler_method(
+        tmp_path,
+        _native_ksampler_sample(),
+        name="official_ksampler",
     )
-    sample_method = next(
-        node
-        for node in ksampler.body
-        if isinstance(node, ast.FunctionDef) and node.name == "sample"
+
+    result = validate_ksampler_sample(
+        method,
+        expected_adapter=adapter,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
     )
-    assert _ast_digest(sample_method) == ER_SDE_KSAMPLER_SAMPLE_DIGEST
+
+    assert result.accepted, result.failure
+    assert result.provenance.source_inspected
+
+
+@pytest.mark.parametrize(
+    "case",
+    ("logging", "bookkeeping", "callback_instrumentation"),
+)
+def test_ksampler_semantic_contract_accepts_irrelevant_method_changes(tmp_path, case):
+    function = _native_ksampler_sample()
+    _mutate_ksampler_contract(function, case)
+    method, adapter = _compile_ksampler_method(tmp_path, function, name=case)
+
+    result = validate_ksampler_sample(
+        method,
+        expected_adapter=adapter,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+    assert result.accepted, result.failure
+    assert result.provenance.observed_digest != ER_SDE_KSAMPLER_SAMPLE_DIGEST
+
+
+@pytest.mark.parametrize(
+    ("case", "failure"),
+    (
+        ("signature", "positional invocation contract"),
+        ("drop_extra_options", "extra_options are not forwarded unchanged"),
+        ("different_sigmas", "scaled noise, and sigmas"),
+        ("different_noise", "scaled noise, and sigmas"),
+        ("different_extra_args", "does not forward extra_args unchanged"),
+        ("different_callback", "callback adapter"),
+        ("double_dispatch", "exactly one self.sampler_function dispatch"),
+        ("missing_noise_scaling", "expected one native noise_scaling call"),
+        ("late_noise_scaling", "must occur before sampler dispatch"),
+        ("conditional_noise_scaling", "initial noise_scaling inputs"),
+        ("conditional_dispatch", "direct method-body assignment"),
+        ("bypass_adapter", "native KSamplerX0Inpaint adapter"),
+        ("missing_inverse_scaling", "expected one final inverse_noise_scaling call"),
+    ),
+)
+def test_ksampler_semantic_contract_rejects_relevant_changes(
+    tmp_path,
+    case,
+    failure,
+):
+    function = _native_ksampler_sample()
+    _mutate_ksampler_contract(function, case)
+    method, adapter = _compile_ksampler_method(tmp_path, function, name=case)
+
+    result = validate_ksampler_sample(
+        method,
+        expected_adapter=adapter,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+    assert not result.accepted
+    assert failure in result.failure
+
+
+def test_ksampler_semantic_contract_accepts_compatible_plain_monkeypatch(tmp_path):
+    function = _native_ksampler_sample()
+    _mutate_ksampler_contract(function, "logging")
+    method, adapter = _compile_ksampler_method(
+        tmp_path,
+        function,
+        name="compatible_monkeypatch",
+    )
+
+    class KSAMPLER:
+        pass
+
+    KSAMPLER.sample = method
+    result = validate_ksampler_sample(
+        vars(KSAMPLER)["sample"],
+        expected_adapter=adapter,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+    assert result.accepted, result.failure
+
+
+def test_ksampler_semantic_contract_rejects_incompatible_plain_monkeypatch(tmp_path):
+    function = _native_ksampler_sample()
+    _mutate_ksampler_contract(function, "drop_extra_options")
+    method, adapter = _compile_ksampler_method(
+        tmp_path,
+        function,
+        name="incompatible_monkeypatch",
+    )
+
+    class KSAMPLER:
+        pass
+
+    KSAMPLER.sample = method
+    result = validate_ksampler_sample(
+        vars(KSAMPLER)["sample"],
+        expected_adapter=adapter,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+    assert not result.accepted
+    assert "extra_options are not forwarded unchanged" in result.failure
+
+
+def test_ksampler_semantic_contract_rejects_uninspectable_source_with_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    missing_source = tmp_path / "missing_runtime_patch.py"
+    namespace = {}
+    exec(  # noqa: S102
+        compile(
+            "def sample(self, model_wrap, sigmas, extra_args, callback, noise, "
+            "latent_image=None, denoise_mask=None, disable_pbar=False):\n    return noise\n",
+            str(missing_source),
+            "exec",
+        ),
+        namespace,
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "comfyui_version",
+        SimpleNamespace(__version__="runtime-test"),
+    )
+
+    result = validate_ksampler_sample(
+        namespace["sample"],
+        expected_adapter=type("KSamplerX0Inpaint", (), {}),
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+    assert not result.accepted
+    assert "source is unavailable" in result.failure
+    fields = result.provenance.log_fields()
+    assert "observed_digest=unavailable" in fields
+    assert f"expected_reference_digest={ER_SDE_KSAMPLER_SAMPLE_DIGEST}" in fields
+    assert "source_inspected=False" in fields
+    assert "comfyui_version=runtime-test" in fields
 
 
 def test_native_er_sde_stages_reuse_only_solver_local_denoised_history():

--- a/tests/test_sampler_contract.py
+++ b/tests/test_sampler_contract.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import ast
 import copy
+import hashlib
 import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
+
+from comfyui_spectrum_h3.sampling import (
+    ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST,
+    ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    ER_SDE_NATIVE_FUNCTION_DIGEST,
+)
 
 RES_VARIANTS = (
     "sample_res_multistep",
@@ -43,7 +50,7 @@ def _compile_native_sampling_function(name: str, globals_: dict):
     function.decorator_list = []
     module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
     namespace = dict(globals_)
-    exec(compile(module, f"<native {name}>", "exec"), namespace)
+    exec(compile(module, f"<native {name}>", "exec"), namespace)  # noqa: S102
     return namespace[name]
 
 
@@ -61,6 +68,14 @@ def _loaded_names(node: ast.AST) -> set[str]:
         for item in ast.walk(node)
         if isinstance(item, ast.Name) and isinstance(item.ctx, ast.Load)
     }
+
+
+def _ast_digest(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    normalized = copy.deepcopy(node)
+    normalized.decorator_list = []
+    return hashlib.sha256(
+        ast.dump(normalized, include_attributes=False).encode("utf-8")
+    ).hexdigest()
 
 
 def _delegates_to_ancestral_res(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
@@ -170,6 +185,28 @@ def test_native_er_sde_makes_one_model_call_per_outer_solver_iteration():
     assert len(loops) == 1
     assert len(_named_calls(loops[0], "model")) == 1
     assert len(_named_calls(function, "model")) == 1
+
+
+def test_native_er_sde_runtime_sources_match_reviewed_compensation_contract():
+    functions = _native_sampling_functions()
+    assert _ast_digest(functions["sample_er_sde"]) == ER_SDE_NATIVE_FUNCTION_DIGEST
+    assert (
+        _ast_digest(functions["default_noise_sampler"])
+        == ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST
+    )
+
+    samplers_tree = _native_tree("comfy/samplers.py")
+    ksampler = next(
+        node
+        for node in samplers_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "KSAMPLER"
+    )
+    sample_method = next(
+        node
+        for node in ksampler.body
+        if isinstance(node, ast.FunctionDef) and node.name == "sample"
+    )
+    assert _ast_digest(sample_method) == ER_SDE_KSAMPLER_SAMPLE_DIGEST
 
 
 def test_native_er_sde_stages_reuse_only_solver_local_denoised_history():

--- a/tests/test_tiled_diffusion_ksampler_contract.py
+++ b/tests/test_tiled_diffusion_ksampler_contract.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from comfyui_spectrum_h3.er_sde_ksampler_contract import validate_ksampler_sample
+from comfyui_spectrum_h3.sampling import ER_SDE_KSAMPLER_SAMPLE_DIGEST
+
+
+def _native_ksampler_sample() -> ast.FunctionDef:
+    comfyui_path = os.environ.get("COMFYUI_PATH")
+    if not comfyui_path:
+        pytest.skip("COMFYUI_PATH is required for native sampler contract tests")
+    source = (Path(comfyui_path) / "comfy/samplers.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    ksampler = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "KSAMPLER"
+    )
+    return next(
+        node
+        for node in ksampler.body
+        if isinstance(node, ast.FunctionDef) and node.name == "sample"
+    )
+
+
+def _compile_native_method(tmp_path: Path):
+    function = _native_ksampler_sample()
+    source_path = tmp_path / "native_ksampler.py"
+    source_path.write_text(ast.unparse(ast.fix_missing_locations(function)) + "\n", encoding="utf-8")
+    adapter = type("KSamplerX0Inpaint", (), {})
+    namespace = {
+        "KSamplerX0Inpaint": adapter,
+        "detail": lambda *_args: None,
+    }
+    exec(compile(source_path.read_text(encoding="utf-8"), str(source_path), "exec"), namespace)  # noqa: S102
+    method = namespace["sample"]
+    method.__module__ = "comfy.samplers"
+    method.__qualname__ = "KSAMPLER.sample"
+    return method, adapter
+
+
+def _compile_tiled_wrapper(
+    tmp_path: Path,
+    target,
+    *,
+    name: str,
+    pop_key: str = "sigmas",
+    altered_return: bool = False,
+):
+    source_path = tmp_path / f"{name}.py"
+    return_expression = (
+        "orig_fn(*args, **dict(kwargs))"
+        if altered_return
+        else "orig_fn(*args, **kwargs)"
+    )
+    source_path.write_text(
+        f'''def KSAMPLER_sample(*args, **kwargs):
+    orig_fn = store.KSAMPLER_sample
+    extra_args = None
+    model_options = None
+    try:
+        extra_args = kwargs["extra_args"] if "extra_args" in kwargs else args[3]
+        model_options = extra_args["model_options"]
+    except Exception:
+        ...
+    if model_options is not None and "tiled_diffusion" in model_options and extra_args is not None:
+        sigmas_ = kwargs["sigmas"] if "sigmas" in kwargs else args[2]
+        sigmas_all = model_options.pop("{pop_key}", None)
+        sigmas = sigmas_all if sigmas_all is not None else sigmas_
+        store.sigmas = sigmas
+        store.model_options = model_options
+        store.extra_args = extra_args
+    else:
+        for attr in ["sigmas", "model_options", "extra_args"]:
+            _delattr(store, attr)
+    return {return_expression}
+''',
+        encoding="utf-8",
+    )
+    store = SimpleNamespace(KSAMPLER_sample=target)
+
+    def _delattr(owner, attr):
+        if hasattr(owner, attr):
+            delattr(owner, attr)
+
+    namespace = {"store": store, "_delattr": _delattr, "dict": dict}
+    exec(compile(source_path.read_text(encoding="utf-8"), str(source_path), "exec"), namespace)  # noqa: S102
+    wrapper = namespace["KSAMPLER_sample"]
+    wrapper.__module__ = "/home/toor/ComfyUI/custom_nodes/tiled-diffusion.utils"
+    wrapper.__qualname__ = "KSAMPLER_sample"
+    return wrapper, store
+
+
+def _validate(wrapper, adapter):
+    return validate_ksampler_sample(
+        wrapper,
+        expected_adapter=adapter,
+        expected_reference_digest=ER_SDE_KSAMPLER_SAMPLE_DIGEST,
+    )
+
+
+def test_tiled_diffusion_variadic_ksampler_wrapper_is_accepted(tmp_path):
+    native, adapter = _compile_native_method(tmp_path)
+    wrapper, _store = _compile_tiled_wrapper(tmp_path, native, name="tiled_wrapper")
+
+    result = _validate(wrapper, adapter)
+
+    assert result.accepted, result.failure
+    assert result.provenance.qualname == "KSAMPLER_sample"
+    assert "tiled-diffusion.utils" in (result.provenance.module or "")
+
+
+def test_tiled_diffusion_wrapper_chain_is_accepted(tmp_path):
+    native, adapter = _compile_native_method(tmp_path)
+    inner, _inner_store = _compile_tiled_wrapper(tmp_path, native, name="tiled_inner")
+    outer, _outer_store = _compile_tiled_wrapper(tmp_path, inner, name="tiled_outer")
+
+    result = _validate(outer, adapter)
+
+    assert result.accepted, result.failure
+
+
+def test_tiled_diffusion_wrapper_rejects_changed_sigmas_handoff(tmp_path):
+    native, adapter = _compile_native_method(tmp_path)
+    wrapper, _store = _compile_tiled_wrapper(
+        tmp_path,
+        native,
+        name="tiled_wrong_pop",
+        pop_key="other",
+    )
+
+    result = _validate(wrapper, adapter)
+
+    assert not result.accepted
+    assert "TiledDiffusion sigmas handoff" in (result.failure or "")
+
+
+def test_tiled_diffusion_wrapper_rejects_changed_delegate_arguments(tmp_path):
+    native, adapter = _compile_native_method(tmp_path)
+    wrapper, _store = _compile_tiled_wrapper(
+        tmp_path,
+        native,
+        name="tiled_changed_return",
+        altered_return=True,
+    )
+
+    result = _validate(wrapper, adapter)
+
+    assert not result.accepted
+    assert "does not forward *args/**kwargs unchanged" in (result.failure or "")
+
+
+def test_tiled_diffusion_wrapper_cycle_fails_closed(tmp_path):
+    native, adapter = _compile_native_method(tmp_path)
+    wrapper, store = _compile_tiled_wrapper(tmp_path, native, name="tiled_cycle")
+    store.KSAMPLER_sample = wrapper
+
+    result = _validate(wrapper, adapter)
+
+    assert not result.accepted
+    assert "delegates to itself" in (result.failure or "") or "cycle" in (result.failure or "")


### PR DESCRIPTION
## Summary

Release v0.2.11 with the native ER-SDE forecast-state fix, audited TiledDiffusion sampler-wrapper compatibility, hardened post-run teardown, and a full README refresh.

The production fix preserves native ER-SDE's stochastic latent trajectory and NFE budget. Spectrum no longer feeds a skipped H3 hidden/velocity forecast back into ER-SDE as an invalid current-state denoised/x0 observation. Causal ER-SDE forecast steps instead use bounded solver-space dense output from exact actual denoised anchors.

## Root cause and implementation

The first candidate tracked native ER-SDE's exact stochastic increment `q_i` and removed direct pending-`q` leakage from forecast denoised values. Real MiniMax H3 testing proved that correction was executing at large magnitude, but the characteristic high-frequency/confetti artifact remained. That falsified direct `q` leakage as the primary visible mechanism.

The stronger mismatch was solver-space consistency: ER-SDE integrates and differentiates denoised/x0 values, while Spectrum's skipped H3 hidden/velocity forecast is not a valid current-state denoised observation for ER-SDE's stochastic latent.

The final path therefore:

- keeps the exact reviewed native `sample_er_sde` implementation;
- preserves native RNG draws, `s_noise`, stochastic latent `x`, stage-2/stage-3 history and terminal behavior;
- tracks native ER-SDE lambda coordinates from the reviewed scaler path;
- retains at most two exact causal actual packed denoised anchors;
- uses a latest-actual denoised hold for the first causal forecast after one anchor;
- uses bounded linear denoised extrapolation in native ER-SDE lambda coordinate once two actual anchors exist;
- falls back to latest-actual hold for degenerate, reversed, non-finite or excessive extrapolation;
- substitutes the solver-space result before native ER-SDE callback/integration/derivative-history consumption;
- retains exact stochastic compensation for replay/compatibility paths where solver-space dense output is not the reviewed causal path;
- adds zero H3 transformer/denoiser NFEs.

## Real MiniMax H3 validation

The final solver-space candidate has now been exercised on repeated real MiniMax H3 native ER-SDE generations (`max_stage=3`, `s_noise=1.0`).

Observed results:

- forecast confetti disappeared completely;
- final fine/low-resolution structure improved modestly but visibly;
- action/motion remained comparable in the tested prompts;
- audio remained comparable;
- the normal 20-step run retained 11 actual H3 evaluations + 9 forecasts;
- a second generation in the same workflow completed normally;
- the previously problematic older saved T2V workflow was rerun after teardown hardening and also completed normally.

This is strong causal validation of the solver-space diagnosis. The exact historical cause of the one WSL hard-wedge cannot be proven retrospectively, but the unsafe synchronous research boundary described below has been removed and the reproducing workflow subsequently completed.

## TiledDiffusion compatibility

Real runtime testing exposed ComfyUI-TiledDiffusion's variadic `KSAMPLER_sample(*args, **kwargs)` monkeypatch above native `KSAMPLER.sample`.

The ER-SDE semantic validator now accepts only the audited passthrough form by recursively validating its stored native delegate, exact argument forwarding and reviewed `model_options`/`sigmas` bookkeeping. Arbitrary variadic wrappers, altered delegation, argument mutation, cycles and unrelated state mutation still fail closed to native execution.

## Post-run / teardown safety

A real saved-workflow run once hard-wedged WSL after all ER-SDE steps and the Spectrum run summary had completed, before Spectrum teardown and downstream VAE/video nodes.

The old generic-correction hook performed optional persistence/evaluation synchronously inside `SpectrumH3Runtime.end_run()`. v0.2.11 now:

- keeps calibration export synchronous and bounded;
- releases core Spectrum runtime/history synchronously;
- logs calibration-export and runtime-release teardown boundaries in debug mode;
- dispatches optional generic-correction persistence/evaluation only after runtime release;
- uses one bounded daemon research worker;
- skips later diagnostic jobs while a previous worker is still active rather than accumulating threads;
- passes only a tensor-free calibration block to the worker;
- never lets optional research persistence/evaluation block an already-completed sampler result.

No speculative `torch.cuda.empty_cache()`, forced CUDA synchronization or history offload was added.

## README and v0.2.11 metadata

The README has been rewritten around current behavior and now documents the ER-SDE solver-space path, current defaults/recommendations, supported samplers, TiledDiffusion compatibility, model-aware/generic-correction settings, replay/live-preview behavior, attention/cache compatibility, storage/teardown guidance, research nodes and debugging.

Release metadata is advanced to `0.2.11` in `pyproject.toml`, replay-calibration fallback provenance and generic-correction fallback provenance. `RELEASE_NOTES.md` is rewritten for v0.2.11.

After merge, the existing repository automation will:

- run the pinned test matrix on `main`;
- create the v0.2.11 GitHub release only after that tested `main` commit succeeds;
- build the source ZIP and `SHA256SUMS` assets;
- publish the changed package version to the Comfy Registry through the existing publish workflow.

## Validation

Final PR head: `e7119b8d6e0485a435ed21e27cbb808448f006f8`.

GitHub Actions `tests` run #336 (`31886379326`) passed across all four pinned ComfyUI revisions:

- `e377e263049f9338b4d12a3dd417b36ae62948ff`
- `0dd9b154a1654fc699dcdc3af066c7cce096045a`
- `5599a05fea715cb2aff11f30f5b06e16d0dfa0c4`
- `27bca654eb9a70237d93f56a6ea336ab55f8925d`

Every matrix job passed wheel build, native-H3 forecaster smoke, scoped Ruff, `compileall`, and the full pytest suite.

Coverage includes stochastic ownership, RNG/replay parity, first/terminal boundaries, stages 1/2/3, solver-space bootstrap hold and lambda extrapolation, extrapolation guards, all-actual parity, replay isolation, TiledDiffusion semantic validation, bounded denoised-anchor lifetime, post-run release/research ordering, bounded background research dispatch and worker cleanup.

## Performance and ownership

- zero additional denoiser/transformer NFEs;
- native ER-SDE RNG stream unchanged;
- one pending packed-latent stochastic increment plus at most two packed denoised anchors;
- no historical denoised archive beyond those anchors;
- no production hidden-state expansion beyond existing Spectrum forecasting requirements;
- post-run research cannot retain Spectrum feature-history VRAM.

## Status

Real H3 validation is successful, the old saved T2V workflow reran successfully after teardown hardening, the final release metadata/docs are prepared, there are no open review threads, and the final PR head is green across the full pinned matrix. This PR is ready to merge and release as v0.2.11.