### PR TITLE
Fix MiniMax H3 PDD final-layer forecast compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,10 @@ jobs:
         include:
           - comfy_ref: 27bca654eb9a70237d93f56a6ea336ab55f8925d
             python_version: "3.13"
+          - comfy_ref: 2504e68d4d9dedb514e172692f13436623f25aed
+            python_version: "3.12"
+            comfy_kitchen_version: "0.2.31"
+            comfy_aimdo_version: "0.4.15"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -54,10 +58,13 @@ jobs:
           cache: pip
 
       - name: Install test dependencies
+        env:
+          COMFY_KITCHEN_VERSION: ${{ matrix.comfy_kitchen_version || '0.2.26' }}
+          COMFY_AIMDO_VERSION: ${{ matrix.comfy_aimdo_version || '0.4.13' }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install pytest ruff numpy psutil safetensors einops tqdm pyyaml pillow packaging comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
+          python -m pip install pytest ruff numpy psutil safetensors einops tqdm pyyaml pillow packaging "comfy-kitchen==${COMFY_KITCHEN_VERSION}" "comfy-aimdo==${COMFY_AIMDO_VERSION}"
           python -m pip wheel --no-deps --wheel-dir /tmp/spectrum-h3-wheel .
 
       - name: Run forecaster smoke test

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -186,6 +187,7 @@ class _OutputState:
     video_timestep_row: int | torch.Tensor
     audio_timestep_row: int | torch.Tensor
     sigma_v: torch.Tensor
+    sample_sigmas: torch.Tensor | None
     shift_v: float
     shift_a: float
     original_video_shape: tuple[int, int, int]
@@ -311,6 +313,7 @@ def _prepare_output_state(
         video_timestep_row=video_timestep_row,
         audio_timestep_row=audio_timestep_row,
         sigma_v=sigma_v,
+        sample_sigmas=transformer_options.get("sample_sigmas"),
         shift_v=shift_v,
         shift_a=shift_a,
         original_video_shape=tuple(int(v) for v in video_x.shape[-3:]),
@@ -433,6 +436,27 @@ def _execute_actual(
     return result
 
 
+def _final_layer_uses_pdd_contract(module: Any) -> bool:
+    """Detect the native Core FinalLayer contract without probing by execution."""
+    final_layer_type = getattr(module, "FinalLayer", None)
+    forward = getattr(final_layer_type, "forward", None)
+    if forward is None:
+        return False
+    try:
+        parameters = inspect.signature(forward).parameters
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("unable to inspect native MiniMax H3 FinalLayer.forward contract") from exc
+    pdd_parameters = ("sigma", "sample_sigmas", "shifts")
+    present = tuple(name in parameters for name in pdd_parameters)
+    if all(present):
+        return True
+    if any(present):
+        raise RuntimeError(
+            "native MiniMax H3 FinalLayer exposes an incomplete PDD projection contract"
+        )
+    return False
+
+
 def _execute_forecast(
     inner: Any,
     predicted: torch.Tensor,
@@ -449,12 +473,23 @@ def _execute_forecast(
         raise RuntimeError("forecasted MiniMax H3 target feature has an invalid compact shape")
     audio_segment = (0, audio_rows, state.audio_timestep_row)
     video_segment = (audio_rows, audio_rows + video_rows, state.video_timestep_row)
-    video_projected, audio_projected = inner.final_layer(
-        compact,
-        state.t_emb,
-        video_segment,
-        audio_segment,
-    )
+    if _final_layer_uses_pdd_contract(module):
+        video_projected, audio_projected = inner.final_layer(
+            compact,
+            state.t_emb,
+            video_segment,
+            audio_segment,
+            sigma=state.sigma_v,
+            sample_sigmas=state.sample_sigmas,
+            shifts=(state.shift_v, state.shift_a),
+        )
+    else:
+        video_projected, audio_projected = inner.final_layer(
+            compact,
+            state.t_emb,
+            video_segment,
+            audio_segment,
+        )
     latent_t, latent_h, latent_w = state.padded_video_shape
     video_out = module.unpatchify_video(
         video_projected,

--- a/tests/test_h3_masked_forecast.py
+++ b/tests/test_h3_masked_forecast.py
@@ -22,6 +22,41 @@ class _FakeFinalLayer:
         )
 
 
+class _FakePDDFinalLayer:
+    def __init__(self):
+        self.calls = []
+
+    def forward(
+        self,
+        compact,
+        t_emb,
+        video_segment,
+        audio_segment,
+        sigma,
+        sample_sigmas,
+        shifts,
+    ):
+        self.calls.append(
+            (
+                compact.clone(),
+                t_emb.clone(),
+                video_segment,
+                audio_segment,
+                sigma,
+                sample_sigmas,
+                shifts,
+            )
+        )
+        video_rows = video_segment[1] - video_segment[0]
+        audio_rows = audio_segment[1] - audio_segment[0]
+        return (
+            torch.zeros((video_rows, 96), dtype=torch.float32),
+            torch.zeros((audio_rows, 32), dtype=torch.float32),
+        )
+
+    __call__ = forward
+
+
 def _fake_module(monkeypatch):
     def time_shift_sigma(sigma, from_shift, to_shift):
         base = sigma / (from_shift + sigma * (1.0 - from_shift))
@@ -53,6 +88,7 @@ def _fake_module(monkeypatch):
         "comfyui_spectrum_h3.minimax_h3._native_module",
         lambda _inner: module,
     )
+    return module
 
 
 def _inner():
@@ -134,6 +170,34 @@ def test_masked_forecast_passes_vector_timestep_rows_to_native_final_layer(monke
     assert audio_segment[:2] == (0, 4)
     assert torch.equal(video_segment[2], state.video_timestep_row)
     assert torch.equal(audio_segment[2], state.audio_timestep_row)
+
+
+def test_pdd_final_layer_receives_sigma_schedule_and_stream_shifts(monkeypatch):
+    module = _fake_module(monkeypatch)
+    module.FinalLayer = _FakePDDFinalLayer
+    inner = _inner()
+    inner.final_layer = _FakePDDFinalLayer()
+    sample_sigmas = torch.tensor([1.0, 0.5, 0.0])
+    video_x = torch.zeros((1, 24, 2, 4, 4))
+    audio_x = torch.zeros((1, 32, 2, 2))
+    state = _prepare_output_state(
+        inner,
+        video_x,
+        audio_x,
+        torch.tensor([500.0]),
+        torch.zeros((1, 2, 4)),
+        {"sample_sigmas": sample_sigmas},
+        {},
+        _layout(),
+    )
+
+    _execute_forecast(inner, torch.zeros((1, 12, 4)), state, video_x, audio_x)
+
+    assert len(inner.final_layer.calls) == 1
+    _, _, _, _, sigma, forwarded_sigmas, shifts = inner.final_layer.calls[0]
+    torch.testing.assert_close(sigma, state.sigma_v)
+    assert forwarded_sigmas is sample_sigmas
+    assert shifts == (state.shift_v, state.shift_a)
 
 
 def test_fully_generating_masks_keep_scalar_fast_path(monkeypatch):


### PR DESCRIPTION
Fixes #82.

Supersedes #83. Thanks @bun-dev for independently identifying the same ComfyUI PDD `FinalLayer` contract break and proposing the compatible call shape; this maintainer PR adds the regression test and pinned Core CI coverage.

## Root cause

ComfyUI commit `2504e68d4d9dedb514e172692f13436623f25aed` (MiniMax-H3 PDD LoRA support) extended native `FinalLayer.forward` from:

```python
forward(x, t_emb, video_seg, audio_seg)
```

to:

```python
forward(x, t_emb, video_seg, audio_seg, sigma, sample_sigmas, shifts)
```

Spectrum reconstructs the native H3 output head on forecast steps. Its forecast path still called the old four-argument contract, so the first eligible forecast now fails with:

```text
FinalLayer.forward() missing 3 required positional arguments: 'sigma', 'sample_sigmas', and 'shifts'
```

A real Continuum + Spectrum run exposed this after one successful actual transformer step.

## Fix

- Preserve the existing four-argument path for reviewed older ComfyUI revisions.
- Detect the native Core `FinalLayer.forward` contract from the Core class signature instead of probing by execution.
- For the PDD-capable contract, forward the same values native H3 uses:
  - current video sigma;
  - the sampler's exact `transformer_options["sample_sigmas"]` schedule;
  - the active video/audio sigma shifts.
- Keep masked scalar/per-row output-head modulation unchanged.
- Fail explicitly if Core ever exposes only a partial PDD argument contract.

## Regression coverage

- Add a focused projection test proving the PDD call receives the exact sigma schedule and stream shifts.
- Add ComfyUI `2504e68d` to the compatibility matrix with the dependency versions required by that Core revision.
- Retain all existing historical Core lanes, including the legacy four-argument FinalLayer contract.

No Continuum-side workaround is needed; the failure is in Spectrum's native output-head reconstruction boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility for ComfyUI versions using the PDD final-layer projection contract.
  * Forecast execution now supports sigma schedules and stream shifts with compatible configurations.

* **Bug Fixes**
  * Improved compatibility across supported ComfyUI, Python, and package-version combinations.

* **Tests**
  * Added coverage verifying that sigma schedules and shifts are passed correctly to compatible final layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->