### PR TITLE
Recognize Untwist H3 visual-reference external patch profiles

### DIFF
--- a/comfyui_spectrum_h3/__init__.py
+++ b/comfyui_spectrum_h3/__init__.py
@@ -3,6 +3,7 @@ from .er_sde_offline_replay_safety import install_er_sde_offline_replay_safety
 from .er_sde_policy import install_er_sde_tail_policy
 from .external_patch_compat import install_external_patch_compat
 from .external_patch_hardening import install_external_patch_hardening
+from .external_patch_visual_reference import install_visual_reference_patch_compat
 from .forecast import HistoryWeightForecaster
 from .generic_correction import install_generic_residual_correction
 from .minimax_h3 import locate_minimax_h3_inner, require_native_minimax_h3
@@ -34,6 +35,7 @@ install_replay_calibration_validation()
 install_replay_calibration_provenance()
 install_er_sde_tail_policy()
 install_external_patch_compat()
+install_visual_reference_patch_compat()
 install_external_patch_hardening()
 install_er_sde_offline_replay_safety()
 

--- a/comfyui_spectrum_h3/external_patch_visual_reference.py
+++ b/comfyui_spectrum_h3/external_patch_visual_reference.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any
+
+from . import external_patch_compat as compat
+
+
+VISUAL_PATCH_PROFILES_KEY = "spectrum_h3_visual_reference_patch_profiles"
+VISUAL_PATCH_RUNTIME_KEY = "spectrum_h3_visual_reference_patch_runtime"
+VISUAL_PATCH_SCHEMA_VERSION = 1
+VISUAL_PATCH_PROVIDER = "comfyui-flux2-untwisting-rope"
+VISUAL_PATCH_KIND = "visual_reference_attention_modulation"
+VISUAL_PATCH_ARCHITECTURE = "minimax_h3"
+VISUAL_PATCH_SCOPES = frozenset(
+    {"image_only", "image_and_video", "all_visual_including_continuum"}
+)
+
+_INSTALLED = False
+_ORIGINAL_PARSE = None
+_ORIGINAL_RUNTIME_ENTRIES = None
+
+
+def _required_bool(mapping: dict[str, Any], name: str, *, position: int) -> bool:
+    value = mapping.get(name)
+    if not isinstance(value, bool):
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].{name} must be a boolean"
+        )
+    return value
+
+
+def _finite(mapping: dict[str, Any], name: str, *, position: int) -> float:
+    return compat._finite_number(
+        mapping.get(name),
+        name=f"visual_profile[{position}].{name}",
+    )
+
+
+def _parse_visual_profile(
+    raw: Any,
+    *,
+    block_count: int,
+    position: int,
+) -> tuple[compat.ExternalPatchDescriptor, tuple[Any, ...]]:
+    if not isinstance(raw, dict):
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] must be a dictionary"
+        )
+
+    schema = raw.get("schema_version")
+    if isinstance(schema, bool) or not isinstance(schema, int):
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].schema_version must be an integer"
+        )
+    if schema != VISUAL_PATCH_SCHEMA_VERSION:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] uses unsupported schema_version={schema}"
+        )
+
+    provider = compat._required_string(raw, "provider")
+    kind = compat._required_string(raw, "kind")
+    architecture = compat._required_string(raw, "architecture")
+    instance_id = compat._required_string(raw, "instance_id")
+    scope = compat._required_string(raw, "scope")
+    if provider != VISUAL_PATCH_PROVIDER:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] uses unsupported provider={provider!r}"
+        )
+    if kind != VISUAL_PATCH_KIND:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] uses unsupported kind={kind!r}"
+        )
+    if architecture != VISUAL_PATCH_ARCHITECTURE:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] architecture={architecture!r} is not MiniMax H3"
+        )
+    if scope not in VISUAL_PATCH_SCOPES:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] uses unsupported scope={scope!r}"
+        )
+
+    declared_count = raw.get("model_block_count")
+    if isinstance(declared_count, bool) or not isinstance(declared_count, int) or declared_count <= 0:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].model_block_count must be a positive integer"
+        )
+    if declared_count != int(block_count):
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] declares {declared_count} blocks but detected H3 has {block_count}"
+        )
+
+    raw_indices = raw.get("block_indices_0based")
+    if not isinstance(raw_indices, (tuple, list)) or not raw_indices:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].block_indices_0based must be a non-empty sequence"
+        )
+    indices: list[int] = []
+    for index in raw_indices:
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise compat.ExternalPatchContractError(
+                f"visual_profile[{position}] block indices must be integers"
+            )
+        if index < 0 or index >= block_count:
+            raise compat.ExternalPatchContractError(
+                f"visual_profile[{position}] block index {index} is outside 0..{block_count - 1}"
+            )
+        indices.append(index)
+    if len(set(indices)) != len(indices):
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] contains duplicate block indices"
+        )
+
+    strength = _finite(raw, "strength", position=position)
+    if strength < 0.0:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].strength must be >= 0"
+        )
+    progress_start = _finite(raw, "progress_start", position=position)
+    progress_end = _finite(raw, "progress_end", position=position)
+    if not 0.0 <= progress_start <= progress_end <= 1.0:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}] requires 0 <= progress_start <= progress_end <= 1"
+        )
+    hard_start = _required_bool(raw, "hard_start", position=position)
+    hard_end = _required_bool(raw, "hard_end", position=position)
+
+    high_start = _finite(raw, "high_scale_start", position=position)
+    high_end = _finite(raw, "high_scale_end", position=position)
+    low_start = _finite(raw, "low_scale_start", position=position)
+    low_end = _finite(raw, "low_scale_end", position=position)
+    beta = _finite(raw, "beta", position=position)
+    if beta <= 0.0:
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].beta must be > 0"
+        )
+    scale_temporal_axis = _required_bool(
+        raw,
+        "scale_temporal_axis",
+        position=position,
+    )
+
+    expected_strength = max(
+        abs(high_start - 1.0),
+        abs(high_end - 1.0),
+        abs(low_start - 1.0),
+        abs(low_end - 1.0),
+    )
+    if not math.isclose(strength, expected_strength, rel_tol=1e-9, abs_tol=1e-9):
+        raise compat.ExternalPatchContractError(
+            f"visual_profile[{position}].strength does not match the declared scale endpoints"
+        )
+
+    # Spectrum's existing transaction guard operates on an inclusive normalized
+    # sigma interval. Convert only boundaries that the producer declares hard;
+    # a soft boundary is widened to the edge so it cannot spuriously force an
+    # actual step. Progress increases as sampling proceeds, hence the inversion.
+    guard_progress_start = progress_start if hard_start else 0.0
+    guard_progress_end = progress_end if hard_end else 1.0
+    sigma_start = 1.0 - guard_progress_end
+    sigma_end = 1.0 - guard_progress_start
+
+    descriptor = compat.ExternalPatchDescriptor(
+        schema_version=schema,
+        provider=provider,
+        kind=kind,
+        architecture=architecture,
+        instance_id=instance_id,
+        block_indices_0based=tuple(indices),
+        model_block_count=declared_count,
+        strength=strength,
+        sigma_start=sigma_start,
+        sigma_end=sigma_end,
+        sigma_ramp=0.0,
+        token_weight_mode="none",
+        token_tail=1.0,
+        cond_only=False,
+        scope=scope,
+    )
+    canonical = descriptor.canonical + (
+        "visual_reference_profile_v1",
+        progress_start,
+        progress_end,
+        hard_start,
+        hard_end,
+        high_start,
+        high_end,
+        low_start,
+        low_end,
+        beta,
+        scale_temporal_axis,
+    )
+    return descriptor, canonical
+
+
+def parse_external_patch_contracts_with_visual_references(
+    model_options: dict[str, Any] | None,
+    *,
+    block_count: int,
+) -> compat.ParsedExternalPatchContracts:
+    assert _ORIGINAL_PARSE is not None
+    base = _ORIGINAL_PARSE(model_options, block_count=block_count)
+    options = model_options or {}
+    raw = options.get(VISUAL_PATCH_PROFILES_KEY)
+    if raw is None:
+        return base
+    if not isinstance(raw, (tuple, list)):
+        raise compat.ExternalPatchContractError(
+            f"{VISUAL_PATCH_PROFILES_KEY} must be a sequence of descriptors"
+        )
+
+    parsed_visual = tuple(
+        _parse_visual_profile(value, block_count=int(block_count), position=index)
+        for index, value in enumerate(raw)
+    )
+    if not parsed_visual:
+        return base
+
+    descriptors = tuple(base.descriptors) + tuple(value[0] for value in parsed_visual)
+    instance_ids = [value.instance_id for value in descriptors]
+    if len(set(instance_ids)) != len(instance_ids):
+        raise compat.ExternalPatchContractError(
+            "external patch instance_id values must be unique across all profile kinds"
+        )
+
+    canonical = tuple(base.canonical) + tuple(value[1] for value in parsed_visual)
+    fingerprint = hashlib.sha256(
+        repr(canonical).encode("utf-8", "backslashreplace")
+    ).hexdigest()
+    return compat.ParsedExternalPatchContracts(descriptors, canonical, fingerprint)
+
+
+def _visual_runtime_entries(
+    transformer_options: dict[str, Any],
+    descriptors: tuple[compat.ExternalPatchDescriptor, ...],
+) -> list[dict[str, Any]]:
+    if not descriptors:
+        raw = transformer_options.get(VISUAL_PATCH_RUNTIME_KEY)
+        if raw not in (None, (), []):
+            raise compat.ExternalPatchContractError(
+                "visual-reference runtime state exists without a declared static profile"
+            )
+        return []
+
+    raw = transformer_options.get(VISUAL_PATCH_RUNTIME_KEY)
+    if not isinstance(raw, (tuple, list)):
+        raise compat.ExternalPatchContractError(
+            f"{VISUAL_PATCH_RUNTIME_KEY} is missing or is not a sequence"
+        )
+
+    by_id: dict[str, dict[str, Any]] = {}
+    for position, value in enumerate(raw):
+        if not isinstance(value, dict):
+            raise compat.ExternalPatchContractError(
+                f"visual_runtime[{position}] must be a dictionary"
+            )
+        schema = value.get("schema_version")
+        if isinstance(schema, bool) or not isinstance(schema, int) or schema != VISUAL_PATCH_SCHEMA_VERSION:
+            raise compat.ExternalPatchContractError(
+                f"visual_runtime[{position}] has unsupported schema_version"
+            )
+        provider = compat._required_string(value, "provider")
+        instance_id = compat._required_string(value, "instance_id")
+        if provider != VISUAL_PATCH_PROVIDER:
+            raise compat.ExternalPatchContractError(
+                f"visual_runtime[{position}] uses unsupported provider={provider!r}"
+            )
+        if instance_id in by_id:
+            raise compat.ExternalPatchContractError(
+                f"duplicate visual runtime state for external patch instance {instance_id!r}"
+            )
+        progress = compat._finite_number(
+            value.get("schedule_progress"),
+            name=f"visual_runtime[{instance_id}].schedule_progress",
+        )
+        if not 0.0 <= progress <= 1.0:
+            raise compat.ExternalPatchContractError(
+                f"visual runtime progress for {instance_id!r} is outside [0, 1]"
+            )
+        active = value.get("active")
+        if not isinstance(active, bool):
+            raise compat.ExternalPatchContractError(
+                f"visual_runtime[{instance_id}].active must be a boolean"
+            )
+        by_id[instance_id] = {
+            "schema_version": VISUAL_PATCH_SCHEMA_VERSION,
+            "provider": provider,
+            "instance_id": instance_id,
+            "normalized_sigma": 1.0 - progress,
+        }
+
+    expected = {value.instance_id for value in descriptors}
+    if set(by_id) != expected:
+        missing = sorted(expected - set(by_id))
+        extra = sorted(set(by_id) - expected)
+        raise compat.ExternalPatchContractError(
+            f"visual patch runtime/static instance mismatch missing={missing} extra={extra}"
+        )
+    return [by_id[value.instance_id] for value in descriptors]
+
+
+def runtime_entries_with_visual_references(
+    transformer_options: dict[str, Any],
+    parsed: compat.ParsedExternalPatchContracts,
+) -> tuple[float, ...]:
+    assert _ORIGINAL_RUNTIME_ENTRIES is not None
+    visual_descriptors = tuple(
+        value for value in parsed.descriptors if value.kind == VISUAL_PATCH_KIND
+    )
+    if not visual_descriptors:
+        return _ORIGINAL_RUNTIME_ENTRIES(transformer_options, parsed)
+
+    raw_legacy = transformer_options.get(compat.EXTERNAL_PATCH_RUNTIME_KEY)
+    if raw_legacy is None:
+        legacy_entries: list[Any] = []
+    elif isinstance(raw_legacy, (tuple, list)):
+        legacy_entries = list(raw_legacy)
+    else:
+        raise compat.ExternalPatchContractError(
+            f"{compat.EXTERNAL_PATCH_RUNTIME_KEY} is not a sequence"
+        )
+
+    synthetic_visual = _visual_runtime_entries(
+        transformer_options,
+        visual_descriptors,
+    )
+    combined = dict(transformer_options)
+    combined[compat.EXTERNAL_PATCH_RUNTIME_KEY] = tuple(legacy_entries + synthetic_visual)
+    return _ORIGINAL_RUNTIME_ENTRIES(combined, parsed)
+
+
+def install_visual_reference_patch_compat() -> None:
+    global _INSTALLED, _ORIGINAL_PARSE, _ORIGINAL_RUNTIME_ENTRIES
+    if _INSTALLED:
+        return
+    if not compat._INSTALLED:
+        raise RuntimeError(
+            "visual-reference external patch support requires install_external_patch_compat() first"
+        )
+
+    _ORIGINAL_PARSE = compat.parse_external_patch_contracts
+    _ORIGINAL_RUNTIME_ENTRIES = compat._runtime_entries
+    compat.parse_external_patch_contracts = parse_external_patch_contracts_with_visual_references
+    compat._runtime_entries = runtime_entries_with_visual_references
+    _INSTALLED = True
+
+
+__all__ = [
+    "VISUAL_PATCH_ARCHITECTURE",
+    "VISUAL_PATCH_KIND",
+    "VISUAL_PATCH_PROFILES_KEY",
+    "VISUAL_PATCH_PROVIDER",
+    "VISUAL_PATCH_RUNTIME_KEY",
+    "VISUAL_PATCH_SCHEMA_VERSION",
+    "install_visual_reference_patch_compat",
+    "parse_external_patch_contracts_with_visual_references",
+    "runtime_entries_with_visual_references",
+]

