### PR TITLE
Harden isolated research crash and timeout teardown

### DIFF
--- a/comfyui_spectrum_h3/postrun_safety.py
+++ b/comfyui_spectrum_h3/postrun_safety.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import signal
 import subprocess
 import sys
@@ -23,7 +24,23 @@ LOG = logging.getLogger(__name__)
 # only owns subprocess I/O/lifetime management; it never runs the evaluator.
 _RESEARCH_SLOT = threading.BoundedSemaphore(1)
 _RESEARCH_TIMEOUT_SECONDS = 30.0
+_RESEARCH_TERMINATION_GRACE_SECONDS = 1.0
 _RESEARCH_WORKER = Path(__file__).with_name("generic_correction_worker.py")
+_RESEARCH_BOOTSTRAP = """\
+import os
+import runpy
+import sys
+
+if os.name == "posix":
+    try:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+    except (ImportError, OSError, ValueError):
+        pass
+
+runpy.run_path(sys.argv[1], run_name="__main__")
+"""
 _CORE_RUNTIME_END = _generic._ORIGINAL_RUNTIME_END
 
 
@@ -49,12 +66,60 @@ def _stderr_tail(text: str, *, limit: int = 2000) -> str:
     return rendered.replace("\n", " | ")
 
 
+def _timeout_stream_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def _signal_name(returncode: int) -> str:
     number = -int(returncode)
     try:
         return signal.Signals(number).name
     except (ValueError, TypeError):
         return f"signal {number}"
