### PR TITLE
Support native H3 masked forecasting and short refinement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           - 0dd9b154a1654fc699dcdc3af066c7cce096045a
           - 5599a05fea715cb2aff11f30f5b06e16d0dfa0c4
           - 27bca654eb9a70237d93f56a6ea336ab55f8925d
+          - ff6c8a8af144fc9e9e7bc436b1b202f9316848d8
         python_version:
           - "3.12"
         include:
@@ -78,6 +79,7 @@ jobs:
             comfyui_spectrum_h3/experiments.py \
             comfyui_spectrum_h3/er_sde_ksampler_contract.py \
             comfyui_spectrum_h3/er_sde_stochastic.py \
+            comfyui_spectrum_h3/minimax_h3.py \
             comfyui_spectrum_h3/objective_media.py \
             comfyui_spectrum_h3/objective_media_bounded.py \
             comfyui_spectrum_h3/objective_media_nodes.py \
@@ -96,6 +98,9 @@ jobs:
             tests/test_generic_correction_evaluator.py \
             tests/test_generic_correction_research.py \
             tests/test_generic_correction_research_regional_summary.py \
+            tests/test_h3_masked_forecast.py \
+            tests/test_h3_masked_native_equivalence.py \
+            tests/test_h3_masked_native_wrapper.py \
             tests/test_model_aware.py \
             tests/test_objective_media.py \
             tests/test_objective_media_bounded.py \
@@ -121,6 +126,9 @@ jobs:
             tests/test_external_patch_hardening.py \
             tests/test_external_patch_transaction_parity.py \
             tests/test_h3_wrapper.py \
+            tests/test_h3_masked_forecast.py \
+            tests/test_h3_masked_native_equivalence.py \
+            tests/test_h3_masked_native_wrapper.py \
             tests/test_runtime.py \
             tests/test_sampling.py \
             tests/test_model_aware.py \
@@ -137,6 +145,9 @@ jobs:
             --ignore=tests/test_external_patch_hardening.py \
             --ignore=tests/test_external_patch_transaction_parity.py \
             --ignore=tests/test_h3_wrapper.py \
+            --ignore=tests/test_h3_masked_forecast.py \
+            --ignore=tests/test_h3_masked_native_equivalence.py \
+            --ignore=tests/test_h3_masked_native_wrapper.py \
             --ignore=tests/test_runtime.py \
             --ignore=tests/test_sampling.py \
             --ignore=tests/test_model_aware.py \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,96 +1,55 @@
-# Spectrum MiniMax H3 v0.2.16
+# Spectrum MiniMax H3 v0.2.17
 
-v0.2.16 releases the MiniMax H3 Untwisting RoPE compatibility consumer from PR #65 together with the post-run research isolation and process-lifetime hardening already merged in PRs #64 and #66.
+v0.2.17 completes the current H3 Continuum interoperability work: native masked continuation can remain forecast-capable where the installed ComfyUI core exposes the required per-token H3 mask helper, and the learned-latent sampler-2 refinement path can use Spectrum without inheriting sampler-1's Continuum actual-prefix policy.
 
-The release does not change Spectrum's normal forecasting defaults, sampler cadence, generic-correction defaults, native ER-SDE stochastic ownership, or offline-replay policy.
+## Native Masked H3 forecasting
 
-## Untwisting RoPE visual-reference compatibility
+Spectrum now reconstructs native MiniMax H3 FinalLayer modulation for mixed VIDEO/AUDIO denoise masks instead of disabling forecasting for the entire masked continuation chunk.
 
-Spectrum now recognizes a separate versioned external-patch contract for deterministic MiniMax H3 visual-reference attention modulation produced by the H3 Untwisting RoPE integration.
+- Per-row VIDEO and AUDIO timestep selections follow native H3 mask semantics.
+- Scalar fully-generating paths retain the existing fast path.
+- Residual/shadow output-head evaluation uses the same reconstruction.
+- Per-row timestep index tensors are placed on the target latent device, avoiding CPU/CUDA index-device mismatches in FinalLayer implementations that use `index_select`.
+- On older reviewed ComfyUI cores that do not expose `mask_row_values`, a masked forecast fails closed to one native H3 transformer evaluation instead of raising during output-head reconstruction.
+- Malformed audio mask layouts continue to fail explicitly.
 
-The new producer namespace is intentionally separate from the existing Diff-Aid contract:
+## Short learned-latent refinement
 
-```text
-spectrum_h3_visual_reference_patch_profiles
-spectrum_h3_visual_reference_patch_runtime
-```
+The integrated MiniMax H3 latent upscaler/refiner supplies an explicit `h3_refinement` API-v1 marker on a clone of Continuum's exact per-chunk MODEL. Spectrum validates that contract and lets its sampler-2 actual-prefix policy override the generation-only Continuum prefix carried by sampler 1.
 
-This preserves the strict v0.2.12 Diff-Aid `text_activation_modulation` schema while allowing Untwist to declare `visual_reference_attention_modulation` without being misidentified as a Diff-Aid patch or rejected into the all-actual fail-safe.
-
-Spectrum validates the visual-reference profile's:
-
-- schema version, provider, architecture, patch kind, and unique instance identity;
-- H3 block count and zero-based block coverage;
-- reference scope;
-- active denoising-progress interval and producer-declared hard boundaries;
-- high/low frequency scale endpoints;
-- interpolation `beta`;
-- temporal-axis scaling mode;
-- scalar strength summary against the declared endpoint scales.
-
-The full visual strength/configuration metadata participates in the external profile fingerprint, so behaviorally different Untwist profiles cannot alias the same Spectrum model-profile cache entry.
-
-Per-call runtime progress is converted into Spectrum's existing normalized-sigma transaction guard. Only boundaries explicitly declared hard by the producer become compatibility transitions. If such a boundary is crossed on a step that Spectrum had scheduled as a forecast, that current step is promoted to one real H3 transformer evaluation. A transition landing on an already-actual step adds no duplicate NFE.
-
-The default companion Untwist window ending at `end_percent=0.90` is covered by regression tests: the first forecast after crossing the hard end boundary is promoted to an actual anchor.
-
-Diff-Aid and Untwist descriptors can be stacked in the same run. Their kinds remain distinct in runtime/model-aware telemetry, for example:
+Normal Continuum generation still preserves its two-step actual prefix. A valid three-step sampler-2 refinement can therefore use:
 
 ```text
-external_patch_kinds=text_activation_modulation,visual_reference_attention_modulation
+actual -> forecast -> actual
 ```
 
-Malformed or inconsistent declared metadata continues to use Spectrum's existing fail-safe behavior rather than allowing an ambiguous forecast transaction. The compatibility layer adds no hard dependency on the Untwisting RoPE custom node; Spectrum only consumes the declared pure-data contract when it is present.
+with the normal warmup/final-tail safety rules.
 
