### PR TITLE
Release Spectrum MiniMax H3 v0.2.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,12 @@ jobs:
             HEAD
           (cd dist && sha256sum "${archive}" > SHA256SUMS)
 
+      - name: Extract current release notes
+        shell: bash
+        run: |
+          awk '/^---$/ { exit } { print }' RELEASE_NOTES.md > CURRENT_RELEASE_NOTES.md
+          test -s CURRENT_RELEASE_NOTES.md
+
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -69,4 +75,4 @@ jobs:
             dist/SHA256SUMS \
             --target "${RELEASE_SHA}" \
             --title "Spectrum MiniMax H3 ${TAG}" \
-            --notes-file RELEASE_NOTES.md
+            --notes-file CURRENT_RELEASE_NOTES.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,24 @@
-# Spectrum MiniMax H3 v0.2.20
+# Spectrum MiniMax H3 v0.2.21
+
+v0.2.21 restores Spectrum forecast execution with current ComfyUI MiniMax H3 after the PDD LoRA update changed the native output-head contract.
+
+## ComfyUI 0.34 PDD final-layer compatibility
+
+- Fixes `FinalLayer.forward() missing 3 required positional arguments: 'sigma', 'sample_sigmas', and 'shifts'` on the first eligible Spectrum forecast with ComfyUI 0.34.0 and later PDD-capable H3 cores.
+- Spectrum now detects the reviewed native FinalLayer contract and forwards the same current sigma, exact sampler sigma schedule, and video/audio sigma shifts used by native H3.
+- Reviewed older ComfyUI revisions retain the existing four-argument FinalLayer path.
+- An incomplete future PDD argument contract fails explicitly instead of guessing.
+- No H3 Continuum-side workaround is required; Continuum exposed the stale Spectrum forecast output-head call.
+
+## Validation
+
+PR #84 adds focused regression coverage for the PDD projection call and adds ComfyUI commit `2504e68d4d9dedb514e172692f13436623f25aed` to the compatibility matrix with its required `comfy-kitchen` and `comfy-aimdo` versions. All seven ComfyUI/Python lanes pass, including the historical legacy FinalLayer contracts. CodeRabbit reported no actionable code finding.
+
+PR #84 supersedes #83; thanks to @bun-dev for independently identifying the same Core contract break and proposing the compatible call shape.
+
+---
+
+## v0.2.20
 
 v0.2.20 fixes the RefDelta API-v1 step-provenance handoff after a tracked ER-SDE model call.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.20"
+version = "0.2.21"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release the ComfyUI 0.34 / MiniMax H3 PDD FinalLayer compatibility fix from #84.

Changes:
- bump package version to 0.2.21 so Comfy Registry/Manager can receive the fix;
- add the v0.2.21 release notes for the FinalLayer contract break and validation;
- make the GitHub release workflow publish only the current top release-note section, avoiding historical changelogs in each new release description.

The runtime fix itself was already validated in #84 across the seven-lane ComfyUI/Python matrix, including the exact PDD-introducing Core commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Released Spectrum MiniMax H3 v0.2.21.
  * Added compatibility with ComfyUI 0.34+ PDD FinalLayer contracts.
  * Improved handling of legacy contracts and incomplete contract failures.
  * Added regression validation for these compatibility updates.

* **Release Process**
  * GitHub releases now use only the current release notes section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->