### PR TITLE
Fix FinalLayer.forward() call for ComfyUI 0.34 (PDD LoRA signature)

### DIFF
--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -190,6 +191,8 @@ class _OutputState:
     shift_a: float
     original_video_shape: tuple[int, int, int]
     padded_video_shape: tuple[int, int, int]
+    # sampler sigma schedule, consumed by FinalLayer on ComfyUI >= 0.34 (PDD LoRA)
+    sample_sigmas: Any = None
 
 
 def _prepare_output_state(
@@ -315,6 +318,7 @@ def _prepare_output_state(
         shift_a=shift_a,
         original_video_shape=tuple(int(v) for v in video_x.shape[-3:]),
         padded_video_shape=(padded_t, padded_h, padded_w),
+        sample_sigmas=transformer_options.get("sample_sigmas"),
     )
 
 
@@ -449,12 +453,25 @@ def _execute_forecast(
         raise RuntimeError("forecasted MiniMax H3 target feature has an invalid compact shape")
     audio_segment = (0, audio_rows, state.audio_timestep_row)
     video_segment = (audio_rows, audio_rows + video_rows, state.video_timestep_row)
-    video_projected, audio_projected = inner.final_layer(
-        compact,
-        state.t_emb,
-        video_segment,
-        audio_segment,
-    )
+    # ComfyUI >= 0.34 (PDD LoRA support) added required
+    # sigma/sample_sigmas/shifts arguments to FinalLayer.forward
+    if "sample_sigmas" in inspect.signature(type(inner.final_layer).forward).parameters:
+        video_projected, audio_projected = inner.final_layer(
+            compact,
+            state.t_emb,
+            video_segment,
+            audio_segment,
+            state.sigma_v,
+            state.sample_sigmas,
+            (state.shift_v, state.shift_a),
+        )
+    else:
+        video_projected, audio_projected = inner.final_layer(
+            compact,
+            state.t_emb,
+            video_segment,
+            audio_segment,
+        )
     latent_t, latent_h, latent_w = state.padded_video_shape
     video_out = module.unpatchify_video(
         video_projected,


### PR DESCRIPTION
Fixes #82.

ComfyUI comfyanonymous/ComfyUI@2504e68d4d9dedb514e172692f13436623f25aed ("MiniMax-H3: Support PDD LoRA", comfyanonymous/ComfyUI#15908, in 0.34.0) added three required positional arguments to `FinalLayer.forward`: `sigma`, `sample_sigmas`, and `shifts`. The residual output-head forecast path (`_execute_forecast`) still calls it with the old four arguments, so every sampling run through Spectrum now fails immediately with:

```
TypeError: FinalLayer.forward() missing 3 required positional arguments: 'sigma', 'sample_sigmas', and 'shifts'
```

## Changes

- `_OutputState` gains a `sample_sigmas` field (defaulted to `None`), populated from `transformer_options.get("sample_sigmas")` in `_prepare_output_state` — the same source the core forward uses.
- `_execute_forecast` passes `state.sigma_v`, `state.sample_sigmas`, and `(state.shift_v, state.shift_a)` to `final_layer`, mirroring the core call site (`comfy/ldm/minimax/model.py`) exactly. `sigma_v`, `shift_v`, and `shift_a` were already tracked in `_OutputState`, so the values are the real ones, not stubs.
- The call is signature-detected (`inspect.signature` on `FinalLayer.forward`), so older ComfyUI cores keep working unchanged.

On a plain (non-PDD) checkpoint the new arguments are ignored by core (`n == 1` head path), so behavior there is identical to before the ComfyUI change. With a PDD head bank the forecast path now feeds the head-bank interpolation the same schedule the core forward does.

Written and tested against ComfyUI 0.34.0 (2504e68d4): the new call mirrors the core `final_layer` call site argument-for-argument, and the file compiles clean. Without the patch, any MiniMax H3 workflow with Spectrum active fails at the first sampling step with the `TypeError` above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compatibility with newer ComfyUI model-layer interfaces.
  * Improved support for PDD LoRA workflows by passing sampling and shift settings when available.
  * Maintained compatibility with older interfaces through automatic fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->