--- a/tests/test_external_patch_visual_reference.py
+++ b/tests/test_external_patch_visual_reference.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from comfyui_spectrum_h3 import external_patch_compat as compat
+from comfyui_spectrum_h3 import external_patch_visual_reference as visual
+
+
+def diffaid_contract(**overrides):
+    value = {
+        "schema_version": 1,
+        "provider": "comfyui-diffaid-patches",
+        "kind": "text_activation_modulation",
+        "architecture": "minimax_h3",
+        "instance_id": "diffaid-h3-1",
+        "block_indices_0based": [0, 1, 2, 3, 4],
+        "model_block_count": 5,
+        "strength": 0.2,
+        "sigma_start": 0.0,
+        "sigma_end": 1.0,
+        "sigma_ramp": 0.0,
+        "token_weight_mode": "none",
+        "token_tail": 0.35,
+        "cond_only": True,
+        "scope": "native_mod_segments_tag_1_only",
+    }
+    value.update(overrides)
+    return value
+
+
+def untwist_profile(**overrides):
+    value = {
+        "schema_version": 1,
+        "provider": visual.VISUAL_PATCH_PROVIDER,
+        "kind": visual.VISUAL_PATCH_KIND,
+        "architecture": visual.VISUAL_PATCH_ARCHITECTURE,
+        "instance_id": "untwist-h3-1",
+        "block_indices_0based": [0, 1, 2, 3, 4],
+        "model_block_count": 5,
+        "strength": 0.25,
+        "progress_start": 0.0,
+        "progress_end": 0.90,
+        "hard_start": False,
+        "hard_end": True,
+        "scope": "image_and_video",
+        "high_scale_start": 0.75,
+        "high_scale_end": 0.90,
+        "low_scale_start": 1.0,
+        "low_scale_end": 1.05,
+        "beta": 2.0,
+        "scale_temporal_axis": False,
+    }
+    value.update(overrides)
+    return value
+
+
+def parse(*, include_diffaid=True, profile=None):
+    options = {visual.VISUAL_PATCH_PROFILES_KEY: [profile or untwist_profile()]}
+    if include_diffaid:
+        options[compat.EXTERNAL_PATCH_CONTRACTS_KEY] = [diffaid_contract()]
+    return compat.parse_external_patch_contracts(options, block_count=5)
+
+
+def visual_runtime(progress, *, active=True):
+    return {
+        visual.VISUAL_PATCH_RUNTIME_KEY: (
+            {
+                "schema_version": 1,
+                "provider": visual.VISUAL_PATCH_PROVIDER,
+                "instance_id": "untwist-h3-1",
+                "schedule_progress": progress,
+                "active": active,
+            },
+        )
+    }
+
+
+def test_stacked_diffaid_and_untwist_profiles_preserve_distinct_kinds():
+    parsed = parse()
+    assert len(parsed.descriptors) == 2
+    assert [value.kind for value in parsed.descriptors] == [
+        "text_activation_modulation",
+        "visual_reference_attention_modulation",
+    ]
+    visual_descriptor = parsed.descriptors[1]
+    assert visual_descriptor.scope == "image_and_video"
+    assert visual_descriptor.sigma_start == pytest.approx(0.10)
+    assert visual_descriptor.sigma_end == 1.0
+    assert visual_descriptor.has_hard_temporal_transition is True
+
+
+def test_visual_strength_metadata_changes_external_profile_fingerprint():
+    first = parse(include_diffaid=False)
+    second = parse(
+        include_diffaid=False,
+        profile=untwist_profile(
+            strength=0.20,
+            high_scale_start=0.80,
+        ),
+    )
+    assert first.fingerprint != second.fingerprint
+
+
+def test_external_model_profile_counts_diffaid_and_untwist_separately():
+    parsed = parse()
+    base = SimpleNamespace(
+        active_patch_count=0,
+        active_patch_keys=0,
+        profile_confidence=1.0,
+        aggregate_sensitivity=0.0,
+        patch_perturbation=0.0,
+        final_block_perturbation=0.0,
+        forecast_risk_prior=0.0,
+        build_seconds=0.0,
+        estimated_bytes=0,
+        transient_workspace_bytes=0,
+        patch_identity="base",
+    )
+    lookup = SimpleNamespace(profile=base, cache_hit=True)
+    profile = compat._external_profile_from_base(
+        lookup,
+        parsed,
+        cache_key=("test", parsed.fingerprint),
+        adjustment_started=time.perf_counter(),
+    )
+    assert profile.recognized_runtime_patch_count == 2
+    assert profile.active_patch_count == 2
+    assert profile.runtime_patch_kinds == (
+        "text_activation_modulation",
+        "visual_reference_attention_modulation",
+    )
+
+
+class FakeRuntime:
+    def __init__(self, parsed_contracts):
+        self.config = SimpleNamespace(debug=False, model_aware_mode="off")
+        self._step = None
+        self.disabled_reason = None
+        state = compat._compat_state(self)
+        state.parsed = parsed_contracts
+        state.contract_failure = None
+        state.run = compat._ExternalRunState(
+            run_id=1,
+            parsed=parsed_contracts,
+            replay=False,
+        )
+
+    def set_step(self, step_id, mode):
+        self._step = SimpleNamespace(
+            step_id=step_id,
+            mode=mode,
+            reason="scheduled",
+            adaptive_recompute=False,
+            bootstrap_forecast=False,
+            model_aware_decision=None,
+            model_aware_forced_actual=False,
+        )
+        setattr(
+            self,
+            compat._CURRENT_DECISION_ATTR,
+            {
+                "run_id": 1,
+                "step_id": step_id,
+                "actual": mode == "actual",
+                "reason": "scheduled",
+            },
+        )
+
+    def _disable_forecasting(self, reason):
+        self.disabled_reason = str(reason)
+
+
+def commit_pending(fake):
+    run = compat._compat_state(fake).run
+    run.committed_active = run.pending_active
+    run.committed_sigma = run.pending_sigma
+    run.committed_step_id = run.pending_step_id
+    run.pending_step_id = None
+    run.pending_active = None
+    run.pending_sigma = None
+    run.pending_transition_indices = ()
+
+
+def test_untwist_end_percent_transition_forces_actual_after_point_nine():
+    parsed = parse(include_diffaid=False)
+    fake = FakeRuntime(parsed)
+
+    fake.set_step(16, "actual")
+    assert compat.observe_external_patch_runtime(
+        fake,
+        visual_runtime(16 / 18, active=True),
+    ) is True
+    commit_pending(fake)
+
+    fake.set_step(17, "forecast")
+    assert compat.observe_external_patch_runtime(
+        fake,
+        visual_runtime(17 / 18, active=False),
+    ) is True
+    assert fake._step.mode == "actual"
+    assert fake._step.reason == "external patch hard sigma transition"
+    run = compat._compat_state(fake).run
+    assert run.transitions == 1
+    assert run.forced_actuals == 1
+
+
+def test_visual_runtime_is_required_when_static_profile_exists():
+    parsed = parse(include_diffaid=False)
+    with pytest.raises(compat.ExternalPatchContractError, match="visual_reference_patch_runtime"):
+        compat._runtime_entries({}, parsed)


