### PR TITLE
Fix ER-SDE source-contract false rejection on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,11 @@ jobs:
           - 0dd9b154a1654fc699dcdc3af066c7cce096045a
           - 5599a05fea715cb2aff11f30f5b06e16d0dfa0c4
           - 27bca654eb9a70237d93f56a6ea336ab55f8925d
+        python_version:
+          - "3.12"
+        include:
+          - comfy_ref: 27bca654eb9a70237d93f56a6ea336ab55f8925d
+            python_version: "3.13"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -36,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python_version }}
           cache: pip
 
       - name: Install test dependencies

--- a/comfyui_spectrum_h3/er_sde_stochastic.py
+++ b/comfyui_spectrum_h3/er_sde_stochastic.py
@@ -59,9 +59,15 @@ def function_node_ast_digest(
     """Return the normalized digest shared by runtime and source-contract tests."""
     normalized = copy.deepcopy(function_node)
     normalized.decorator_list = []
-    return hashlib.sha256(
-        ast.dump(normalized, include_attributes=False).encode("utf-8")
-    ).hexdigest()
+    # Python 3.13 changed ast.dump() to omit empty fields by default. The reviewed
+    # source digests were generated from the full-field representation used by
+    # Python <=3.12. Force that representation when the runtime supports the new
+    # show_empty switch so identical native source keeps identical provenance.
+    try:
+        dumped = ast.dump(normalized, include_attributes=False, show_empty=True)
+    except TypeError:
+        dumped = ast.dump(normalized, include_attributes=False)
+    return hashlib.sha256(dumped.encode("utf-8")).hexdigest()
 
 
 def function_ast_digest(


### PR DESCRIPTION
## Problem

Closes #57.

Native `er_sde` can be incorrectly disabled with:

`native sample_er_sde implementation is not a reviewed revision`

This is a false provenance rejection on Python 3.13. It is not caused by the ComfyUI scheduler and it is not a semantic change in ComfyUI's `sample_er_sde` implementation.

The reviewed native `sample_er_sde` body is the same in the reported ComfyUI v0.30.0 and v0.33.0 sources. Spectrum hashes a decorator-stripped AST to fail closed if the solver implementation actually changes. The digest helper relied on the default textual representation from `ast.dump()`.

Python 3.13 changed that default representation: empty AST fields are omitted unless `show_empty=True`. The exact same function therefore hashes differently purely because of the Python interpreter version. On Python 3.13 the current reviewed `sample_er_sde` produces `8e4ec9c4...` with the new default instead of the pinned reviewed `55b76bd3...`; the native `default_noise_sampler` is affected the same way (`d74b53c4...` vs `11cfe81f...`). Python 3.12 CI did not expose this because its `ast.dump()` default still emits the full field set.

## Fix

- preserve the existing reviewed digest constants and fail-closed source contract;
- on runtimes that support Python 3.13's `show_empty` option, call `ast.dump(..., show_empty=True)` so the normalized AST representation remains identical to the reviewed Python <=3.12 representation;
- retain the existing fallback on older Python versions;
- add a Python 3.13 / reviewed-current-ComfyUI CI row so this exact regression cannot recur unnoticed.

No ER-SDE solver math, stochastic compensation, scheduling, replay ownership, forecast cadence, or sampler options are changed.

## Validation

Local Python 3.13 reproduction against the reviewed native function source confirms that forcing `show_empty=True` restores both existing pinned digests exactly:

- `sample_er_sde`: `55b76bd3a76d44fbd363de39f2ab3ea672c78de9f001f47168b47ec6ff6d2447`
- `default_noise_sampler`: `11cfe81f36f0b43e96c12eff32a4f074f35227a53ca116e837bf268b6383f9ad`

The existing source-contract suite remains the semantic guard; the new Python 3.13 matrix row exercises it under the interpreter that triggered the false rejection.