### PR TITLE
Isolate post-run generic-correction research from ComfyUI

### DIFF
--- a/comfyui_spectrum_h3/generic_correction_worker.py
+++ b/comfyui_spectrum_h3/generic_correction_worker.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import traceback
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from typing import Any
+
+_PACKAGE_NAME = "comfyui_spectrum_h3"
+
+
+def _load_research_module():
+    """Load the stdlib-only research path without executing package __init__."""
+    package_dir = Path(__file__).resolve().parent
+    package = sys.modules.get(_PACKAGE_NAME)
+    if package is None:
+        package = types.ModuleType(_PACKAGE_NAME)
+        package.__file__ = str(package_dir / "__init__.py")
+        package.__package__ = _PACKAGE_NAME
+        package.__path__ = [str(package_dir)]
+        package.__spec__ = ModuleSpec(_PACKAGE_NAME, loader=None, is_package=True)
+        package.__spec__.submodule_search_locations = [str(package_dir)]
+        sys.modules[_PACKAGE_NAME] = package
+    return importlib.import_module(f"{_PACKAGE_NAME}.generic_correction_research")
+
+
+def _run_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("worker payload must be a JSON object")
+    block = payload.get("block")
+    root = payload.get("root")
+    if not isinstance(block, dict):
+        raise ValueError("worker payload is missing a calibration block")
+    if not isinstance(root, str) or not root:
+        raise ValueError("worker payload is missing the research root")
+
+    research = _load_research_module()
+    result = research.persist_and_analyze(block, root=Path(root))
+    return {
+        "ok": True,
+        "duplicate": bool(result.duplicate),
+        "console_summary": result.console_summary,
+        "elapsed_seconds": float(result.elapsed_seconds),
+    }
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        result = _run_payload(payload)
+    except Exception:  # noqa: BLE001 - child reports failure to the parent process
+        traceback.print_exc(file=sys.stderr)
+        return 1
+
+    json.dump(result, sys.stdout, sort_keys=True, allow_nan=False)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/comfyui_spectrum_h3/postrun_safety.py
+++ b/comfyui_spectrum_h3/postrun_safety.py
@@ -1,20 +1,29 @@
 from __future__ import annotations
 
+import json
 import logging
+import signal
+import subprocess
+import sys
 import threading
 import time
+from pathlib import Path
 from typing import Any
 
 from . import generic_correction as _generic
 from .generic_correction_calibration import GenericCalibrationState
+from .generic_correction_research import default_store_root
 from .runtime import SpectrumH3Runtime
 
 LOG = logging.getLogger(__name__)
 
-# Generic-correction research is diagnostic-only. A single daemon worker is enough:
-# if one report job ever wedges, later jobs are skipped rather than accumulating
-# threads or blocking completed generations.
+# Generic-correction research is diagnostic-only. Keep at most one analysis in
+# flight, and run the evaluator in a separate interpreter so a native crash in
+# diagnostic code cannot terminate the live ComfyUI process. The watcher thread
+# only owns subprocess I/O/lifetime management; it never runs the evaluator.
 _RESEARCH_SLOT = threading.BoundedSemaphore(1)
+_RESEARCH_TIMEOUT_SECONDS = 30.0
+_RESEARCH_WORKER = Path(__file__).with_name("generic_correction_worker.py")
 _CORE_RUNTIME_END = _generic._ORIGINAL_RUNTIME_END
 
 
@@ -31,19 +40,89 @@ def _teardown_log(runtime: Any, event: str, **fields: Any) -> None:
     )
 
 
-def _research_worker(block: dict[str, Any]) -> None:
+def _stderr_tail(text: str, *, limit: int = 2000) -> str:
+    rendered = (text or "").strip()
+    if not rendered:
+        return ""
+    if len(rendered) > limit:
+        rendered = "..." + rendered[-limit:]
+    return rendered.replace("\n", " | ")
+
+
+def _signal_name(returncode: int) -> str:
+    number = -int(returncode)
     try:
