### PR TITLE
Fix RefDelta step provenance after tracked model calls

### DIFF
--- a/comfyui_spectrum_h3/refdelta_interop.py
+++ b/comfyui_spectrum_h3/refdelta_interop.py
@@ -4,6 +4,7 @@ import importlib.abc
 import importlib.util
 import sys
 from dataclasses import dataclass
+from functools import wraps
 from types import ModuleType
 from typing import ClassVar
 
@@ -31,6 +32,7 @@ _REFDELTA_ALIAS_METADATA = frozenset(
         "__cached__",
     }
 )
+_REFDELTA_TRACKER_BRIDGE_MARKER = "__spectrum_refdelta_bridge__"
 
 
 class RefDeltaInteropError(RuntimeError):
@@ -110,6 +112,43 @@ class RefDeltaInteropBridge:
     )
     _descriptor: ERSDEStepDescriptor | None = None
 
+    def __post_init__(self) -> None:
+        """Observe the exact descriptor successfully consumed by stochastic tracking.
+
+        ComfyUI can reconstruct model-option dictionaries between the sampler and
+        PREDICT_NOISE layers. RefDelta keeps the bridge from the sampler's extra_args,
+        while Spectrum's stochastic tracker is the object that actually consumes the
+        post-model descriptor. Bind this bridge to that tracker instance so provenance
+        follows the successful consume operation instead of depending on a second
+        model-options lookup finding the bridge object after the model call.
+        """
+        tracker = self.tracker
+        if tracker is None:
+            return
+        consume = tracker.consume
+        consume_function = getattr(consume, "__func__", consume)
+        owner = getattr(consume_function, _REFDELTA_TRACKER_BRIDGE_MARKER, None)
+        if owner is not None and owner is not self:
+            raise RefDeltaInteropError(
+                "ER-SDE tracker is already bound to another Spectrum RefDelta bridge"
+            )
+
+        @wraps(consume)
+        def consume_with_refdelta_provenance(
+            denoised: torch.Tensor,
+            descriptor: ERSDEStepDescriptor,
+        ) -> torch.Tensor:
+            result = consume(denoised, descriptor)
+            self.note_model_result(descriptor)
+            return result
+
+        setattr(
+            consume_with_refdelta_provenance,
+            _REFDELTA_TRACKER_BRIDGE_MARKER,
+            self,
+        )
+        tracker.consume = consume_with_refdelta_provenance
+
     def note_model_result(self, descriptor: ERSDEStepDescriptor) -> None:
         if descriptor.run_id != self.run_id:
             raise RefDeltaInteropError("stale Spectrum RefDelta run descriptor")
@@ -118,8 +157,10 @@ class RefDeltaInteropBridge:
     def model_result_is_actual(self, step_id: int) -> bool:
         descriptor = self._descriptor
         if descriptor is None or descriptor.step_id != int(step_id):
+            current = "none" if descriptor is None else str(descriptor.step_id)
             raise RefDeltaInteropError(
-                "RefDelta requested a model-result classification for the wrong step"
+                "RefDelta requested a model-result classification for the wrong step "
+                f"(requested={int(step_id)}, observed={current})"
             )
         if descriptor.mode == "actual":
             return True
@@ -138,8 +179,10 @@ class RefDeltaInteropBridge:
     ) -> None:
         descriptor = self._descriptor
         if descriptor is None or descriptor.step_id != int(source_step_id):