### PR DESCRIPTION
## Summary

Adds Spectrum-side recognition for MiniMax H3 Untwisting RoPE runtime profiles without weakening the existing Diff-Aid external-patch contract.

## Why this is required

Untwist modifies native H3 visual-reference attention and has a hard denoising-window transition. Spectrum previously understood only Diff-Aid's `text_activation_modulation` contract, so publishing Untwist through that existing schema would either mislabel the patch or be rejected and force an all-actual fail-safe.

This PR adds a separate, backward-compatible producer contract for `visual_reference_attention_modulation`. Older Spectrum versions ignore the new namespaced keys; this version validates them and folds them into the existing transaction guard.

## Behavior

- accepts `spectrum_h3_visual_reference_patch_profiles` static descriptors;
- accepts per-call `spectrum_h3_visual_reference_patch_runtime` progress state;
- preserves Diff-Aid's existing schema and runtime handling unchanged;
- keeps distinct external patch kinds in model-aware/debug telemetry;
- converts only producer-declared hard progress boundaries into Spectrum's transaction guard;
- forces an actual step when Untwist crosses a hard boundary, including the default `end_percent=0.90` transition;
- fingerprints the full Untwist strength metadata (`high/low` endpoints, `beta`, scope, temporal-axis mode), so behaviorally different profiles do not share a cache identity.

With Diff-Aid and Untwist stacked, the recognized profile is expected to report two runtime patches with kinds `text_activation_modulation,visual_reference_attention_modulation`.

## Tests

Regression coverage verifies stacked kind recognition/counting, strength-profile fingerprinting, and promotion of the first post-0.90 forecast step to an actual step.

Companion implementation: xmarre/ComfyUI-Flux.2-Untwisting-RoPE#2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility for visual-reference patches with MiniMax H3.
  * Supports combining visual-reference and other external patch contracts.
  * Preserves visual profile details and schedules runtime processing across configured progress ranges.
  * Validates required visual-reference metadata and reports invalid runtime configurations.

* **Tests**
  * Added coverage for combined patch types, profile changes, runtime scheduling, and missing metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->