+
+
+def _research_command(worker: Path | None = None) -> list[str]:
+    target = _RESEARCH_WORKER if worker is None else worker
+    return [
+        sys.executable,
+        "-I",
+        "-X",
+        "faulthandler",
+        "-c",
+        _RESEARCH_BOOTSTRAP,
+        str(target),
+    ]
+
+
+def _kill_research_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+            return
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+    try:
+        process.kill()
+    except ProcessLookupError:
+        pass
+
+
+def _close_process_pipes(process: subprocess.Popen[str]) -> None:
+    for stream in (process.stdin, process.stdout, process.stderr):
+        if stream is None:
+            continue
+        try:
+            stream.close()
+        except OSError:
+            pass
 
 
 def _research_process_watcher(
@@ -67,15 +132,36 @@ def _research_process_watcher(
                 payload,
                 timeout=_RESEARCH_TIMEOUT_SECONDS,
             )
-        except subprocess.TimeoutExpired:
-            process.kill()
-            stdout, stderr = process.communicate()
-            LOG.warning(
-                "Spectrum H3 generic-correction isolated research timed out after "
-                "%.1f s and was terminated; the completed generation remains valid%s",
-                _RESEARCH_TIMEOUT_SECONDS,
-                f": {_stderr_tail(stderr)}" if _stderr_tail(stderr) else "",
-            )
+        except subprocess.TimeoutExpired as exc:
+            partial_stderr = _timeout_stream_text(exc.stderr)
+            _kill_research_process(process)
+            cleanup_timed_out = False
+            try:
+                _, stderr = process.communicate(
+                    timeout=_RESEARCH_TERMINATION_GRACE_SECONDS
+                )
+            except subprocess.TimeoutExpired as cleanup_exc:
+                cleanup_timed_out = True
+                stderr = _timeout_stream_text(cleanup_exc.stderr) or partial_stderr
+                _close_process_pipes(process)
+
+            detail = _stderr_tail(stderr or partial_stderr)
+            if cleanup_timed_out:
+                LOG.warning(
+                    "Spectrum H3 generic-correction isolated research timed out after "
+                    "%.1f s; forced termination did not drain within %.1f s. The "
+                    "completed generation remains valid%s",
+                    _RESEARCH_TIMEOUT_SECONDS,
+                    _RESEARCH_TERMINATION_GRACE_SECONDS,
+                    f": {detail}" if detail else "",
+                )
+            else:
+                LOG.warning(
+                    "Spectrum H3 generic-correction isolated research timed out after "
+                    "%.1f s and was terminated; the completed generation remains valid%s",
+                    _RESEARCH_TIMEOUT_SECONDS,
+                    f": {detail}" if detail else "",
+                )
             return
 
         returncode = int(process.returncode or 0)
@@ -150,19 +236,14 @@ def _dispatch_research(block: dict[str, Any]) -> bool:
             allow_nan=False,
         )
         process = subprocess.Popen(
-            [
-                sys.executable,
-                "-I",
-                "-X",
-                "faulthandler",
-                str(_RESEARCH_WORKER),
-            ],
+            _research_command(),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             encoding="utf-8",
             errors="replace",
+            start_new_session=(os.name == "posix"),
         )
         watcher = threading.Thread(
             target=_research_process_watcher,
@@ -174,8 +255,10 @@ def _dispatch_research(block: dict[str, Any]) -> bool:
     except Exception as exc:  # noqa: BLE001 - dispatch must not affect generation
         if process is not None:
             try:
-                process.kill()
-                process.communicate(timeout=1.0)
+                _kill_research_process(process)
+                process.communicate(timeout=_RESEARCH_TERMINATION_GRACE_SECONDS)
+            except subprocess.TimeoutExpired:
+                _close_process_pipes(process)
             except Exception as cleanup_exc:  # noqa: BLE001 - best-effort cleanup
                 LOG.debug(
                     "Spectrum H3 isolated research cleanup after dispatch failure failed: %s",

--- a/comfyui_spectrum_h3/postrun_safety.py
+++ b/comfyui_spectrum_h3/postrun_safety.py
@@ -41,6 +41,13 @@ if os.name == "posix":
 
 runpy.run_path(sys.argv[1], run_name="__main__")
 """
+_FAULTHANDLER_FATAL_SIGNALS = (
+    ("Fatal Python error: Segmentation fault", "SIGSEGV"),
+    ("Fatal Python error: Aborted", "SIGABRT"),
+    ("Fatal Python error: Bus error", "SIGBUS"),
+    ("Fatal Python error: Illegal instruction", "SIGILL"),
+    ("Fatal Python error: Floating-point exception", "SIGFPE"),
+)
 _CORE_RUNTIME_END = _generic._ORIGINAL_RUNTIME_END
 
 
@@ -72,6 +79,14 @@ def _timeout_stream_text(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value
+
+
+def _fatal_signal_from_stderr(text: str) -> str | None:
+    """Normalize a fatal signal already reported by CPython's faulthandler."""
+    for marker, signal_name in _FAULTHANDLER_FATAL_SIGNALS:
+        if marker in text:
+            return signal_name
+    return None
 
 
 def _signal_name(returncode: int) -> str:
@@ -134,6 +149,7 @@ def _research_process_watcher(
             )
         except subprocess.TimeoutExpired as exc:
             partial_stderr = _timeout_stream_text(exc.stderr)
+            fatal_signal = _fatal_signal_from_stderr(partial_stderr)
             _kill_research_process(process)
             cleanup_timed_out = False
             try:
@@ -145,7 +161,32 @@ def _research_process_watcher(
                 stderr = _timeout_stream_text(cleanup_exc.stderr) or partial_stderr
                 _close_process_pipes(process)
 
-            detail = _stderr_tail(stderr or partial_stderr)
+            combined_stderr = stderr or partial_stderr
+            fatal_signal = fatal_signal or _fatal_signal_from_stderr(combined_stderr)
+            detail = _stderr_tail(combined_stderr)
+            if fatal_signal is not None:
+                if cleanup_timed_out:
+                    LOG.warning(
+                        "Spectrum H3 generic-correction isolated research reported fatal "
+                        "%s but did not become reapable within %.1f s; forced termination "
+                        "did not drain within %.1f s. The completed generation remains "
+                        "valid%s",
+                        fatal_signal,
+                        _RESEARCH_TIMEOUT_SECONDS,
+                        _RESEARCH_TERMINATION_GRACE_SECONDS,
+                        f": {detail}" if detail else "",
+                    )
+                else:
+                    LOG.warning(
+                        "Spectrum H3 generic-correction isolated research reported fatal "
+                        "%s but did not become reapable within %.1f s and was "
+                        "force-terminated; the completed generation remains valid%s",
+                        fatal_signal,
+                        _RESEARCH_TIMEOUT_SECONDS,
+                        f": {detail}" if detail else "",
+                    )
+                return
+
             if cleanup_timed_out:
                 LOG.warning(
                     "Spectrum H3 generic-correction isolated research timed out after "

--- a/tests/test_postrun_safety.py
+++ b/tests/test_postrun_safety.py
@@ -102,6 +102,16 @@ def test_dispatch_research_never_waits_for_isolated_worker_completion(
     _wait_for_research_slot()
 
 
+def test_faulthandler_fatal_signal_is_normalized():
+    assert (
+        postrun._fatal_signal_from_stderr(
+            "Fatal Python error: Segmentation fault\nCurrent thread ..."
+        )
+        == "SIGSEGV"
+    )
+    assert postrun._fatal_signal_from_stderr("ordinary timeout") is None
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX rlimit semantics required")
 def test_research_command_disables_core_dumps_before_worker(tmp_path):
     worker = tmp_path / "core_limit_worker.py"
@@ -144,8 +154,10 @@ def test_isolated_research_sigsegv_cannot_terminate_parent(
         assert postrun._dispatch_research({"compatible": True})
         _wait_for_research_slot()
 
-    assert "isolated research terminated by SIGSEGV" in caplog.text
-    assert "timed out" not in caplog.text
+    assert (
+        "isolated research terminated by SIGSEGV" in caplog.text
+        or "isolated research reported fatal SIGSEGV" in caplog.text
+    )
     assert "completed generation remains valid" in caplog.text
 
 

--- a/tests/test_postrun_safety.py
+++ b/tests/test_postrun_safety.py
@@ -152,7 +152,15 @@ def test_isolated_research_sigsegv_cannot_terminate_parent(
 
     with caplog.at_level("WARNING"):
         assert postrun._dispatch_research({"compatible": True})
-        _wait_for_research_slot()
+        # The watcher is allowed the research timeout plus its bounded forced-
+        # termination drain. Leave scheduler margin beyond that combined budget.
+        _wait_for_research_slot(
+            timeout=(
+                postrun._RESEARCH_TIMEOUT_SECONDS
+                + postrun._RESEARCH_TERMINATION_GRACE_SECONDS
+                + 1.0
+            )
+        )
 
     assert (
         "isolated research terminated by SIGSEGV" in caplog.text

--- a/tests/test_postrun_safety.py
+++ b/tests/test_postrun_safety.py
@@ -102,6 +102,28 @@ def test_dispatch_research_never_waits_for_isolated_worker_completion(
     _wait_for_research_slot()
 
 
+@pytest.mark.skipif(os.name != "posix", reason="POSIX rlimit semantics required")
+def test_research_command_disables_core_dumps_before_worker(tmp_path):
+    worker = tmp_path / "core_limit_worker.py"
+    worker.write_text(
+        "import resource\nprint(resource.getrlimit(resource.RLIMIT_CORE)[0])\n",
+        encoding="utf-8",
+    )
+
+    completed = postrun.subprocess.run(
+        postrun._research_command(worker),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=5.0,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.strip() == "0"
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX signal semantics required")
 def test_isolated_research_sigsegv_cannot_terminate_parent(
     monkeypatch,
@@ -123,6 +145,34 @@ def test_isolated_research_sigsegv_cannot_terminate_parent(
         _wait_for_research_slot()
 
     assert "isolated research terminated by SIGSEGV" in caplog.text
+    assert "timed out" not in caplog.text
+    assert "completed generation remains valid" in caplog.text
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group semantics required")
+def test_research_timeout_kills_descendants_and_releases_slot(
+    monkeypatch,
+    tmp_path,
+    caplog,
+):
+    worker = tmp_path / "descendant_worker.py"
+    worker.write_text(
+        "import subprocess, sys, time\n"
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(2)'])\n"
+        "time.sleep(2)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(postrun, "_RESEARCH_SLOT", threading.BoundedSemaphore(1))
+    monkeypatch.setattr(postrun, "_RESEARCH_WORKER", worker)
+    monkeypatch.setattr(postrun, "default_store_root", lambda: tmp_path)
+    monkeypatch.setattr(postrun, "_RESEARCH_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(postrun, "_RESEARCH_TERMINATION_GRACE_SECONDS", 0.25)
+
+    with caplog.at_level("WARNING"):
+        assert postrun._dispatch_research({"compatible": True})
+        _wait_for_research_slot(timeout=1.0)
+
+    assert "isolated research timed out after 0.1 s and was terminated" in caplog.text
     assert "completed generation remains valid" in caplog.text
 
 
@@ -151,11 +201,7 @@ def test_isolated_research_python_failure_releases_worker_slot(
 
 def test_worker_script_loads_research_without_package_entrypoint(tmp_path):
     completed = postrun.subprocess.run(
-        [
-            postrun.sys.executable,
-            "-I",
-            str(postrun._RESEARCH_WORKER),
-        ],
+        postrun._research_command(),
         input='{"block":{},"root":"' + str(tmp_path).replace("\\", "\\\\") + '"}',
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Problem

The merge commit for #64 failed one CI matrix in `tests #402`:

- ComfyUI `27bca654eb9a70237d93f56a6ea336ab55f8925d`
- Python 3.12
- `test_isolated_research_sigsegv_cannot_terminate_parent`

The isolated child emitted CPython faulthandler's `Fatal Python error: Segmentation fault`, yet `communicate(timeout=2)` expired before the child became reapable. The timeout path then force-killed the process and classified the event only as a timeout, losing the already-observed fatal-signal diagnosis.

The same ComfyUI/Python matrix passed on the pre-merge PR run, and this regression uses a standalone temporary worker. The failure is in research-child lifetime/diagnostic handling, not the native H3 integration.

A first hardening pass in this PR disabled POSIX core dumps before executing the worker and isolated the worker in its own process group. `tests #404` proved the important remaining condition: the exact failing runner can still delay reaping for more than two seconds even with `RLIMIT_CORE=0`. The watcher therefore must preserve a fatal signal already reported by faulthandler independently of when the OS makes the child reapable.

## Root cause

The watcher assumed a fatally signaled child would always become reapable before the research timeout. That assumption is not valid on the GitHub-hosted runner. `TimeoutExpired` can contain authoritative faulthandler stderr describing the native signal while the process has not yet produced a usable return code. Killing it at that point can replace the eventual status with the cleanup signal.

The original timeout cleanup also performed an unbounded second `communicate()`. A descendant retaining stdout/stderr could therefore keep the single research slot occupied beyond the stated timeout bound.

## Fix

- recognize only CPython faulthandler's canonical fatal-error markers in captured/partial stderr and normalize them to signal names such as `SIGSEGV`;
- when a fatal marker is already present at timeout, report the observed fatal signal while stating precisely that the child had not become reapable before the deadline;
- keep direct negative-return-code signal reporting when the child is reaped normally;
- launch research through an isolated stdlib bootstrap that best-effort sets POSIX `RLIMIT_CORE=0` before executing the worker;
- start the research child in its own POSIX session/process group;
- kill the research process group on timeout so descendants cannot retain the I/O pipes;
- bound the post-kill drain with a separate termination grace period and close the parent pipe handles if cleanup still cannot drain;
- preserve the Windows direct-process kill path, `-I`, faulthandler, package-entrypoint avoidance, the single-worker bound, and non-blocking sampler teardown.

## Regression coverage

- deterministic faulthandler marker normalization;
- production launch command sets `RLIMIT_CORE=0` on POSIX;
- SIGSEGV containment accepts both valid OS lifetime paths: a normal `-SIGSEGV` return code or a delayed-reap timeout carrying faulthandler's `SIGSEGV` diagnosis;
- descendant-inheriting worker verifies timeout teardown kills the process group and releases the research slot promptly;
- isolated worker/package-entrypoint test exercises the production bootstrap.

Forecasting, ER-SDE behavior, generic-correction math, runtime-release ordering, and downstream VAE execution are unchanged.