+            current = "none" if descriptor is None else str(descriptor.step_id)
             raise RefDeltaInteropError(
-                "RefDelta published a stochastic increment for the wrong step"
+                "RefDelta published a stochastic increment for the wrong step "
+                f"(source={int(source_step_id)}, observed={current})"
             )
         if self.tracker is None:
             raise RefDeltaInteropError(

--- a/tests/test_refdelta_tracker_provenance.py
+++ b/tests/test_refdelta_tracker_provenance.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3.er_sde_stochastic import (
+    ERSDEStepDescriptor,
+    ERSDEStochasticTracker,
+)
+from comfyui_spectrum_h3.refdelta_interop import (
+    RefDeltaInteropBridge,
+    RefDeltaInteropError,
+)
+
+
+def _descriptor(
+    step_id: int,
+    *,
+    mode: str = "actual",
+    replay_source_actual: bool | None = None,
+) -> ERSDEStepDescriptor:
+    return ERSDEStepDescriptor(
+        run_id=41,
+        step_id=step_id,
+        mode=mode,
+        replay_source_actual=replay_source_actual,
+        requires_compensation=(
+            mode == "forecast"
+            or (mode == "replay" and replay_source_actual is False)
+        ),
+    )
+
+
+def _tracker() -> ERSDEStochasticTracker:
+    return ERSDEStochasticTracker(
+        noise_sampler=lambda _sigma, _sigma_next: torch.ones((1, 2)),
+        noise_scaler=lambda value: value**2,
+        effective_s_noise=1.0,
+        max_stage=3,
+        debug=False,
+        run_id=41,
+        external_increment=True,
+    )
+
+
+def test_tracker_consumption_is_the_refdelta_classification_source():
+    tracker = _tracker()
+    bridge = RefDeltaInteropBridge(run_id=41, tracker=tracker)
+    denoised = torch.tensor([[1.0, -2.0]])
+
+    # Reproduce the real ComfyUI failure: the stochastic tracker consumes Spectrum's
+    # descriptor, but no separate post-model bridge.note_model_result() call occurs.
+    result = tracker.consume(denoised, _descriptor(0, mode="actual"))
+
+    assert result is denoised
+    assert bridge.model_result_is_actual(0)
+
+
+def test_tracker_driven_provenance_still_rejects_stale_step_queries():
+    tracker = _tracker()
+    bridge = RefDeltaInteropBridge(run_id=41, tracker=tracker)
+    tracker.consume(torch.zeros((1, 2)), _descriptor(0, mode="actual"))
+
+    with pytest.raises(
+        RefDeltaInteropError,
+        match=r"requested=1, observed=0",
+    ):
+        bridge.model_result_is_actual(1)
+
+
+def test_tracker_driven_provenance_validates_external_increment_source():
+    tracker = _tracker()
+    bridge = RefDeltaInteropBridge(run_id=41, tracker=tracker)
+    tracker.consume(torch.zeros((1, 2)), _descriptor(0, mode="actual"))
+
+    tracker.noise_scaler(torch.tensor(0.5))
+    tracker.noise_scaler(torch.tensor(1.0))
+    tracker.noise_sampler(torch.tensor(0.8), torch.tensor(0.4))
+    increment = torch.tensor([[0.25, -0.5]])
+
+    bridge.publish_stochastic_increment(0, increment)
+
+    assert tracker.pending_step_id == 1
+
+
+def test_replay_source_provenance_is_bound_to_successful_tracker_consume():
+    tracker = _tracker()
+    bridge = RefDeltaInteropBridge(run_id=41, tracker=tracker)
+    descriptor = _descriptor(0, mode="replay", replay_source_actual=False)
+
+    tracker.consume(torch.zeros((1, 2)), descriptor)
+
+    assert not bridge.model_result_is_actual(0)
+    assert bridge.is_replay_step
+
+
+def test_deterministic_bridge_keeps_direct_descriptor_path():
+    bridge = RefDeltaInteropBridge(run_id=41, tracker=None)
+    bridge.note_model_result(_descriptor(0, mode="forecast"))
+
+    assert not bridge.model_result_is_actual(0)


### PR DESCRIPTION
## Root cause

With Spectrum v0.2.19 + RefDelta Solver, the namespace discovery issue is fixed, but the first real tracked model call can still fail immediately afterward with:

```text
RefDelta requested a model-result classification for the wrong step
```

The runtime log proves Spectrum's stochastic tracker successfully consumed the step-0 descriptor (`ER-SDE compensation step=0` and dense-anchor step 0), while RefDelta's separate bridge-local descriptor remained unset by the time the sampler queried `model_result_is_actual(0)`.

The API-v1 implementation therefore had two independently timed provenance updates for stochastic RefDelta runs: the stochastic tracker consumed the authoritative descriptor, then a separate model-options bridge lookup attempted to mirror that descriptor. In the real ComfyUI/Continuum wrapper stack, relying on the second lookup is not safe.

## Fix

- Bind each stochastic `RefDeltaInteropBridge` directly to the exact `ERSDEStochasticTracker.consume` operation for that run.
- Only after tracker consumption succeeds, record that same `ERSDEStepDescriptor` on the bridge.
- Keep the existing post-model `bridge.note_model_result()` path as a redundant consistency path; RefDelta no longer depends on it being the only provenance update.
- Preserve the direct bridge descriptor path for deterministic `s_noise=0` RefDelta runs where no stochastic tracker exists.
- Keep strict stale-step validation. Error messages now include requested/source vs observed step ids.
- Refuse accidentally binding one tracker instance to multiple RefDelta bridges.

This does **not** weaken the interop contract and does not infer step ids. The classification is sourced from the exact descriptor already accepted by Spectrum's stochastic-state tracker.

## Regression coverage

New tests reproduce the observed asymmetry by calling `tracker.consume(step 0)` without any separate `bridge.note_model_result()` call, then verify:

- RefDelta classifies step 0 correctly;
- stale step queries still fail;
- external stochastic increment publication remains source-step checked;
- replay source-actual/source-forecast provenance survives;
- deterministic no-tracker bridge behavior remains unchanged.

No RefDelta Solver workflow changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provenance tracking for stochastic model results.
  * Added clearer errors for mismatched or stale step IDs.
  * Prevented conflicting tracker-to-bridge bindings.
  * Improved classification of actual, replay, and externally published results.

* **Tests**
  * Added coverage for tracker-based provenance, replay handling, external increments, stale steps, and deterministic operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->