-## Post-run research process isolation
+Spectrum continues to honor genuine external-patch hard transitions. DiffAid v1.0.7 removes the artificial partial-denoise transition at its source by evaluating marked refinement against the full H3 sigma reference; Spectrum does not bypass a real model-function transition.
 
-PR #64 moves optional generic-correction post-run evaluation/report work out of the ComfyUI process and into an isolated Python subprocess.
+## Coordinated runtime validation
 
-The previous in-process daemon-thread boundary could not satisfy Spectrum's post-run safety invariant: a native SIGSEGV in any Python thread terminates the entire process and cannot be contained by `except Exception`. A completed generation could therefore be lost after sampling had already finished while optional research analysis was running.
+The complete real CUDA path was validated with:
 
-The isolated path now:
+- H3 Continuum exact `refine_state` handoff;
+- MiniMax H3 learned latent upscale + internal sampler-2 refinement;
+- DiffAid marked-refinement sigma semantics;
+- Untwisting RoPE external-patch metadata;
+- native ER-SDE;
+- Spectrum enabled on both the main Continuum generation and sampler 2.
 
-- releases core Spectrum runtime/history state before optional research dispatch;
-- starts the research worker through an isolated stdlib bootstrap with `-I` and `faulthandler`;
-- keeps only a lightweight watcher thread in the ComfyUI process for child I/O and lifetime management;
-- retains the single-worker bound so diagnostic jobs cannot accumulate;
-- caps stalled analysis and reports Python failures, timeouts, and fatal signals without invalidating the completed sampler result;
-- preserves the ordering invariant `calibration export -> core runtime/VRAM release -> optional research dispatch`.
+A three-step high-resolution refinement produced `2 actual + 1 forecast` per refined chunk, with no inherited Continuum-prefix force-actual and no artificial DiffAid middle-step transition. The resulting media quality was user-validated as impeccable.
 
-Forecasting math, native ER-SDE behavior, offline replay, generic-correction controller math, and downstream VAE/output execution are unchanged by this isolation.
+The tested 0.7 MP native -> 1.75x learned-upscale workflow reduced the Refine node from roughly 302.5 s with three native refinement NFEs to roughly 212.7 s with the middle NFE forecast, while preserving the tested output quality.
 
-## Fatal-signal and timeout teardown hardening
+## Validation and compatibility
 
-The first isolation implementation exposed a runner-specific process-lifetime race after PR #64 merged. A child could already have emitted CPython faulthandler's canonical `Fatal Python error: Segmentation fault` diagnostic while still failing to become reapable before the watcher's timeout. Killing it at that point could replace the useful native-signal diagnosis with the cleanup signal. The timeout cleanup also had an unbounded final `communicate()` path if descendants retained the worker's stdout/stderr pipes.
+The PR test matrix covers Python 3.10-3.13, the forecaster smoke test, Ruff/compileall, focused H3/external compatibility suites, and native MiniMax H3 fixtures across the reviewed ComfyUI revisions.
 
-PR #66 hardens that boundary by:
+This release is coordinated with:
 
-- recognizing only CPython faulthandler's canonical fatal-error markers and normalizing them to signal names such as `SIGSEGV`;
-- preserving an already-observed fatal-signal diagnosis even when the child has not become reapable by the deadline;
-- retaining direct negative-return-code signal reporting for normally reaped children;
-- best-effort disabling POSIX core dumps before the worker executes;
-- launching the worker in its own POSIX session/process group;
-- terminating the whole research process group on timeout so descendants cannot keep inherited pipes alive;
-- bounding the post-kill drain with a separate termination grace period and closing parent pipe handles if cleanup still cannot drain;
-- preserving the Windows direct-process termination path;
-- preserving the single-worker bound and non-blocking sampler teardown.
+- ComfyUI-DiffAid-Patches v1.0.7;
+- H3 Continuum v3.4.1;
+- the integrated MiniMax H3 Latent Upscaler + Refine release.
 
-This fixes the violated lifetime/diagnostic invariant without broadening the research worker's authority over the generation process.
-
-## Included merged work since v0.2.15
-
-This release contains all runtime work merged after v0.2.15:
-
-- **#64 — Isolate post-run generic-correction research from ComfyUI**
-- **#66 — Harden isolated research crash and timeout teardown**
-- **#65 — Recognize Untwist H3 visual-reference external patch profiles**
-
-The v0.2.15 H3 Continuum interoperability and native ER-SDE post-prefix solver-space fix remain included unchanged, along with the v0.2.14 replay-preview safety, v0.2.13 Python 3.13 provenance normalization, and v0.2.12 Diff-Aid compatibility layer.
-
-## Validation and release boundary
-
-PR #65 passed the repository `tests` workflow on its implementation head before merge. Its regression coverage checks stacked Diff-Aid/Untwist recognition, distinct runtime patch kinds, strength-profile fingerprinting, hard `end_percent=0.90` boundary promotion, and required runtime/static contract consistency.
-
-PR #64 added isolation coverage for non-blocking dispatch, worker-slot lifetime, child failures, package-entrypoint avoidance, and intentional child SIGSEGV containment. PR #66 added deterministic fatal-marker normalization, POSIX core-dump/bootstrap checks, delayed-reap SIGSEGV handling, process-group timeout cleanup, and descendant-pipe teardown coverage.
-
-The v0.2.16 release commit changes release metadata only. The exact combined runtime tree is the already-merged `main` state containing #64, #66, and #65. The release remains gated by the repository's existing CI workflow: after this version bump is merged to `main`, the Comfy Registry publish workflow is triggered by `pyproject.toml`, and the GitHub release workflow publishes `v0.2.16` only from a successful tested `main` commit.
+Existing Spectrum defaults, generic-correction defaults, normal 19-step Continuum forecasting policy, ER-SDE stochastic ownership, offline-replay policy, and real external-patch transition barriers remain unchanged.

--- a/comfyui_spectrum_h3/__init__.py
+++ b/comfyui_spectrum_h3/__init__.py
@@ -9,6 +9,7 @@ from .generic_correction import install_generic_residual_correction
 from .minimax_h3 import locate_minimax_h3_inner, require_native_minimax_h3
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 from .postrun_safety import install_postrun_safety
+from .refinement_compat import install_refinement_compat
 from .replay_calibration import install_replay_calibration
 from .replay_calibration_provenance import install_replay_calibration_provenance
 from .replay_calibration_validation import install_replay_calibration_validation
@@ -34,6 +35,7 @@ install_replay_calibration()
 install_replay_calibration_validation()
 install_replay_calibration_provenance()
 install_er_sde_tail_policy()
