### PR TITLE
Release Spectrum MiniMax H3 v0.2.19

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,24 @@
-# Spectrum MiniMax H3 v0.2.18
+# Spectrum MiniMax H3 v0.2.19
+
+v0.2.19 fixes RefDelta Solver discovery in the actual ComfyUI custom-node loading layout.
+
+## RefDelta custom-node namespace discovery
+
+- Fixes the runtime failure `RefDelta interop API is unavailable: No module named 'comfyui_refdelta_solver'` that could occur even though the RefDelta sampler itself was already loaded and usable by ComfyUI.
+- Spectrum now recognizes the already-loaded RefDelta implementation when ComfyUI has placed it under a package-relative custom-node namespace instead of exposing `comfyui_refdelta_solver` as a top-level package.
+- Canonical RefDelta imports reuse the exact live config class, sampler function, and interop contract objects instead of importing the same files a second time under a different module identity.
+- The existing strict RefDelta API-v1 checks remain unchanged: function identity, config provenance, interop version, option allowlist, stochastic ownership, and wrapper ordering still fail closed on drift.
+- No `PYTHONPATH` changes, pip installation, duplicated model path, or workflow changes are required.
+
+## Validation
+
+PR #76 adds a regression for the exact nested ComfyUI package layout that produced the failure. The complete six-lane Spectrum ComfyUI/Python matrix passes, including Ruff, compileall, focused external compatibility tests, and native MiniMax H3 fixtures. CodeRabbit reported no actionable findings on the substantive compatibility change.
+
+This patch changes discovery only. RefDelta solver behavior, Spectrum forecasting policy, stochastic compensation, Continuum interoperability, Diff-Aid handling, Untwisting RoPE handling, and offline replay semantics remain unchanged.
+
+---
+
+## v0.2.18
 
 v0.2.18 adds explicit compatibility with MiniMax H3 RefDelta Solver v0.2.0+.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.18"
+version = "0.2.19"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Release Spectrum MiniMax H3 v0.2.19 with the RefDelta custom-node namespace discovery fix merged in #76.

## Included fix

A normal ComfyUI load can place RefDelta Solver under a package-relative custom-node namespace without exposing `comfyui_refdelta_solver` as a top-level module. Spectrum v0.2.18 incorrectly assumed the top-level import existed and could therefore disable forecasting with:

```
RefDelta interop API is unavailable: No module named 'comfyui_refdelta_solver'
```

PR #76 fixes that discovery path while retaining the existing strict RefDelta API-v1 provenance and stochastic-ownership checks.

## Release changes

- bump package version from `0.2.18` to `0.2.19`;
- document the RefDelta namespace-discovery fix and its validation;
- no additional runtime changes beyond the already-reviewed and merged #76 implementation.

## Validation

- #76 passed the complete six-lane Spectrum ComfyUI/Python matrix;
- Ruff and compileall passed;
- focused external compatibility suites passed;
- native MiniMax H3 fixture suites passed;
- CodeRabbit reported no actionable findings on the substantive compatibility change.

After this PR merges, the existing release workflow should publish tag/release `v0.2.19` from the tested `main` commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved RefDelta Solver discovery for nested custom-node namespaces.
  * Reuses canonical live API objects during discovery.
  * Maintains strict API v1 validation behavior.

* **Documentation**
  * Added release notes covering the discovery updates and validation results.
  * Clarified the v0.2.18 release boundary.

* **Chores**
  * Updated the project version to 0.2.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->