### PR TITLE
Clarify Untwist compatibility boundary semantics and close review coverage gaps

### DIFF
--- a/comfyui_spectrum_h3/external_patch_visual_reference.py
+++ b/comfyui_spectrum_h3/external_patch_visual_reference.py
@@ -152,10 +152,11 @@ def _parse_visual_profile(
             f"visual_profile[{position}].strength does not match the declared scale endpoints"
         )
 
-    # Spectrum's existing transaction guard operates on an inclusive normalized
-    # sigma interval. Convert only boundaries that the producer declares hard;
-    # a soft boundary is widened to the edge so it cannot spuriously force an
-    # actual step. Progress increases as sampling proceeds, hence the inversion.
+    # Both the producer's schedule_fraction() and Spectrum's active_at() are
+    # inclusive at their start/end coordinates. Preserve those endpoint semantics
+    # exactly under sigma = 1 - progress. Only producer-declared hard boundaries
+    # are retained; soft boundaries are widened to the edge so they cannot
+    # spuriously force an actual step.
     guard_progress_start = progress_start if hard_start else 0.0
     guard_progress_end = progress_end if hard_end else 1.0
     sigma_start = 1.0 - guard_progress_end
@@ -283,6 +284,10 @@ def _visual_runtime_entries(
             raise compat.ExternalPatchContractError(
                 f"visual_runtime[{instance_id}].active must be a boolean"
             )
+        # `active` is validated as part of the producer contract but is not the
+        # temporal guard input. The producer folds reference selection/mapping into
+        # cfg.enabled, while Spectrum's transaction state must follow the declared
+        # hard schedule boundaries. Derive that state only from exact progress.
         by_id[instance_id] = {
             "schema_version": VISUAL_PATCH_SCHEMA_VERSION,
             "provider": provider,

--- a/tests/test_external_patch_visual_reference.py
+++ b/tests/test_external_patch_visual_reference.py
@@ -92,6 +92,64 @@ def test_stacked_diffaid_and_untwist_profiles_preserve_distinct_kinds():
     assert visual_descriptor.has_hard_temporal_transition is True
 
 
+def test_soft_end_widens_visual_guard_to_sigma_zero():
+    parsed = parse(
+        include_diffaid=False,
+        profile=untwist_profile(hard_end=False),
+    )
+    descriptor = parsed.descriptors[0]
+    assert descriptor.sigma_start == 0.0
+    assert descriptor.sigma_end == 1.0
+    assert descriptor.has_hard_temporal_transition is False
+
+
+def test_hard_start_maps_inclusive_progress_start_to_sigma_end():
+    parsed = parse(
+        include_diffaid=False,
+        profile=untwist_profile(progress_start=0.20, hard_start=True),
+    )
+    descriptor = parsed.descriptors[0]
+    assert descriptor.sigma_start == pytest.approx(0.10)
+    assert descriptor.sigma_end == pytest.approx(0.80)
+    assert descriptor.has_hard_temporal_transition is True
+
+
+def test_visual_profile_rejects_strength_inconsistent_with_scale_endpoints():
+    with pytest.raises(
+        compat.ExternalPatchContractError,
+        match="strength does not match",
+    ):
+        parse(
+            include_diffaid=False,
+            profile=untwist_profile(strength=0.24),
+        )
+
+
+def test_visual_profile_rejects_duplicate_instance_id_across_patch_kinds():
+    options = {
+        compat.EXTERNAL_PATCH_CONTRACTS_KEY: [
+            diffaid_contract(instance_id="untwist-h3-1")
+        ],
+        visual.VISUAL_PATCH_PROFILES_KEY: [untwist_profile()],
+    }
+    with pytest.raises(
+        compat.ExternalPatchContractError,
+        match="unique across all profile kinds",
+    ):
+        compat.parse_external_patch_contracts(options, block_count=5)
+
+
+def test_visual_profile_rejects_unsupported_scope():
+    with pytest.raises(
+        compat.ExternalPatchContractError,
+        match="unsupported scope",
+    ):
+        parse(
+            include_diffaid=False,
+            profile=untwist_profile(scope="unsupported"),
+        )
+
+
 def test_visual_strength_metadata_changes_external_profile_fingerprint():
     first = parse(include_diffaid=False)
     second = parse(
@@ -182,6 +240,21 @@ def commit_pending(fake):
     run.pending_active = None
     run.pending_sigma = None
     run.pending_transition_indices = ()
+
+
+def test_visual_runtime_active_flag_does_not_override_sigma_derived_schedule_state():
+    parsed = parse(include_diffaid=False)
+    progress = 17 / 18
+    active_entry = compat._runtime_entries(
+        visual_runtime(progress, active=True),
+        parsed,
+    )
+    inactive_entry = compat._runtime_entries(
+        visual_runtime(progress, active=False),
+        parsed,
+    )
+    assert active_entry == pytest.approx((1.0 - progress,))
+    assert inactive_entry == pytest.approx(active_entry)
 
 
 def test_untwist_end_percent_transition_forces_actual_after_point_nine():


### PR DESCRIPTION
Follow-up to the final CodeRabbit review on merged PR #65. This does not change Spectrum runtime behavior.

## Review findings resolved

- Documents the verified **inclusive** boundary contract shared by the Untwist producer's `schedule_fraction()` and Spectrum's `ExternalPatchDescriptor.active_at()` after `sigma = 1 - progress`.
- Documents that the producer runtime `active` field is validated but is intentionally **not** the temporal transaction-state input. Untwist folds reference-range availability and mapping validity into `cfg.enabled`; Spectrum's hard-boundary transaction guard remains owned by the declared static schedule plus exact per-call schedule progress.
- Adds an explicit regression proving `active=True` and `active=False` produce the same schedule-derived runtime sigma entry.

## Added parser coverage

Adds focused tests for the review-requested branches:

- soft `hard_end=False` widening to `sigma_start=0.0`;
- hard `progress_start` mapping to the inclusive sigma end;
- mismatched strength/scale endpoint rejection;
- duplicate `instance_id` rejection across Diff-Aid and visual-reference patch kinds;
- unsupported visual-reference scope rejection.

## Deliberately unchanged

Two review nitpicks are not applied because they would increase integration surface without fixing a supported runtime defect:

- no shared fingerprint helper extraction: both paths already use the same canonical SHA-256 representation, and changing the established compatibility module for deduplication would be cleanup-only churn;
- no new parser extension-hook architecture: Spectrum's installed runtime paths resolve `external_patch_compat.parse_external_patch_contracts` through the module global after visual compatibility installation. A caller that captured the old function object before installation is outside the supported installed-runtime contract; changing parser dispatch for that hypothetical caller is a broader API redesign.

## Release impact

v0.2.16 remains the released runtime. This follow-up is comments/tests only and does not alter the published behavior or package version.