-        result = _generic.persist_and_analyze(block)
-        duplicate_note = " (duplicate ignored)" if result.duplicate else ""
-        LOG.warning("\n%s%s", result.console_summary, duplicate_note)
+        return signal.Signals(number).name
+    except (ValueError, TypeError):
+        return f"signal {number}"
+
+
+def _research_process_watcher(
+    process: subprocess.Popen[str],
+    payload: str,
+) -> None:
+    try:
+        try:
+            stdout, stderr = process.communicate(
+                payload,
+                timeout=_RESEARCH_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            LOG.warning(
+                "Spectrum H3 generic-correction isolated research timed out after "
+                "%.1f s and was terminated; the completed generation remains valid%s",
+                _RESEARCH_TIMEOUT_SECONDS,
+                f": {_stderr_tail(stderr)}" if _stderr_tail(stderr) else "",
+            )
+            return
+
+        returncode = int(process.returncode or 0)
+        if returncode != 0:
+            detail = _stderr_tail(stderr)
+            if returncode < 0:
+                failure = f"terminated by {_signal_name(returncode)}"
+            else:
+                failure = f"exited with status {returncode}"
+            LOG.warning(
+                "Spectrum H3 generic-correction isolated research %s; the completed "
+                "generation remains valid%s",
+                failure,
+                f": {detail}" if detail else "",
+            )
+            return
+
+        try:
+            result = json.loads(stdout)
+        except (TypeError, json.JSONDecodeError) as exc:
+            LOG.warning(
+                "Spectrum H3 generic-correction isolated research returned malformed "
+                "output; the completed generation remains valid: %s%s",
+                exc,
+                f"; stderr={_stderr_tail(stderr)}" if _stderr_tail(stderr) else "",
+            )
+            return
+        if not isinstance(result, dict) or result.get("ok") is not True:
+            LOG.warning(
+                "Spectrum H3 generic-correction isolated research returned an invalid "
+                "result; the completed generation remains valid"
+            )
+            return
+
+        duplicate_note = " (duplicate ignored)" if result.get("duplicate") else ""
+        summary = str(result.get("console_summary") or "").strip()
+        if summary:
+            LOG.warning("\n%s%s", summary, duplicate_note)
+        elapsed = float(result.get("elapsed_seconds", 0.0))
         LOG.warning(
             "Spectrum H3 generic-correction post-run analysis completed in %.3f s",
-            result.elapsed_seconds,
+            elapsed,
         )
-    except Exception as exc:  # noqa: BLE001 - research must never affect generation
+    except Exception as exc:  # noqa: BLE001 - diagnostics must never affect generation
         LOG.warning(
-            "Spectrum H3 generic-correction background research failed; "
-            "the completed generation remains valid: %s",
+            "Spectrum H3 generic-correction research watcher failed; the completed "
+            "generation remains valid: %s",
             exc,
         )
     finally:
@@ -51,25 +130,60 @@ def _research_worker(block: dict[str, Any]) -> None:
 
 
 def _dispatch_research(block: dict[str, Any]) -> bool:
-    """Start one bounded daemon research job without joining the sampling path."""
+    """Dispatch one bounded, process-isolated research job without blocking sampling."""
     if not _RESEARCH_SLOT.acquire(blocking=False):
         LOG.warning(
             "Spectrum H3 generic-correction post-run research skipped because a "
-            "previous background analysis is still active"
+            "previous isolated analysis is still active"
         )
         return False
+
+    process: subprocess.Popen[str] | None = None
     try:
-        worker = threading.Thread(
-            target=_research_worker,
-            args=(block,),
-            name="SpectrumH3GenericResearch",
+        payload = json.dumps(
+            {
+                "block": block,
+                "root": str(default_store_root()),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-I",
+                "-X",
+                "faulthandler",
+                str(_RESEARCH_WORKER),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        watcher = threading.Thread(
+            target=_research_process_watcher,
+            args=(process, payload),
+            name="SpectrumH3GenericResearchWatcher",
             daemon=True,
         )
-        worker.start()
-    except Exception as exc:  # noqa: BLE001 - thread creation must not affect generation
+        watcher.start()
+    except Exception as exc:  # noqa: BLE001 - dispatch must not affect generation
+        if process is not None:
+            try:
+                process.kill()
+                process.communicate(timeout=1.0)
+            except Exception as cleanup_exc:  # noqa: BLE001 - best-effort cleanup
+                LOG.debug(
+                    "Spectrum H3 isolated research cleanup after dispatch failure failed: %s",
+                    cleanup_exc,
+                )
         _RESEARCH_SLOT.release()
         LOG.warning(
-            "Spectrum H3 generic-correction post-run research could not be dispatched; "
+            "Spectrum H3 generic-correction isolated research could not be dispatched; "
             "the completed generation remains valid: %s",
             exc,
         )
@@ -78,15 +192,13 @@ def _dispatch_research(block: dict[str, Any]) -> bool:
 
 
 def _safe_end_run(self: SpectrumH3Runtime, run_id: int) -> None:
-    """End a run before any optional research and expose teardown crash boundaries.
+    """End a run before optional research and expose teardown crash boundaries.
 
-    The previous generic-correction hook performed persistence/evaluation inline in
-    ``SpectrumH3Runtime.end_run``. That made diagnostic research part of the sampler
-    critical path: a filesystem/evaluator hang after the native sampler had already
-    returned could prevent downstream VAE/video nodes from ever receiving the valid
-    result. Keep calibration export synchronous and bounded, release runtime/VRAM
-    state synchronously, then transfer the tensor-free calibration block to at most
-    one daemon research worker.
+    Calibration export stays synchronous and bounded. Runtime/VRAM ownership is
+    released synchronously. The tensor-free calibration block is then handed to
+    at most one process-isolated research job. A Python exception, hang, or native
+    crash in that diagnostic evaluator therefore cannot terminate the ComfyUI
+    process or invalidate the completed generation.
     """
     active = getattr(self, "_run", None)
     if active is None or active.run_id != int(run_id):
@@ -155,6 +267,7 @@ def _safe_end_run(self: SpectrumH3Runtime, run_id: int) -> None:
             "research_dispatch",
             run_id=run_id,
             dispatched=dispatched,
+            isolation="subprocess",
         )
 
 

--- a/tests/test_postrun_safety.py
+++ b/tests/test_postrun_safety.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
 import threading
 import time
 from types import SimpleNamespace
+
+import pytest
 
 from comfyui_spectrum_h3 import external_patch_compat as external_compat
 from comfyui_spectrum_h3 import postrun_safety as postrun
@@ -37,6 +40,16 @@ def _fake_runtime(run_id: int = 7):
     )
 
 
+def _wait_for_research_slot(timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if postrun._RESEARCH_SLOT.acquire(blocking=False):
+            postrun._RESEARCH_SLOT.release()
+            return
+        time.sleep(0.01)
+    raise AssertionError("isolated research slot was not released")
+
+
 def test_safe_end_releases_runtime_before_dispatching_research(monkeypatch):
     runtime = _fake_runtime()
     events = []
@@ -69,68 +82,92 @@ def test_safe_end_releases_runtime_before_dispatching_research(monkeypatch):
     assert runtime.forecaster._generic_correction_capture_mode is None
 
 
-def test_dispatch_research_never_waits_for_worker_completion(monkeypatch):
+def test_dispatch_research_never_waits_for_isolated_worker_completion(
+    monkeypatch,
+    tmp_path,
+):
+    worker = tmp_path / "slow_worker.py"
+    worker.write_text("import time\ntime.sleep(0.5)\n", encoding="utf-8")
     monkeypatch.setattr(postrun, "_RESEARCH_SLOT", threading.BoundedSemaphore(1))
-    started = threading.Event()
-    release = threading.Event()
-    finished = threading.Event()
-
-    def persist(_block):
-        started.set()
-        assert release.wait(timeout=2.0)
-        finished.set()
-        return SimpleNamespace(
-            duplicate=False,
-            console_summary="synthetic research",
-            elapsed_seconds=0.01,
-        )
-
-    monkeypatch.setattr(postrun._generic, "persist_and_analyze", persist)
+    monkeypatch.setattr(postrun, "_RESEARCH_WORKER", worker)
+    monkeypatch.setattr(postrun, "default_store_root", lambda: tmp_path)
+    monkeypatch.setattr(postrun, "_RESEARCH_TIMEOUT_SECONDS", 2.0)
 
     began = time.perf_counter()
     assert postrun._dispatch_research({"compatible": True})
     elapsed = time.perf_counter() - began
 
     assert elapsed < 0.25
-    assert started.wait(timeout=1.0)
-    assert not finished.is_set()
     assert not postrun._dispatch_research({"compatible": True})
-
-    release.set()
-    assert finished.wait(timeout=1.0)
-    deadline = time.monotonic() + 1.0
-    acquired = False
-    while time.monotonic() < deadline:
-        if postrun._RESEARCH_SLOT.acquire(blocking=False):
-            acquired = True
-            break
-        time.sleep(0.01)
-    assert acquired
-    postrun._RESEARCH_SLOT.release()
+    _wait_for_research_slot()
 
 
-def test_background_research_failure_releases_single_worker_slot(monkeypatch):
+@pytest.mark.skipif(os.name != "posix", reason="POSIX signal semantics required")
+def test_isolated_research_sigsegv_cannot_terminate_parent(
+    monkeypatch,
+    tmp_path,
+    caplog,
+):
+    worker = tmp_path / "segv_worker.py"
+    worker.write_text(
+        "import os, signal\nos.kill(os.getpid(), signal.SIGSEGV)\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(postrun, "_RESEARCH_SLOT", threading.BoundedSemaphore(1))
-    attempted = threading.Event()
+    monkeypatch.setattr(postrun, "_RESEARCH_WORKER", worker)
+    monkeypatch.setattr(postrun, "default_store_root", lambda: tmp_path)
+    monkeypatch.setattr(postrun, "_RESEARCH_TIMEOUT_SECONDS", 2.0)
 
-    def persist(_block):
-        attempted.set()
-        raise OSError("synthetic report failure")
+    with caplog.at_level("WARNING"):
+        assert postrun._dispatch_research({"compatible": True})
+        _wait_for_research_slot()
 
-    monkeypatch.setattr(postrun._generic, "persist_and_analyze", persist)
+    assert "isolated research terminated by SIGSEGV" in caplog.text
+    assert "completed generation remains valid" in caplog.text
 
-    assert postrun._dispatch_research({"compatible": True})
-    assert attempted.wait(timeout=1.0)
 
-    deadline = time.monotonic() + 1.0
-    acquired = False
-    while time.monotonic() < deadline:
-        if postrun._RESEARCH_SLOT.acquire(blocking=False):
-            acquired = True
-            break
-        time.sleep(0.01)
-    assert acquired
-    postrun._RESEARCH_SLOT.release()
+def test_isolated_research_python_failure_releases_worker_slot(
+    monkeypatch,
+    tmp_path,
+    caplog,
+):
+    worker = tmp_path / "failed_worker.py"
+    worker.write_text(
+        "import sys\nsys.stderr.write('synthetic report failure\\n')\nraise SystemExit(3)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(postrun, "_RESEARCH_SLOT", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(postrun, "_RESEARCH_WORKER", worker)
+    monkeypatch.setattr(postrun, "default_store_root", lambda: tmp_path)
+    monkeypatch.setattr(postrun, "_RESEARCH_TIMEOUT_SECONDS", 2.0)
+
+    with caplog.at_level("WARNING"):
+        assert postrun._dispatch_research({"compatible": True})
+        _wait_for_research_slot()
+
+    assert "isolated research exited with status 3" in caplog.text
+    assert "synthetic report failure" in caplog.text
+
+
+def test_worker_script_loads_research_without_package_entrypoint(tmp_path):
+    completed = postrun.subprocess.run(
+        [
+            postrun.sys.executable,
+            "-I",
+            str(postrun._RESEARCH_WORKER),
+        ],
+        input='{"block":{},"root":"' + str(tmp_path).replace("\\", "\\\\") + '"}',
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=5.0,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "CalibrationError" in completed.stderr
+    assert "unsupported generic calibration schema" in completed.stderr
 
 
 def test_installed_runtime_end_run_preserves_postrun_chain_identity():


### PR DESCRIPTION
## Problem

A real single-pass native ER-SDE run completed sampling and runtime teardown, dispatched generic-correction post-run research, then moved on to `VAEDecodeAudio`. The process subsequently died with SIGSEGV/status 139 while the daemon research thread was in `generic_correction_evaluator.py::_ratio`.

The existing `postrun_safety` invariant says diagnostic research must never invalidate a completed generation, but an in-process Python thread cannot provide that guarantee: a native crash in any thread terminates the entire ComfyUI process, and `except Exception` cannot catch SIGSEGV.

## Fix

- move the generic-correction evaluator/report path into a separate isolated Python subprocess;
- keep sampler teardown non-blocking by using a lightweight watcher thread only for subprocess I/O/lifetime management;
- launch the child with `-I` and `faulthandler`, and load only the stdlib research/evaluator modules without executing the package entrypoint;
- retain the existing single-worker bound so research jobs cannot accumulate;
- cap a wedged analysis at 30 seconds and terminate only the child;
- report child Python failures, timeouts, and fatal signals without affecting the completed generation;
- preserve the ordering invariant: calibration export -> core runtime/VRAM release -> optional research dispatch.

## Regression coverage

- runtime state is still released before research dispatch;
- dispatch remains non-blocking and bounded to one in-flight analysis;
- an intentionally SIGSEGVing research child is contained and the parent test process survives;
- nonzero child failures release the worker slot and are surfaced in logs;
- the isolated worker can load the research path under `python -I` without executing `comfyui_spectrum_h3.__init__`;
- end-run hook identity/compatibility chaining remains intact.

This specifically addresses the observed process-wide crash without changing Spectrum forecasting, ER-SDE solver behavior, offline replay, or downstream VAE behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Isolated post-run research processing so crashes and failures no longer interrupt completed generations.
  * Added timeout handling and clearer error reporting for stalled or failed processing.
  * Ensured processing capacity is released after failures, malformed results, or terminated tasks.

* **Reliability**
  * Post-run analysis now runs asynchronously without blocking the main application.
  * Added validation for calibration data and result output to improve safety and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->