### PR TITLE
Release v0.2.14: harden native ER-SDE offline replay safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Spectrum reduces the number of expensive H3 transformer evaluations during sampl
 
 Spectrum is an **approximate accelerator**. Forecasted steps change the denoising trajectory, so output can differ from native H3 even with the same seed and workflow.
 
+## v0.2.14: native ER-SDE offline replay safety
+
+v0.2.14 hardens native ER-SDE offline smoothing replay around a reproduced WSL hard-wedge boundary. The captured failing run completed first-pass teardown, constructed and validated the offline smoother, entered transformer-free replay, and stopped producing output after replay step 13.
+
+During **native ER-SDE offline replay only**, Spectrum now recognizes the reviewed KJNodes Model Preview Override nested callback and forwards directly to its underlying Spectrum replay callback. KJ preview remains active during the transformer-backed first-pass capture. The replay path preserves Spectrum progress/callback semantics while avoiding KJ's synchronous preview/decode and GPU-to-CPU copy work during the fast replay.
+
+The guard accepts only the reviewed KJ callback provenance and closure shape. Other sampler paths, native ER-SDE single-pass operation, and unrelated callback wrappers retain their existing behavior. Debug mode also records callback, noise-sampler, and successful replay-finalization boundary breadcrumbs so a recurring wedge can be localized more precisely.
+
+The reproduced trace identifies KJ replay preview work as the strongest narrowed protection target. It does not establish KJNodes as the proven historical root cause of the WSL wedge.
+
 ## v0.2.12: Diff-Aid H3 forecast compatibility
 
 v0.2.12 adds coordinated interoperability with **ComfyUI-DiffAid-Patches v1.0.6+** for the native MiniMax H3 sparse activation patch.
@@ -254,7 +264,9 @@ Because callback side effects must not run twice, ordinary sampler callbacks are
 
 ## Live preview
 
-The explicitly supported capture-pass preview integration is **KJNodes Model Preview Override**, typically used with Kijai's MiniMax H3 TAE. Spectrum recognizes the `kj_preview_override` wrapper as observational and keeps it active during capture/replay.
+The explicitly supported capture-pass preview integration is **KJNodes Model Preview Override**, typically used with Kijai's MiniMax H3 TAE. Spectrum recognizes the `kj_preview_override` wrapper as observational.
+
+With native ER-SDE plus `offline_smoothing_replay=true`, v0.2.14 keeps KJ preview active during the first-pass capture and bypasses the KJ preview wrapper during transformer-free replay while preserving Spectrum's underlying replay callback/progress semantics. Other supported paths retain their existing preview behavior.
 
 Built-in ComfyUI preview callbacks, ComfyUI-bleh Better Previews, VHS Preview and other callback-based preview implementations are not currently guaranteed to update during the capture pass.
 
@@ -333,6 +345,9 @@ Spectrum H3 external patch transition step=... transitions=... action=force_actu
 Spectrum H3 ER-SDE stochastic tracking active ...
 Spectrum H3 ER-SDE dense anchor ...
 Spectrum H3 ER-SDE dense output ...
+Spectrum H3 offline transition ... event=er_sde_replay_preview_bypass ...
+Spectrum H3 offline transition ... event=er_sde_callback_begin|er_sde_callback_end ...
+Spectrum H3 ER-SDE replay boundary event=noise_sampler_begin|noise_sampler_end ...
 Spectrum H3 run summary ... external_patch_transitions=... external_patch_forced_actuals=... external_patch_contract_failures=...
 Spectrum H3 teardown transition ...
 Spectrum H3 run teardown ...

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,46 +1,58 @@
-# Spectrum MiniMax H3 v0.2.13
+# Spectrum MiniMax H3 v0.2.14
 
-v0.2.13 fixes a false native ER-SDE compatibility rejection on Python 3.13. Spectrum could disable ER-SDE and fall back to an untouched native sampler with:
+v0.2.14 hardens native ER-SDE offline smoothing replay around a reproduced WSL hard-wedge boundary. In the captured failing run, Spectrum completed the entire first pass, released causal history, constructed and validated the offline smoother, entered transformer-free replay, and then stopped producing output after replay step 13. That trace rules out the previously suspected post-run teardown boundary and narrows the protection target to work occurring inside replay.
 
-```text
-native sample_er_sde implementation is not a reviewed revision
-```
+## Native ER-SDE replay preview protection
 
-The affected ComfyUI `sample_er_sde` implementation had not actually changed. The failure came from Spectrum's source-provenance guard hashing a decorator-stripped Python AST with the runtime default representation from `ast.dump()`.
+KJNodes Model Preview Override performs observational preview work from the sampler callback, including GPU preview/decode work and a blocking GPU-to-CPU transfer before its asynchronous encoder handoff. Offline replay can drive that callback much faster than the transformer-backed capture pass while the full replay archive is still live.
 
-## Python 3.13 ER-SDE compatibility fix
+For **native ER-SDE offline replay only**, Spectrum now recognizes the reviewed KJNodes nested callback provenance and bypasses the KJ preview wrapper while forwarding directly to the underlying Spectrum replay callback. This preserves Spectrum's replay progress and external callback semantics without performing KJ's preview decode/copy during the fast replay.
 
-Python 3.13 changed the default AST dump representation so empty fields are omitted unless `show_empty=True`. Spectrum's reviewed ER-SDE source digests were generated from the full-field representation used by Python 3.12 and older runtimes.
+The guard is deliberately narrow:
 
-That meant identical native source could produce a different digest solely because ComfyUI was running under Python 3.13. The same interpreter-dependent mismatch affected both the reviewed `sample_er_sde` implementation and native `default_noise_sampler` provenance.
+- KJNodes preview remains active during the expensive first-pass capture;
+- native ER-SDE single-pass behavior is unchanged;
+- other sampler and replay callback paths are unchanged;
+- arbitrary callback wrappers are never unwrapped;
+- the KJ callback is accepted only when its module, qualified name, source-file suffix and `original_callback` closure shape match the reviewed implementation.
 
