### PR TITLE
Release Spectrum MiniMax H3 v0.2.20

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,26 @@
-# Spectrum MiniMax H3 v0.2.19
+# Spectrum MiniMax H3 v0.2.20
+
+v0.2.20 fixes the RefDelta API-v1 step-provenance handoff after a tracked ER-SDE model call.
+
+## RefDelta tracked-step provenance
+
+- Fixes `RefDelta requested a model-result classification for the wrong step` immediately after the first successful Spectrum/RefDelta model evaluation.
+- The real runtime trace showed Spectrum's ER-SDE stochastic tracker had already consumed and logged step 0 while the separate RefDelta bridge-local descriptor had not been mirrored reliably through the surrounding ComfyUI/Continuum model-options path.
+- For stochastic RefDelta runs, provenance is now recorded directly from the exact `ERSDEStepDescriptor` that the ER-SDE stochastic tracker successfully consumes. RefDelta therefore uses the same authoritative step classification that Spectrum used for stochastic-state ownership.
+- The existing post-model bridge update remains a redundant consistency path instead of the sole source of RefDelta provenance.
+- Deterministic `s_noise=0` RefDelta runs keep their direct bridge descriptor path because no stochastic tracker exists in that mode.
+- Stale-step and external-increment source validation remain strict; diagnostics now include requested/source and observed step IDs.
+- No model-path, Continuum, RefDelta Solver, prompt, sampler-setting, or workflow changes are required.
+
+## Validation
+
+PR #78 adds regression coverage for the exact failure mode: the tracker consumes step 0 successfully without a separate bridge update, and RefDelta must still classify the same step correctly. Coverage also verifies stale-step rejection, external-increment source checking, replay provenance, and deterministic no-tracker behavior.
+
+The complete six-lane Spectrum ComfyUI/Python matrix passes, including Ruff, compileall, focused external compatibility suites, and native MiniMax H3 fixtures. CodeRabbit reported no actionable merge-blocking finding and rated the runtime change minimal risk.
+
+---
+
+## v0.2.19
 
 v0.2.19 fixes RefDelta Solver discovery in the actual ComfyUI custom-node loading layout.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.19"
+version = "0.2.20"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Release Spectrum MiniMax H3 v0.2.20 with the RefDelta tracked-step provenance fix merged in #78.

## Included fix

After v0.2.19 fixed RefDelta package discovery, a real Spectrum + RefDelta + Continuum run exposed a second API-v1 handoff issue immediately after the first successful model call:

```text
RefDelta requested a model-result classification for the wrong step
```

The stochastic tracker had already consumed Spectrum's authoritative step-0 descriptor, but RefDelta still depended on a separate bridge-local descriptor update. #78 binds RefDelta provenance directly to the exact descriptor successfully consumed by the stochastic tracker while preserving deterministic behavior and all stale-step / increment-source validation.

## Release changes

- bump package version from `0.2.19` to `0.2.20`;
- document the tracked-step provenance fix and exact failure mode;
- no additional runtime changes beyond the already-reviewed and merged #78 implementation.

## Validation

- #78 passed the complete six-lane Spectrum ComfyUI/Python matrix;
- Ruff and compileall passed;
- focused external compatibility suites passed;
- native MiniMax H3 fixture suites passed;
- regression coverage reproduces tracker-consumed step provenance without a separate bridge update;
- CodeRabbit reported no actionable merge-blocking finding and rated the runtime change minimal risk.

After this PR merges, the existing release workflow can publish `v0.2.20` from the tested `main` commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed RefDelta API-v1 step-provenance handoff after tracked ER-SDE model calls.
  - Improved provenance consistency for both stochastic and deterministic runs.
  - Added regression coverage and validation for the updated behavior.

- **Release**
  - Updated the project version to 0.2.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->