+install_refinement_compat()
 install_external_patch_compat()
 install_visual_reference_patch_compat()
 install_external_patch_hardening()

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -183,8 +183,8 @@ def topology_signature(
 class _OutputState:
     layout: Any
     t_emb: torch.Tensor
-    video_timestep_row: int
-    audio_timestep_row: int
+    video_timestep_row: int | torch.Tensor
+    audio_timestep_row: int | torch.Tensor
     sigma_v: torch.Tensor
     shift_v: float
     shift_a: float
@@ -201,6 +201,8 @@ def _prepare_output_state(
     transformer_options: dict[str, Any],
     payload: dict[str, Any],
     layout: Any,
+    denoise_mask: torch.Tensor | None = None,
+    audio_denoise_mask: torch.Tensor | None = None,
 ) -> _OutputState:
     import comfy.model_management
 
@@ -214,14 +216,87 @@ def _prepare_output_state(
     t_a = float(1.0 - module.time_shift_sigma(sigma_v, shift_v, shift_a))
     visual_aug = float(payload.get("visual_cond_noise_aug", getattr(module, "VISUAL_COND_TIMESTEP", 0.999)))
     audio_aug = float(payload.get("audio_cond_noise_aug", getattr(module, "AUDIO_COND_TIMESTEP", 1.0)))
-    has_visual_condition = any(kind in ("cond", "ref_img") for _, _, kind in layout.segments)
-    has_audio_condition = any(kind == "ref_audio" for _, _, kind in layout.segments)
+    seg_t = {
+        "text": t_v,
+        "video": t_v,
+        "audio": t_a,
+        "cond": max(t_v, visual_aug),
+        "ref_img": max(t_v, visual_aug),
+        "cond_audio": max(t_a, audio_aug),
+        "ref_audio": max(t_a, audio_aug),
+    }
+
+    padded_t, padded_h, padded_w = _padded_shape(tuple(video_x.shape), tuple(inner.patch_size))
+    video_rows_t = None
+    audio_rows_t = None
+    if denoise_mask is not None:
+        mask_row_values = getattr(module, "mask_row_values", None)
+        if not callable(mask_row_values):
+            raise RuntimeError(
+                "native MiniMax H3 module does not expose mask_row_values for per-token VIDEO masks"
+            )
+        mask_rows = mask_row_values(
+            denoise_mask[0, 0].to(torch.float32),
+            padded_t,
+            padded_h,
+            padded_w,
+        )
+        if mask_rows is not None:
+            rows_t = (1.0 - mask_rows * sigma_v.to(mask_rows.device)).clamp(
+                max=max(t_v, getattr(module, "VISUAL_COND_TIMESTEP", 0.999))
+            )
+            if rows_t.unique().numel() == 1:
+                seg_t["video"] = float(rows_t[0])
+            else:
+                video_rows_t = rows_t
+
+    if audio_denoise_mask is not None:
+        mask_rows = audio_denoise_mask[0, 0].to(torch.float32).reshape(-1)
+        expected_audio_rows = int(audio_x.shape[-1]) * int(audio_x.shape[-2])
+        if int(mask_rows.numel()) != expected_audio_rows:
+            raise RuntimeError(
+                "native MiniMax H3 audio denoise mask row count does not match target AUDIO rows: "
+                f"expected {expected_audio_rows}, got {int(mask_rows.numel())}"
+            )
+        if not bool((mask_rows >= 1.0 - 1e-3).all()):
+            sigma_a = 1.0 - t_a
+            rows_t = (1.0 - mask_rows * sigma_a).clamp(
+                max=max(t_a, getattr(module, "AUDIO_COND_TIMESTEP", 1.0))
+            )
+            if rows_t.unique().numel() == 1:
+                seg_t["audio"] = float(rows_t[0])
+            else:
+                audio_rows_t = rows_t
+
     unique_t = sorted(
         {t_v, t_a}
-        | ({max(t_v, visual_aug)} if has_visual_condition else set())
-        | ({max(t_a, audio_aug)} if has_audio_condition else set())
+        | {seg_t[kind] for _, _, kind in layout.segments}
+        | (set(video_rows_t.unique().tolist()) if video_rows_t is not None else set())
+        | (set(audio_rows_t.unique().tolist()) if audio_rows_t is not None else set())
     )
     timestep_row = {value: index for index, value in enumerate(unique_t)}
+
+    def rows_to_timestep_index(rows_t: torch.Tensor) -> torch.Tensor:
+        levels = rows_t.unique()
+        base = torch.tensor(
+            [timestep_row[value] for value in levels.tolist()],
+            dtype=torch.long,
+            device=device,
+        )
+        positions = torch.searchsorted(levels, rows_t).to(device=device)
+        return base[positions]
+
+    video_timestep_row: int | torch.Tensor
+    audio_timestep_row: int | torch.Tensor
+    if video_rows_t is None:
+        video_timestep_row = timestep_row[seg_t["video"]]
+    else:
+        video_timestep_row = rows_to_timestep_index(video_rows_t)
+    if audio_rows_t is None:
+        audio_timestep_row = timestep_row[seg_t["audio"]]
+    else:
+        audio_timestep_row = rows_to_timestep_index(audio_rows_t)
+
     values = torch.tensor(unique_t, dtype=torch.float32, device=device)
     if inner.use_adaln_curves:
         table = comfy.model_management.cast_to(inner.adaln_t_table, device=device)
@@ -233,13 +308,13 @@ def _prepare_output_state(
     return _OutputState(
         layout=layout,
         t_emb=t_emb,
-        video_timestep_row=timestep_row[t_v],
-        audio_timestep_row=timestep_row[t_a],
+        video_timestep_row=video_timestep_row,
+        audio_timestep_row=audio_timestep_row,
         sigma_v=sigma_v,
         shift_v=shift_v,
         shift_a=shift_a,
         original_video_shape=tuple(int(v) for v in video_x.shape[-3:]),
-        padded_video_shape=_padded_shape(tuple(video_x.shape), tuple(inner.patch_size)),
+        padded_video_shape=(padded_t, padded_h, padded_w),
     )
 
 
@@ -330,6 +405,8 @@ def _execute_actual(
                 transformer_options,
                 minimax_payload or {},
                 layout,
+                denoise_mask=kwargs.get("denoise_mask"),
+                audio_denoise_mask=kwargs.get("audio_denoise_mask"),
             )
             output_head_started = time.perf_counter()
             try:
@@ -436,20 +513,6 @@ def diffusion_model_wrapper(
             minimax_payload=minimax_payload,
             **kwargs,
         )
-    if kwargs.get("denoise_mask") is not None or kwargs.get("audio_denoise_mask") is not None:
-        runtime.fallback_current_step(
-            int(run_id),
-            int(step_id),
-            "per-token denoise masks require native MiniMax H3 evaluation",
-        )
-        return executor(
-            x,
-            timestep,
-            context,
-            options,
-            minimax_payload=minimax_payload,
-            **kwargs,
-        )
     if not isinstance(x, (list, tuple)) or len(x) != 2:
         runtime.fallback_current_step(int(run_id), int(step_id), "native H3 input is not a video/audio latent pair")
         return executor(x, timestep, context, options, minimax_payload=minimax_payload, **kwargs)
@@ -508,6 +571,27 @@ def diffusion_model_wrapper(
             residual_probe,
         )
 
+    if kwargs.get("denoise_mask") is not None:
+        module = _native_module(inner)
+        if not callable(getattr(module, "mask_row_values", None)):
+            reason = "native MiniMax H3 core lacks mask_row_values for masked forecasting"
+            runtime.fallback_current_step(int(run_id), int(step_id), reason)
+            return _execute_actual(
+                executor,
+                inner,
+                runtime,
+                int(run_id),
+                int(step_id),
+                call_id,
+                layout,
+                x,
+                timestep,
+                context,
+                options,
+                minimax_payload,
+                kwargs,
+            )
+
     predicted = runtime.predict(
         int(run_id),
         int(step_id),
@@ -553,7 +637,18 @@ def diffusion_model_wrapper(
     if event is not None and runtime.config.debug:
         LOG.warning("Spectrum H3 forecast sanitized run_id=%s step=%s event=%s", run_id, step_id, event)
     try:
-        state = _prepare_output_state(inner, video_x, audio_x, timestep, context, options, payload, layout)
+        state = _prepare_output_state(
+            inner,
+            video_x,
+            audio_x,
+            timestep,
+            context,
+            options,
+            payload,
+            layout,
+            denoise_mask=kwargs.get("denoise_mask"),
+            audio_denoise_mask=kwargs.get("audio_denoise_mask"),
+        )
         output = _execute_forecast(inner, sanitized, state, video_x, audio_x)
     except torch.cuda.OutOfMemoryError:
         raise

--- a/comfyui_spectrum_h3/refinement_compat.py
+++ b/comfyui_spectrum_h3/refinement_compat.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+REFINEMENT_REQUEST_KEY = "h3_refinement"
+REFINEMENT_API = 1
+
+_INSTALL_MARKER_ATTR = "_spectrum_h3_refinement_compat_install_marker"
+_INSTALL_MARKER_VALUE = f"spectrum-h3-refinement:v{REFINEMENT_API}"
+_ORIGINAL_CONTINUUM_ACTUAL_PREFIX = None
+_INSTALLED = False
+
+
+def _refinement_request(model_options: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return a validated low-sigma refinement contract, otherwise None.
+
+    Invalid metadata deliberately fails open to the existing Continuum policy:
+    it must never suppress Continuum's native prefix unless the producer supplied
+    a complete, reviewed refinement contract.
+    """
+    transformer_options = (model_options or {}).get("transformer_options")
+    if not isinstance(transformer_options, dict):
+        return None
+    request = transformer_options.get(REFINEMENT_REQUEST_KEY)
+    if not isinstance(request, dict):
+        return None
+
+    api = request.get("api")
+    active = request.get("active")
+    prefix = request.get("min_actual_prefix_steps")
+    sigma_reference = request.get("sigma_reference")
+    if type(api) is not int or type(active) is not bool or type(prefix) is not int:
+        return None
+    if api != REFINEMENT_API or active is not True or prefix < 0:
+        return None
+    if isinstance(sigma_reference, bool) or not isinstance(sigma_reference, (int, float)):
+        return None
+    sigma_reference = float(sigma_reference)
+    if not math.isfinite(sigma_reference) or sigma_reference <= 0.0:
+        return None
+
+    return {
+        "api": api,
+        "active": active,
+        "min_actual_prefix_steps": prefix,
+        "sigma_reference": sigma_reference,
+    }
+
+
+def _continuum_actual_prefix_with_refinement(model_options: dict[str, Any] | None) -> int:
+    request = _refinement_request(model_options)
+    if request is not None:
+        return int(request["min_actual_prefix_steps"])
+    if _ORIGINAL_CONTINUUM_ACTUAL_PREFIX is None:
+        raise RuntimeError("Spectrum H3 refinement compatibility lost the original Continuum prefix resolver")
+    return _ORIGINAL_CONTINUUM_ACTUAL_PREFIX(model_options)
+
+
+def _is_installed_replacement(value: Any) -> bool:
+    return getattr(value, _INSTALL_MARKER_ATTR, None) == _INSTALL_MARKER_VALUE
+
+
+def install_refinement_compat() -> None:
+    """Let explicit sampler-2 metadata override sampler-1 Continuum prefix policy."""
+    global _INSTALLED, _ORIGINAL_CONTINUUM_ACTUAL_PREFIX
+
+    from . import sampling
+
+    current = sampling._continuum_actual_prefix
+    if _is_installed_replacement(current):
+        _INSTALLED = True
+        return
+
+    _ORIGINAL_CONTINUUM_ACTUAL_PREFIX = current
+    setattr(
+        _continuum_actual_prefix_with_refinement,
+        _INSTALL_MARKER_ATTR,
+        _INSTALL_MARKER_VALUE,
+    )
+    sampling._continuum_actual_prefix = _continuum_actual_prefix_with_refinement
+    _INSTALLED = True
+
+
+__all__ = [
+    "REFINEMENT_API",
+    "REFINEMENT_REQUEST_KEY",
+    "install_refinement_compat",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.16"
+version = "0.2.17"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_h3_masked_forecast.py
+++ b/tests/test_h3_masked_forecast.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3.minimax_h3 import _execute_forecast, _prepare_output_state
+
+
+class _FakeFinalLayer:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, compact, t_emb, video_segment, audio_segment):
+        self.calls.append((compact.clone(), t_emb.clone(), video_segment, audio_segment))
+        video_rows = video_segment[1] - video_segment[0]
+        audio_rows = audio_segment[1] - audio_segment[0]
+        return (
+            torch.zeros((video_rows, 96), dtype=torch.float32),
+            torch.zeros((audio_rows, 32), dtype=torch.float32),
+        )
+
+
+def _fake_module(monkeypatch):
+    def time_shift_sigma(sigma, from_shift, to_shift):
+        base = sigma / (from_shift + sigma * (1.0 - from_shift))
+        return to_shift * base / (1.0 + (to_shift - 1.0) * base)
+
+    def mask_row_values(mask, latent_t, lat_h, lat_w):
+        m = torch.nn.functional.pad(
+            mask,
+            (0, lat_w - mask.shape[-1], 0, lat_h - mask.shape[-2]),
+            mode="replicate",
+        )
+        m = m.reshape(latent_t, lat_h // 2, 2, lat_w // 2, 2).amax(dim=(2, 4))
+        values = m.reshape(-1)
+        return None if bool((values >= 1.0 - 1e-3).all()) else values
+
+    module = SimpleNamespace(
+        time_shift_sigma=time_shift_sigma,
+        mask_row_values=mask_row_values,
+        VISUAL_COND_TIMESTEP=0.999,
+        AUDIO_COND_TIMESTEP=1.0,
+        unpack_audio=lambda rows: rows.reshape(2, rows.shape[0] // 2, rows.shape[-1])
+        .permute(2, 0, 1)
+        .unsqueeze(0),
+        unpatchify_video=lambda rows, t, h, w, c, patch_size: torch.zeros(
+            (1, c, t, h * 2, w * 2)
+        ),
+    )
+    monkeypatch.setattr(
+        "comfyui_spectrum_h3.minimax_h3._native_module",
+        lambda _inner: module,
+    )
+
+
+def _inner():
+    final_layer = _FakeFinalLayer()
+    return SimpleNamespace(
+        patch_size=(1, 2, 2),
+        hidden_size=4,
+        latents_dim=24,
+        audio_latents_dim=32,
+        sigma_shift_video=12.0,
+        sigma_shift_audio=3.0,
+        use_adaln_curves=False,
+        time_embedder=lambda values: values[:, None].repeat(1, 3),
+        final_layer=final_layer,
+    )
+
+
+def _layout():
+    return SimpleNamespace(
+        segments=[
+            (0, 2, "text"),
+            (2, 4, "ref_img"),
+            (4, 8, "audio"),
+            (8, 16, "video"),
+        ],
+        seq_len=16,
+    )
+
+
+def _masked_state(monkeypatch):
+    _fake_module(monkeypatch)
+    inner = _inner()
+    video_x = torch.zeros((1, 24, 2, 4, 4))
+    audio_x = torch.zeros((1, 32, 2, 2))
+    context = torch.zeros((1, 2, 4))
+    video_mask = torch.ones((1, 1, 2, 4, 4))
+    video_mask[:, :, 0] = 0.0
+    audio_mask = torch.tensor([[[[0.0, 1.0], [0.0, 1.0]]]])
+    state = _prepare_output_state(
+        inner,
+        video_x,
+        audio_x,
+        torch.tensor([500.0]),
+        context,
+        {},
+        {},
+        _layout(),
+        denoise_mask=video_mask,
+        audio_denoise_mask=audio_mask,
+    )
+    return inner, video_x, audio_x, state
+
+
+def test_masked_output_state_matches_core_per_row_timestep_contract(monkeypatch):
+    _, _, _, state = _masked_state(monkeypatch)
+
+    assert torch.is_tensor(state.video_timestep_row)
+    assert torch.is_tensor(state.audio_timestep_row)
+    assert state.video_timestep_row.shape == (8,)
+    assert state.audio_timestep_row.shape == (4,)
+    assert state.video_timestep_row.dtype == torch.long
+    assert state.audio_timestep_row.dtype == torch.long
+    assert state.video_timestep_row[:4].unique().numel() == 1
+    assert state.video_timestep_row[4:].unique().numel() == 1
+    assert int(state.video_timestep_row[0]) != int(state.video_timestep_row[-1])
+    assert int(state.audio_timestep_row[0]) != int(state.audio_timestep_row[1])
+
+
+def test_masked_forecast_passes_vector_timestep_rows_to_native_final_layer(monkeypatch):
+    inner, video_x, audio_x, state = _masked_state(monkeypatch)
+    predicted = torch.zeros((1, 12, 4))
+
+    output = _execute_forecast(inner, predicted, state, video_x, audio_x)
+
+    assert len(output) == 2
+    assert len(inner.final_layer.calls) == 1
+    _, _, video_segment, audio_segment = inner.final_layer.calls[0]
+    assert video_segment[:2] == (4, 12)
+    assert audio_segment[:2] == (0, 4)
+    assert torch.equal(video_segment[2], state.video_timestep_row)
+    assert torch.equal(audio_segment[2], state.audio_timestep_row)
+
+
+def test_fully_generating_masks_keep_scalar_fast_path(monkeypatch):
+    _fake_module(monkeypatch)
+    inner = _inner()
+    state = _prepare_output_state(
+        inner,
+        torch.zeros((1, 24, 2, 4, 4)),
+        torch.zeros((1, 32, 2, 2)),
+        torch.tensor([500.0]),
+        torch.zeros((1, 2, 4)),
+        {},
+        {},
+        _layout(),
+        denoise_mask=torch.ones((1, 1, 2, 4, 4)),
+        audio_denoise_mask=torch.ones((1, 1, 2, 2)),
+    )
+
+    assert isinstance(state.video_timestep_row, int)
+    assert isinstance(state.audio_timestep_row, int)
+
+
+def test_audio_mask_row_mismatch_fails_closed(monkeypatch):
+    _fake_module(monkeypatch)
+    inner = _inner()
+    with pytest.raises(RuntimeError, match="audio denoise mask row count"):
+        _prepare_output_state(
+            inner,
+            torch.zeros((1, 24, 2, 4, 4)),
+            torch.zeros((1, 32, 2, 2)),
+            torch.tensor([500.0]),
+            torch.zeros((1, 2, 4)),
+            {},
+            {},
+            _layout(),
+            audio_denoise_mask=torch.ones((1, 1, 1, 2)),
+        )

--- a/tests/test_h3_masked_native_equivalence.py
+++ b/tests/test_h3_masked_native_equivalence.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3.minimax_h3 import _prepare_output_state
+
+
+class _MaskCapableInner:
+    patch_size = (1, 2, 2)
+    hidden_size = 4
+    latents_dim = 24
+    audio_latents_dim = 32
+    sigma_shift_video = 12.0
+    sigma_shift_audio = 3.0
+    use_adaln_curves = False
+
+    @staticmethod
+    def time_embedder(values):
+        return values[:, None].repeat(1, 3)
+
+
+def _native_module():
+    module = importlib.import_module("comfy.ldm.minimax.model")
+    if not hasattr(module, "mask_row_values"):
+        pytest.skip("reviewed ComfyUI revision predates native MiniMax H3 per-token masks")
+    return module
+
+
+def _layout():
+    return SimpleNamespace(
+        segments=[
+            (0, 2, "text"),
+            (2, 4, "ref_img"),
+            (4, 8, "audio"),
+            (8, 16, "video"),
+        ],
+        seq_len=16,
+    )
+
+
+def _row_indices(rows_t, timestep_row):
+    levels = rows_t.unique()
+    base = torch.tensor(
+        [timestep_row[value] for value in levels.tolist()],
+        dtype=torch.long,
+        device=rows_t.device,
+    )
+    return base[torch.searchsorted(levels, rows_t)]
+
+
+def test_spectrum_masked_output_rows_match_native_core_contract():
+    module = _native_module()
+    _MaskCapableInner.__module__ = module.__name__
+    inner = _MaskCapableInner()
+
+    video_x = torch.zeros((1, 24, 2, 4, 4))
+    audio_x = torch.zeros((1, 32, 2, 2))
+    context = torch.zeros((1, 2, 4))
+    timestep = torch.tensor([500.0])
+    video_mask = torch.ones((1, 1, 2, 4, 4))
+    video_mask[:, :, 0] = 0.0
+    audio_mask = torch.tensor([[[[0.0, 1.0], [0.0, 1.0]]]])
+
+    state = _prepare_output_state(
+        inner,
+        video_x,
+        audio_x,
+        timestep,
+        context,
+        {},
+        {},
+        _layout(),
+        denoise_mask=video_mask,
+        audio_denoise_mask=audio_mask,
+    )
+
+    sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+    t_v = float(1.0 - sigma_v)
+    t_a = float(
+        1.0
+        - module.time_shift_sigma(
+            sigma_v,
+            inner.sigma_shift_video,
+            inner.sigma_shift_audio,
+        )
+    )
+
+    video_mask_rows = module.mask_row_values(video_mask[0, 0].float(), 2, 4, 4)
+    assert video_mask_rows is not None
+    video_rows_t = (1.0 - video_mask_rows * sigma_v).clamp(
+        max=max(t_v, module.VISUAL_COND_TIMESTEP)
+    )
+
+    audio_mask_rows = audio_mask[0, 0].float().reshape(-1)
+    sigma_a = 1.0 - t_a
+    audio_rows_t = (1.0 - audio_mask_rows * sigma_a).clamp(
+        max=max(t_a, module.AUDIO_COND_TIMESTEP)
+    )
+
+    unique_t = sorted(
+        {t_v, t_a, max(t_v, module.VISUAL_COND_TIMESTEP)}
+        | set(video_rows_t.unique().tolist())
+        | set(audio_rows_t.unique().tolist())
+    )
+    timestep_row = {value: index for index, value in enumerate(unique_t)}
+
+    assert torch.equal(
+        state.video_timestep_row,
+        _row_indices(video_rows_t, timestep_row),
+    )
+    assert torch.equal(
+        state.audio_timestep_row,
+        _row_indices(audio_rows_t, timestep_row),
+    )
+    assert state.t_emb.shape[0] == len(unique_t)
+
+
+def test_native_final_layer_supports_per_row_modulation_indices():
+    module = _native_module()
+    mod_row = getattr(module, "_mod_row", None)
+    if not callable(mod_row):
+        pytest.fail("mask-capable native H3 Core is missing _mod_row vector-index support")
+
+    vectors = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+    rows = torch.tensor([1, 4, 2], dtype=torch.long)
+    result = mod_row(vectors, rows, torch.float32)
+
+    assert torch.equal(result, vectors[rows])

--- a/tests/test_h3_masked_native_wrapper.py
+++ b/tests/test_h3_masked_native_wrapper.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+import comfyui_spectrum_h3.minimax_h3 as minimax_h3_runtime
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.forecast import HistoryWeightForecaster
+from comfyui_spectrum_h3.minimax_h3 import diffusion_model_wrapper
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
+from comfyui_spectrum_h3.sampling import (
+    ACTUAL_KEY,
+    COORDINATE_KEY,
+    RUN_ID_KEY,
+    RUNTIME_KEY,
+    STEP_ID_KEY,
+)
+
+
+def _native_imports_allow_legacy():
+    try:
+        import comfy.cli_args
+
+        comfy.cli_args.args.cpu = True
+        import comfy.patcher_extension
+        from comfy.ldm.minimax import model as minimax_model
+        from comfy.ldm.minimax.model import MiniMaxH3Model, PackedLayout
+    except Exception as exc:  # noqa: BLE001 - external fixture availability
+        pytest.skip(f"current ComfyUI source is unavailable: {exc}")
+    return comfy.patcher_extension, minimax_model, MiniMaxH3Model, PackedLayout
+
+
+def _native_imports():
+    patcher_extension, minimax_model, MiniMaxH3Model, PackedLayout = _native_imports_allow_legacy()
+    if not hasattr(minimax_model, "mask_row_values"):
+        pytest.skip("reviewed ComfyUI revision predates native MiniMax H3 per-token masks")
+    return patcher_extension, MiniMaxH3Model, PackedLayout
+
+
+class _CountingBlock(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options=None):
+        self.calls += 1
+        return x + t_emb[0].mean().to(x.dtype) * 0.01
+
+
+def _tiny_model(*, allow_legacy=False):
+    if allow_legacy:
+        _, _, MiniMaxH3Model, _ = _native_imports_allow_legacy()
+    else:
+        _, MiniMaxH3Model, _ = _native_imports()
+    torch.manual_seed(31)
+    model = MiniMaxH3Model(
+        hidden_size=8,
+        num_layers=1,
+        token_refiner_num_layers=1,
+        num_attention_heads=1,
+        attention_head_dim=8,
+        ffn_hidden_size=16,
+        latents_dim=2,
+        audio_latents_dim=2,
+        patch_size=(1, 2, 2),
+        text_dim=8,
+        timestep_input_dim=4,
+        time_embed_hidden_size=8,
+        time_embed_dim=4,
+        rope_inv_freq_len=1,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        operations=torch.nn,
+    )
+    block = _CountingBlock()
+    model.blocks[0] = block
+    return model, block
+
+
+def _inputs(PackedLayout):
+    video = torch.randn(1, 2, 2, 4, 4)
+    audio = torch.randn(1, 2, 2, 3)
+    context = torch.randn(1, 2, 8)
+    payload = {"layout": PackedLayout(2, 2, 4, 4, 3), "seed": 13}
+    video_mask = torch.ones((1, 1, 2, 4, 4), dtype=torch.float32)
+    video_mask[:, :, 0] = 0.0
+    audio_mask = torch.ones((1, 1, 2, 3), dtype=torch.float32)
+    audio_mask[:, :, :, 0] = 0.0
+    return [video, audio], context, payload, video_mask, audio_mask
+
+
+def _wrapped_call(
+    model,
+    runtime,
+    sigma,
+    model_timestep,
+    x,
+    context,
+    payload,
+    video_mask,
+    audio_mask,
+):
+    patcher_extension, _, _, _ = _native_imports_allow_legacy()
+    decision = runtime.begin_step(torch.tensor([sigma]))
+    options = {
+        RUNTIME_KEY: runtime,
+        RUN_ID_KEY: decision["run_id"],
+        STEP_ID_KEY: decision["step_id"],
+        COORDINATE_KEY: decision["coordinate"],
+        ACTUAL_KEY: decision["actual"],
+        "cond_or_uncond": [0],
+        "uuids": ["positive"],
+    }
+    executor = patcher_extension.WrapperExecutor.new_class_executor(
+        model._forward,
+        model,
+        [diffusion_model_wrapper],
+    )
+    output = executor.execute(
+        x,
+        torch.tensor([model_timestep]),
+        context,
+        options,
+        minimax_payload=payload,
+        denoise_mask=video_mask,
+        audio_denoise_mask=audio_mask,
+    )
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    return output, decision
+
+
+def test_exact_masked_forecast_reconstructs_native_velocity_and_skips_transformer(monkeypatch):
+    _, _, PackedLayout = _native_imports()
+    model, block = _tiny_model()
+    x, context, payload, video_mask, audio_mask = _inputs(PackedLayout)
+
+    native = model._forward(
+        x,
+        torch.tensor([500.0]),
+        context,
+        {},
+        minimax_payload=payload,
+        denoise_mask=video_mask,
+        audio_denoise_mask=audio_mask,
+    )
+
+    captured = {}
+    original_observe = SpectrumH3Runtime.observe_actual
+
+    def recording_observe(self, run_id, step_id, call_id, target):
+        captured["target"] = target.detach().clone()
+        return original_observe(self, run_id, step_id, call_id, target)
+
+    monkeypatch.setattr(SpectrumH3Runtime, "observe_actual", recording_observe)
+    capture_runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            force_actual=True,
+            warmup_steps=0,
+            tail_actual_steps=0,
+        )
+    )
+    capture_run = capture_runtime.start_run(
+        torch.tensor([0.5, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+    )
+    _wrapped_call(
+        model,
+        capture_runtime,
+        0.5,
+        500.0,
+        x,
+        context,
+        payload,
+        video_mask,
+        audio_mask,
+    )
+    capture_runtime.end_run(capture_run)
+    monkeypatch.setattr(SpectrumH3Runtime, "observe_actual", original_observe)
+    assert "target" in captured
+
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            warmup_steps=2,
+            tail_actual_steps=0,
+            window_size=2.0,
+            bootstrap_first_forecast=False,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+    )
+    _wrapped_call(model, runtime, 1.0, 1000.0, x, context, payload, video_mask, audio_mask)
+    _wrapped_call(model, runtime, 0.75, 750.0, x, context, payload, video_mask, audio_mask)
+    calls_before_forecast = block.calls
+
+    monkeypatch.setattr(
+        HistoryWeightForecaster,
+        "predict_segments",
+        lambda self, coordinate, segment_blends, *, rows, device, dtype: captured["target"].to(
+            device=device,
+            dtype=dtype,
+        ),
+    )
+    forecast, decision = _wrapped_call(
+        model,
+        runtime,
+        0.5,
+        500.0,
+        x,
+        context,
+        payload,
+        video_mask,
+        audio_mask,
+    )
+
+    assert not decision["actual"]
+    assert block.calls == calls_before_forecast
+    assert runtime.disabled_reason is None
+    for native_part, forecast_part in zip(native, forecast, strict=True):
+        assert native_part.shape == forecast_part.shape
+        assert native_part.dtype == forecast_part.dtype
+        torch.testing.assert_close(native_part, forecast_part, rtol=1e-5, atol=1e-5)
+    runtime.end_run(run_id)
+
+
+def test_masked_forecast_selects_native_fallback_when_core_lacks_mask_row_values(monkeypatch):
+    _, minimax_model, _, PackedLayout = _native_imports_allow_legacy()
+    model, _ = _tiny_model(allow_legacy=True)
+    x, context, payload, video_mask, audio_mask = _inputs(PackedLayout)
+
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            warmup_steps=1,
+            tail_actual_steps=0,
+            window_size=2.0,
+            bootstrap_first_forecast=True,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+    )
+    _wrapped_call(model, runtime, 1.0, 1000.0, x, context, payload, video_mask, audio_mask)
+
+    sentinel = [torch.zeros_like(x[0]), torch.zeros_like(x[1])]
+    fallback_calls = []
+
+    def fake_execute_actual(*args, **kwargs):
+        fallback_calls.append((args, kwargs))
+        return sentinel
+
+    # Deleting the Core helper deliberately creates a legacy/unsupported masked
+    # output-head environment. The compatibility invariant under test is that
+    # Spectrum selects its native-actual fallback before trying forecast
+    # reconstruction. Do not execute that deliberately broken Core path here:
+    # some historical revisions reference mask_row_values from native _forward
+    # and therefore cannot themselves service a masked call after the helper is
+    # removed.
+    monkeypatch.delattr(minimax_model, "mask_row_values", raising=False)
+    monkeypatch.setattr(minimax_h3_runtime, "_execute_actual", fake_execute_actual)
+
+    output, decision = _wrapped_call(
+        model,
+        runtime,
+        0.5,
+        500.0,
+        x,
+        context,
+        payload,
+        video_mask,
+        audio_mask,
+    )
+
+    assert not decision["actual"]
+    assert output is sentinel
+    assert len(fallback_calls) == 1
+    assert "lacks mask_row_values" in (runtime.disabled_reason or "")
+    runtime.end_run(run_id)

--- a/tests/test_h3_wrapper.py
+++ b/tests/test_h3_wrapper.py
@@ -95,44 +95,6 @@ def test_non_native_diffusion_call_records_a_native_passthrough_fallback():
     runtime.end_run(run_id)
 
 
-@pytest.mark.parametrize("mask_key", ["denoise_mask", "audio_denoise_mask"])
-def test_per_token_denoise_masks_force_native_passthrough(mask_key):
-    runtime = SpectrumH3Runtime(SpectrumH3Config(degree=1, max_history=4))
-    run_id = runtime.start_run(torch.tensor([1.0, 0.5, 0.0]), "sample_euler", supported_sampler=True)
-    decision = runtime.begin_step(torch.tensor([1.0]))
-    calls = []
-
-    class Executor:
-        class_obj = _native_shaped_fake()
-
-        def __call__(self, *args, **kwargs):
-            calls.append((args, kwargs))
-            return "native-masked-output"
-
-    mask = object()
-    options = {
-        RUNTIME_KEY: runtime,
-        RUN_ID_KEY: decision["run_id"],
-        STEP_ID_KEY: decision["step_id"],
-    }
-    result = diffusion_model_wrapper(
-        Executor(),
-        object(),
-        torch.tensor([1000.0]),
-        object(),
-        options,
-        **{mask_key: mask},
-    )
-    runtime.finalize_step(decision["run_id"], decision["step_id"])
-
-    assert result == "native-masked-output"
-    assert len(calls) == 1
-    assert calls[0][1][mask_key] is mask
-    assert runtime.stats.actual_steps == 1
-    assert "per-token denoise masks require native" in runtime.disabled_reason
-    runtime.end_run(run_id)
-
-
 def test_forecast_sanitization_clamps_and_replaces_nonfinite_values():
     source = torch.tensor([float("nan"), float("inf"), -float("inf"), 1e20, 2.0])
     sanitized, event = _sanitize_prediction(source, torch.float16)

--- a/tests/test_refinement_compat.py
+++ b/tests/test_refinement_compat.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import torch
+
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.refinement_compat import _refinement_request
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
+from comfyui_spectrum_h3.sampling import _continuum_actual_prefix
+
+
+def _options(*, refinement=None, continuum=None):
+    transformer_options = {}
+    if continuum is not None:
+        transformer_options["h3_continuum"] = continuum
+    if refinement is not None:
+        transformer_options["h3_refinement"] = refinement
+    return {"transformer_options": transformer_options}
+
+
+def _continuum(prefix=2):
+    return {"api": 1, "active": True, "min_actual_prefix_steps": prefix}
+
+
+def _refinement(prefix=0, sigma_reference=1.0):
+    return {
+        "api": 1,
+        "active": True,
+        "min_actual_prefix_steps": prefix,
+        "sigma_reference": sigma_reference,
+    }
+
+
+def _runtime():
+    return SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            warmup_steps=1,
+            tail_actual_steps=0,
+            window_size=2.0,
+            bootstrap_first_forecast=True,
+            offline_smoothing_replay=False,
+        )
+    )
+
+
+def _complete_first_actual(runtime):
+    topology = (
+        ("video", (1, 24, 2, 4, 4)),
+        ("audio", (1, 32, 2, 8)),
+        ("hidden", 4),
+        ("target_audio_rows", 1),
+        ("target_video_rows", 2),
+    )
+    labels = ((0, "positive"),)
+    decision = runtime.begin_step(torch.tensor([0.72]))
+    assert decision["actual"]
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=topology,
+        labels=labels,
+        expected_shape=(1, 3, 4),
+    )
+    assert actual
+    runtime.observe_actual(
+        decision["run_id"],
+        decision["step_id"],
+        call_id,
+        torch.ones((1, 3, 4)),
+    )
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    return decision
+
+
+def test_valid_refinement_contract_is_strictly_parsed():
+    request = _refinement_request(_options(refinement=_refinement()))
+    assert request == _refinement()
+
+
+def test_refinement_contract_overrides_inherited_continuum_prefix():
+    options = _options(refinement=_refinement(prefix=0), continuum=_continuum(prefix=2))
+    assert _continuum_actual_prefix(options) == 0
+
+
+def test_invalid_refinement_contract_does_not_suppress_continuum_safety_prefix():
+    options = _options(
+        refinement=_refinement(prefix=0, sigma_reference=float("nan")),
+        continuum=_continuum(prefix=2),
+    )
+    assert _refinement_request(options) is None
+    assert _continuum_actual_prefix(options) == 2
+
+
+def test_normal_continuum_generation_keeps_prefix_two():
+    assert _continuum_actual_prefix(_options(continuum=_continuum(prefix=2))) == 2
+
+
+def test_three_step_refinement_middle_step_is_forecast_eligible_after_warmup():
+    prefix = _continuum_actual_prefix(
+        _options(refinement=_refinement(prefix=0), continuum=_continuum(prefix=2))
+    )
+    runtime = _runtime()
+    run_id = runtime.start_run(
+        torch.tensor([0.72, 0.55, 0.26, 0.0]),
+        "sample_er_sde",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+        min_actual_prefix_steps=prefix,
+    )
+    try:
+        first = _complete_first_actual(runtime)
+        middle = runtime.begin_step(torch.tensor([0.55]))
+        assert first["reason"] == "warmup"
+        assert middle["actual"] is False
+        assert "forecast" in middle["reason"]
+    finally:
+        runtime.end_run(run_id)


### PR DESCRIPTION
## Scope

This PR completes two MiniMax H3 interoperability paths while preserving native H3 semantics:

1. **Native Masked continuation** — forecast output-head reconstruction now supports Core's per-row VIDEO/AUDIO timestep selections produced by H3 denoise masks.
2. **Learned-latent sampler-2 refinement** — a valid explicit `h3_refinement` API-v1 contract can override sampler-1's generation-only Continuum actual prefix without weakening normal generation or external-patch safety.

## Native Masked forecasting

- Reconstruct native H3 FinalLayer modulation with scalar or per-row VIDEO/AUDIO timestep indices.
- Preserve the scalar fully-generating fast path.
- Use the same reconstruction for residual/shadow output-head evaluation.
- Place per-row timestep indices on the target latent device.
- On older reviewed Core revisions without `mask_row_values`, fail closed to one native actual transformer evaluation instead of raising on a masked forecast.
- Keep malformed AUDIO mask layouts explicit failures.

## Short refinement

The integrated latent upscaler/refiner marks only its sampler-2 MODEL clone with:

```text
h3_refinement API v1
```

A complete valid contract is authoritative for sampler 2. Normal Continuum generation still keeps its two-step actual prefix. With the normal warmup/final-tail rules, a stable three-step refinement is eligible for:

```text
actual -> forecast -> actual
```

Real external-patch hard transitions remain hard barriers. DiffAid PR #11 removes the artificial partial-denoise transition at its source; Spectrum does not bypass genuine model-function changes.

## Coordinated runtime validation

Validated on a real CUDA MiniMax H3 workflow with:

- H3 Continuum exact `refine_state`;
- learned latent upscale + internal sampler-2 refinement;
- DiffAid marked-refinement sigma semantics;
- Untwisting RoPE external-patch metadata;
- native ER-SDE;
- Spectrum on both the normal Continuum generation and sampler 2.

The three-step high-resolution refinement reported `2 actual + 1 forecast` per refined chunk, with no inherited Continuum-prefix force-actual and no artificial DiffAid middle-step transition. The resulting media quality was user-validated as impeccable.

In the compared 0.7 MP native -> 1.75x workflow, the Refine node dropped from roughly 302.5 s with three target-resolution native NFEs to roughly 212.7 s with the middle NFE forecast.

## Regression coverage

Coverage includes mixed VIDEO/AUDIO masks, native per-row FinalLayer equivalence, legacy-Core masked fallback, target-device row indices, complete/malformed refinement contracts, unchanged normal Continuum prefix behavior, external-patch transitions, and three-step middle-forecast eligibility.

## Release

This PR is the v0.2.17 release head. `pyproject.toml` and `RELEASE_NOTES.md` are updated; after merge, the existing tested-main release workflow will publish the GitHub release and the existing registry workflow will publish the versioned node package.

Final squashed release commit: `79fdfe7c0ad53b4dce4e6b449e5fe92beb839067`.