-v0.2.13 normalizes the AST representation before hashing:
+This release does **not** claim that the historical WSL wedge has been proven to originate inside KJNodes. The callback is the strongest narrowed protection target from the reproduced trace, and the additional diagnostics below make a subsequent real run classify the remaining boundary precisely if the wedge recurs.
 
-- Python runtimes that support `show_empty` explicitly use `ast.dump(..., show_empty=True)`;
-- older Python versions retain the existing compatible dump path;
-- the existing reviewed digest constants remain unchanged;
-- genuinely changed or unreviewed ER-SDE source still fails closed.
+## Replay boundary diagnostics
 
-This keeps the source-contract safety invariant while removing the interpreter-version false rejection.
+With `debug=true`, native ER-SDE replay now records boundary breadcrumbs around:
 
-## Scope
+- sampler callback begin/end;
+- stochastic noise-sampler begin/end;
+- successful replay step finalization.
 
-This release does not change ER-SDE solver math, stochastic compensation, solver-space dense output, forecast cadence, offline replay ownership, `s_noise`, `max_stage`, sampler options, or scheduler behavior.
+These breadcrumbs do not reduce latent tensors and do not introduce an explicit CUDA synchronization.
 
-The issue was reproduced independently of scheduler choice. The reported ComfyUI v0.30.0 and v0.33.0 ER-SDE implementations use the same relevant solver body, so changing to the beta scheduler cannot resolve this provenance failure.
+The replay `finalize_step_end` breadcrumb is installed outside the v0.2.12 external-patch finalizer. It therefore means the effective finalization chain has completed, including Diff-Aid compatibility bookkeeping, rather than reporting completion before an outer finalizer has finished.
+
+## Existing compatibility preserved
+
+The conflict resolution for PR #55 was performed against v0.2.13 rather than taking the older v0.2.11 branch state. v0.2.14 therefore retains:
+
+- v0.2.12 Diff-Aid H3 forecast compatibility and hard-transition protection;
+- v0.2.13 Python 3.13 native ER-SDE source-provenance normalization;
+- the v0.2.11 ER-SDE stochastic-state and solver-space dense-output correction.
+
+There is no change to native ER-SDE solver math, RNG ownership, `s_noise`, `max_stage`, forecast cadence, scheduler behavior, or the normal actual/forecast NFE budget.
+
+## Live preview behavior
+
+For offline smoothing replay with native ER-SDE, KJNodes Model Preview Override now provides the useful first-pass preview and is intentionally skipped during the transformer-free replay. For paths outside that exact combination, the existing preview behavior remains unchanged.
 
 ## Validation
 
-The fix was validated by reproducing the Python 3.13 digest difference and confirming that normalized full-field AST dumping restores the existing reviewed digests exactly:
+The reconciled PR #55 head passed the complete repository test matrix before merge:
 
-- `sample_er_sde`: `55b76bd3a76d44fbd363de39f2ab3ea672c78de9f001f47168b47ec6ff6d2447`
-- `default_noise_sampler`: `11cfe81f36f0b43e96c12eff32a4f074f35227a53ca116e837bf268b6383f9ad`
+- four reviewed ComfyUI revisions on Python 3.12;
+- the current reviewed ComfyUI revision on Python 3.13;
+- forecaster smoke test;
+- Ruff and `compileall`;
+- focused external-patch compatibility suites;
+- native MiniMax H3 test suite.
 
-CI now includes a dedicated Python 3.13 job against the reviewed current ComfyUI revision in addition to the existing Python 3.12 multi-revision matrix. The full PR #58 matrix passed before merge.
-
-## Compatibility
-
-- Fixes issue #57 for Python 3.13 environments using reviewed native ComfyUI ER-SDE.
-- Python 3.10, 3.11 and 3.12 behavior remains unchanged.
-- Python 3.13 is now explicitly included in package classifiers and CI coverage.
-- Native fallback behavior remains fail-closed for genuinely unreviewed ER-SDE implementations.
+Dedicated regression coverage verifies strict KJ callback recognition/rejection, callback begin/end behavior including exception propagation, debug-off inertness, and the required wrapper ordering that keeps replay finalization telemetry outside external-patch bookkeeping.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.13"
+version = "0.2.14"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Release

Publish Spectrum MiniMax H3 v0.2.14 from the merged PR #55 native ER-SDE offline-replay hardening.

## Changes

- bump package version to `0.2.14`;
- publish release-specific notes for the reproduced native ER-SDE offline-replay WSL wedge boundary;
- document the narrow KJNodes Model Preview Override replay bypass and the retained first-pass preview behavior;
- document the new callback/noise/finalization debug boundaries;
- retain the explicit limitation that the historical WSL wedge root cause is not proven;
- preserve the v0.2.12 Diff-Aid compatibility layer and v0.2.13 Python 3.13 ER-SDE provenance fix.

## Release invariant

The release branch contains documentation/version metadata only. Runtime code is exactly the already-reviewed and green PR #55 merge on `main`.

The repository release workflow publishes `v0.2.14` only after the merged `main` commit passes the `tests` workflow, and builds the release archive plus `SHA256SUMS` from that tested commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native offline replay protection for the reviewed KJ preview callback.
  * Added provenance and closure validation, plus expanded replay boundary diagnostics.
  * Preserved live-preview behavior during capture while bypassing the callback during transformer-free replay.

* **Documentation**
  * Updated README and release notes with v0.2.14 behavior, compatibility details, and validation coverage.

* **Chores**
  * Bumped the project version to 0.2.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->