### PR TITLE
Add Spectrum support for native SEEDS-2 and SEEDS-3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,7 @@ jobs:
             tests/test_continuum_interop.py \
             tests/test_er_sde_solver_dense_output.py \
             tests/test_er_sde_stochastic_compensation.py \
+            tests/test_seeds_deterministic_contract.py \
             tests/test_generic_correction.py \
             tests/test_generic_correction_calibration.py \
             tests/test_generic_correction_core.py \

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The minimum reviewed packed-H3 integration contract starts at ComfyUI commit [`e
 
 ## Supported samplers
 
-Forecasting is fail-closed and allowlisted for reviewed single-call sampler contracts.
+Forecasting is fail-closed and allowlisted for reviewed sampler contracts.
 
 | Sampler | Function | Spectrum policy |
 |---|---|---|
@@ -190,8 +190,39 @@ Forecasting is fail-closed and allowlisted for reviewed single-call sampler cont
 | MiniMax H3 Turbo | `_turbo_sampler` | Reviewed deterministic single-call contract. |
 | RES multistep | `sample_res_multistep` | Conservative cadence with protected native tail. |
 | RES multistep CFG++ | `sample_res_multistep_cfg_pp` | Same RES safeguards. |
+| SEEDS-2 | `sample_seeds_2` | Reviewed two-stage topology with state-conditioned residual forecasting for stochastic internal stages. |
+| SEEDS-3 | `sample_seeds_3` | Reviewed three-stage topology with state-conditioned residual forecasting for stochastic internal stages. |
 
 Unknown or changed sampler contracts fall back to native execution rather than guessing.
+
+For SEEDS-2/3, every internal denoiser stage is a real MiniMax H3 model evaluation opportunity and therefore a Spectrum logical model call. A terminal-zero schedule contains `2N - 1` model evaluations for SEEDS-2 and `3N - 2` for SEEDS-3 when the outer sampler has `N` sigma intervals. Continuum's actual-prefix contract remains expressed in outer sampler steps; stochastic SEEDS applies that prefix in outer-step space while deterministic SEEDS retains the expanded logical-call mapping.
+
+Native SEEDS is stochastic by default (`eta > 0` and `s_noise > 0`). Its higher-stage construction deliberately evaluates the denoiser on intermediate states after correlated noise has been injected. The SEEDS paper identifies the dependence of noise on overlapping subintervals as essential to the Markov-preserving solver construction, and its ablation shows that naive noise substitutions sharply degrade sampling quality.
+
+Spectrum therefore does **not** subtract, rescale, reorder, regenerate, or approximate SEEDS' stochastic increments. Instead, stochastic SEEDS uses a state-conditioned feature geometry:
+
+```text
+final H3 target hidden = exact current-state input embedding
+                       + transformer residual
+```
+
+The current-state term is kept exact for every SEEDS stage. On actual H3 calls Spectrum captures the exact target input hidden state immediately before the first transformer block and stores only `final_hidden - input_hidden`. On a forecast call it recomputes the native target audio/video input projections from the exact current stochastic latent, forecasts only the transformer residual, then adds the exact current-state embedding back before the native H3 final layer.
+
+Stochastic SEEDS now uses one **shared residual history across the true interleaved model-call coordinates** instead of isolated per-stage histories. This is important for efficiency once stage 0 is protected: every exact outer-stage H3 evaluation becomes a fresh anchor for the following internal-stage forecast. The residual forecaster therefore sees the actual continuous SEEDS trajectory rather than discarding the nearest exact outer anchors and forcing an otherwise unnecessary same-lane refresh.
+
+The normal no-back-to-back forecast guard still applies. For SEEDS-2, an internal forecast is immediately followed by the next exact outer stage, which satisfies that refresh naturally. Stochastic SEEDS still suppresses Spectrum's one-point bootstrap, so the shared trajectory must first contain the normal minimum fit history before internal forecasting starts.
+
+The model-aware controller remains active on internal forecasts for risk telemetry, degree/ridge adaptation, blend confidence, and generic correction. Its ordinary `force_actual` veto is not used for stochastic SEEDS internal stages. That scheduler veto was calibrated for ordinary one-lane trajectories; on the shared interleaved SEEDS residual trajectory it can treat the intended outer/internal stage alternation as excess trajectory curvature. The exact outer-stage mask, hard external-patch transitions, Continuum prefix, warmup/tail rules, readiness checks, and transactional fallbacks remain authoritative actual-step boundaries.
+
+The native **outer stage (stage 0) is always actual** for stochastic SEEDS. Native ComfyUI emits its sampler callback immediately after this first model evaluation, and real H3 testing showed that forecasting this noise-conditioned outer evaluation produced the characteristic delayed heavy-noise preview artifact. The state-conditioned residual decomposition preserves the current noisy input exactly, but the transformer residual itself is still a nonlinear response to that specific fresh stochastic state; a time-only residual forecast cannot reconstruct that response reliably. Spectrum therefore forecasts only the internal SEEDS stages (stage 1 for SEEDS-2; stages 1 and 2 for SEEDS-3). This preserves every outer/callback denoiser evaluation exactly while still skipping internal transformer evaluations.
+
+A subsequent real SEEDS-2 run confirmed why the scheduling ownership matters. With stage 0 already exact and shared history active, the first chunk still finished at 15 actual / 4 forecast and the Continuum chunk at 16 / 3 because model-aware risk vetoed internal steps 11 and 15. Those combined risks were only marginally above the ordinary 0.65 threshold, while the interleaved stage geometry already supplied exact outer anchors between internal candidates. The stochastic-SEEDS policy now keeps those model-aware signals advisory instead of spending extra H3 transformer NFEs on top of the explicit sampler safety boundaries.
+
+This specifically addresses the failure mode found during real H3 testing: forecasting the absolute final hidden state ignored the fresh stochastic internal latent, while sampler-space noise subtraction and outer-stage denoised extrapolation both changed the SEEDS trajectory and produced visible corruption. The state-residual path leaves the native SEEDS Markov-preserving noise path untouched and conditions every skipped transformer evaluation on the actual latent produced by that path.
+
+Deterministic SEEDS remains supported as before. Setting either `eta=0` or `s_noise=0` disables native SEEDS stochastic injection, so the ordinary expanded logical-call forecast geometry remains valid. Offline smoothing replay remains available only for deterministic SEEDS. If replay is requested with stochastic SEEDS, Spectrum performs one causal state-residual pass instead; it never replays away the noise-conditioned stage structure.
+
+The `SamplerSEEDS2` node can emulate exponential-Heun variants with `r=1`. Spectrum leaves that endpoint-stage configuration native because the intermediate model call lands on the next outer sigma, producing duplicate timestep coordinates for different solver states. Reviewed Spectrum tracking therefore requires `0 < r < 1` for SEEDS-2 and `0 < r_1 < r_2 < 1` for SEEDS-3.
 
 ### ER-SDE compatibility details
 
@@ -208,7 +239,7 @@ ComfyUI-TiledDiffusion's current `KSAMPLER.sample(*args, **kwargs)` passthrough 
 
 Warmup and tail constraints are always actual. Reviewed samplers also limit the causal forecast horizon and require actual refreshes.
 
-The default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins.
+For ordinary one-lane samplers, the default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins. Stochastic SEEDS deliberately suppresses that bootstrap; its exact outer stages instead provide fresh anchors to the shared state-conditioned residual history.
 
 Typical 20-step Euler/ER-SDE single-pass cadence is approximately:
 

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -19,6 +19,8 @@ from .sampling import (
 
 LOG = logging.getLogger(__name__)
 
+_STATE_BASIS_CHUNK_BYTES = 16 * 1024 * 1024
+
 
 def locate_minimax_h3_inner(model: Any) -> tuple[Any | None, str | None]:
     outer = getattr(model, "model", None)
@@ -48,6 +50,8 @@ def is_native_minimax_h3(inner: Any) -> bool:
         "sigma_shift_video",
         "sigma_shift_audio",
         "use_adaln_curves",
+        "video_patch_proj",
+        "audio_patch_proj",
     )
     if not class_match or not all(hasattr(inner, name) for name in required):
         return False
@@ -104,7 +108,14 @@ def _native_module(inner: Any):
     module = importlib.import_module(type(inner).__module__)
     # time_shift_slope is deliberately absent: cores that still expose it want the
     # audio velocity pre-scaled here, newer ones convert outside this wrapper.
-    required = ("PackedLayout", "unpatchify_video", "unpack_audio", "time_shift_sigma")
+    required = (
+        "PackedLayout",
+        "unpatchify_video",
+        "unpack_audio",
+        "time_shift_sigma",
+        "patchify_video",
+        "pack_audio",
+    )
     missing = [name for name in required if not hasattr(module, name)]
     if missing:
         raise RuntimeError(f"native MiniMax H3 module is missing required helpers: {', '.join(missing)}")
@@ -119,6 +130,58 @@ def _padded_shape(shape: tuple[int, ...], patch_size: tuple[int, int, int]) -> t
         ((h + ph - 1) // ph) * ph,
         ((w + pw - 1) // pw) * pw,
     )
+
+
+def _apply_exact_state_input_embedding_(
+    target: torch.Tensor,
+    inner: Any,
+    video_x: torch.Tensor,
+    audio_x: torch.Tensor,
+    *,
+    scale: float,
+) -> torch.Tensor:
+    """Add/subtract H3's exact target input embedding without running transformer blocks."""
+    if target.ndim != 3 or target.shape[0] != 1:
+        raise ValueError("state-residual target must be a batch-one [1, rows, hidden] tensor")
+    if target.shape[-1] != int(inner.hidden_size):
+        raise ValueError("state-residual target hidden width does not match native H3")
+
+    module = _native_module(inner)
+    common_dit = importlib.import_module("comfy.ldm.common_dit")
+    padded_video = common_dit.pad_to_patch_size(video_x, tuple(inner.patch_size))
+    video_rows = module.patchify_video(
+        padded_video.to(torch.float32),
+        tuple(inner.patch_size),
+    )
+    audio_rows = module.pack_audio(audio_x.to(torch.float32))
+    if audio_rows.ndim != 2 or video_rows.ndim != 2:
+        raise ValueError("native H3 patch helpers returned an unexpected row layout")
+
+    compact = target[0]
+    total_rows = int(audio_rows.shape[0] + video_rows.shape[0])
+    if compact.shape[0] != total_rows:
+        raise ValueError(
+            "state-residual target rows do not match native H3 audio/video input rows"
+        )
+
+    element_size = torch.empty((), dtype=compact.dtype).element_size()
+    rows_per_chunk = max(
+        1,
+        _STATE_BASIS_CHUNK_BYTES
+        // max(1, int(inner.hidden_size) * element_size),
+    )
+    offset = 0
+    for rows, projection in (
+        (audio_rows, inner.audio_patch_proj),
+        (video_rows, inner.video_patch_proj),
+    ):
+        count = int(rows.shape[0])
+        for start in range(0, count, rows_per_chunk):
+            stop = min(count, start + rows_per_chunk)
+            embedded = projection(rows[start:stop]).to(compact.dtype)
+            compact[offset + start : offset + stop].add_(embedded, alpha=float(scale))
+        offset += count
+    return target
 
 
 def _resolve_layout(inner: Any, context: torch.Tensor, video_x: torch.Tensor, audio_x: torch.Tensor, payload: dict[str, Any]):
@@ -365,11 +428,34 @@ def _execute_actual(
     patches_replace["dit"] = dit_replacements
     local_options["patches_replace"] = patches_replace
     existing = dit_replacements.get(("double_block", last_index))
+    first_index = 0
+    existing_first = dit_replacements.get(("double_block", first_index))
     observed = False
     actual_target = None
+    state_input_target = None
+
+    if runtime.active_state_residual_mode and first_index != last_index:
+        def capture_state_input(args, replacement_context):
+            nonlocal state_input_target
+            hidden = args.get("img")
+            (aa, _), (_, vb) = target_segments(layout)
+            if not torch.is_tensor(hidden) or hidden.ndim != 2 or hidden.shape[0] < vb:
+                raise RuntimeError(
+                    "initial MiniMax H3 hidden feature is incompatible with state-residual forecasting"
+                )
+            state_input_target = hidden[aa:vb].detach().clone(
+                memory_format=torch.contiguous_format
+            )
+            return (
+                existing_first(args, replacement_context)
+                if existing_first is not None
+                else replacement_context["original_block"](args)
+            )
+
+        dit_replacements[("double_block", first_index)] = capture_state_input
 
     def capture_replacement(args, replacement_context):
-        nonlocal actual_target, observed
+        nonlocal actual_target, observed, state_input_target
         output = existing(args, replacement_context) if existing is not None else replacement_context["original_block"](args)
         if not isinstance(output, dict) or "img" not in output or not torch.is_tensor(output["img"]):
             raise RuntimeError("final MiniMax H3 block replacement did not return {'img': tensor}")
@@ -382,7 +468,45 @@ def _execute_actual(
         # second full target tensor on the GPU before the required CPU archive.
         target = hidden[aa:vb].unsqueeze(0)
         actual_target = target
-        runtime.observe_actual(run_id, step_id, call_id, target)
+        if runtime.active_state_residual_mode:
+            try:
+                if state_input_target is None:
+                    # This only applies to an unexpected one-block native contract.
+                    history_target = target.detach().clone(
+                        memory_format=torch.contiguous_format
+                    )
+                    _apply_exact_state_input_embedding_(
+                        history_target,
+                        inner,
+                        x[0],
+                        x[1],
+                        scale=-1.0,
+                    )
+                else:
+                    # Native H3 updates the packed hidden state in-place. Capture
+                    # the exact pre-block target once, then turn that owned buffer
+                    # into final_hidden - input_hidden at the last block.
+                    state_input_target.neg_().add_(target[0])
+                    history_target = state_input_target.unsqueeze(0)
+                    state_input_target = None
+                runtime.observe_actual(
+                    run_id,
+                    step_id,
+                    call_id,
+                    history_target,
+                    take_ownership=True,
+                )
+            except torch.cuda.OutOfMemoryError:
+                raise
+            except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+                runtime.fallback_current_step(
+                    run_id,
+                    step_id,
+                    f"SEEDS state-residual actual transform failed: {exc}",
+                )
+                runtime.observe_actual(run_id, step_id, call_id, target)
+        else:
+            runtime.observe_actual(run_id, step_id, call_id, target)
         observed = True
         return output
 
@@ -651,6 +775,39 @@ def diffusion_model_wrapper(
             kwargs,
         )
 
+    if runtime.active_state_residual_mode:
+        try:
+            _apply_exact_state_input_embedding_(
+                predicted,
+                inner,
+                video_x,
+                audio_x,
+                scale=1.0,
+            )
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            runtime.fallback_current_step(
+                int(run_id),
+                int(step_id),
+                f"SEEDS state-residual forecast reconstruction failed: {exc}",
+            )
+            return _execute_actual(
+                executor,
+                inner,
+                runtime,
+                int(run_id),
+                int(step_id),
+                call_id,
+                layout,
+                x,
+                timestep,
+                context,
+                options,
+                minimax_payload,
+                kwargs,
+            )
+
     sanitized, event = _sanitize_prediction(predicted, context.dtype)
     if sanitized is None:
         runtime.fallback_current_step(int(run_id), int(step_id), event["reason"] if event else "forecast sanitization failed")
@@ -693,9 +850,12 @@ def diffusion_model_wrapper(
         raise
     if runtime.config.debug:
         LOG.warning(
-            "Spectrum H3 forecast complete run_id=%s step=%s chunks=%s history=%s",
+            "Spectrum H3 forecast complete run_id=%s step=%s stage=%s geometry=%s "
+            "chunks=%s history=%s",
             run_id,
             step_id,
+            runtime.active_stage_index,
+            "state_residual" if runtime.active_state_residual_mode else "absolute_hidden",
             runtime.last_prediction_chunk_count,
             runtime.prediction_history_length,
         )

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -131,6 +131,7 @@ class RuntimeStats:
     model_profile_sensitivity: float = 0.0
     model_profile_patch_perturbation: float = 0.0
     model_aware_forecasts: int = 0
+    model_aware_veto_suppressed: int = 0
     model_aware_anchor_updates: int = 0
     model_aware_failures: int = 0
     model_aware_risk_max: float = 0.0
@@ -206,6 +207,8 @@ class _StepState:
     adaptive_recompute: bool
     mode: str
     reason: str
+    stage_index: int = 0
+    state_residual_mode: bool = False
     bootstrap_forecast: bool = False
     calls: list[_CallState] = field(default_factory=list)
     actual_records: list[_ActualRecord] = field(default_factory=list)
@@ -225,6 +228,12 @@ class _RunState:
     run_id: int
     sampler_name: str
     total_steps: int
+    policy_steps: int
+    stage_count: int
+    stochastic_multistage: bool
+    separate_stage_histories: bool
+    forecastable_stage_indices: tuple[int, ...] | None
+    model_aware_can_force_actual: bool
     sigma_min: float
     sigma_max: float
     supported_sampler: bool
@@ -244,6 +253,7 @@ class RuntimeRollbackSnapshot:
     current_window: float
     consecutive_forecasts: int
     required_actual_refreshes: int
+    stage_required_actual_refreshes: tuple[tuple[int, int], ...]
     required_feedback_actuals: int
     disabled: bool
     disable_reason: str | None
@@ -264,10 +274,14 @@ class SpectrumH3Runtime:
             max_history=self.config.max_history,
             history_storage=self.config.history_storage,
         )
+        self._primary_forecaster = self.forecaster
+        self._stage_forecasters: dict[int, HistoryWeightForecaster] = {}
         self.model_aware = ModelAwareController(
             self.config.model_aware_mode,
             self.config.model_aware_risk_threshold,
         )
+        self._primary_model_aware = self.model_aware
+        self._stage_model_aware: dict[int, ModelAwareController] = {}
 
         self.stats = RuntimeStats(current_window=self.config.window_size)
         self._run_counter = 0
@@ -278,6 +292,7 @@ class SpectrumH3Runtime:
         self._current_window = float(self.config.window_size)
         self._consecutive_forecasts = 0
         self._required_actual_refreshes = 0
+        self._stage_required_actual_refreshes: dict[int, int] = {}
         self._required_feedback_actuals = 0
         self._disabled = False
         self._disable_reason: str | None = None
@@ -310,6 +325,18 @@ class SpectrumH3Runtime:
     @property
     def active_model_aware_decision(self) -> ModelAwareForecastDecision | None:
         return None if self._step is None else self._step.model_aware_decision
+
+    @property
+    def active_stage_index(self) -> int:
+        return 0 if self._step is None else self._step.stage_index
+
+    @property
+    def active_state_residual_mode(self) -> bool:
+        return bool(self._step is not None and self._step.state_residual_mode)
+
+    @property
+    def stochastic_multistage(self) -> bool:
+        return bool(self._run is not None and self._run.stochastic_multistage)
 
     @property
     def supported_sampler(self) -> bool:
@@ -657,6 +684,12 @@ class SpectrumH3Runtime:
         min_actual_steps_after_forecast: int = 0,
         min_tail_actual_steps: int = 0,
         min_actual_prefix_steps: int = 0,
+        expected_model_calls: int | None = None,
+        stage_count: int = 1,
+        stochastic_multistage: bool = False,
+        separate_stage_histories: bool | None = None,
+        forecastable_stage_indices: tuple[int, ...] | None = None,
+        model_aware_can_force_actual: bool = True,
     ) -> int:
         if self._run is not None:
             raise RuntimeError("Spectrum H3 runtime already has an active run")
@@ -673,8 +706,54 @@ class SpectrumH3Runtime:
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{name} must be an integer >= 0")
+        if isinstance(stage_count, bool) or not isinstance(stage_count, int) or stage_count < 1:
+            raise ValueError("stage_count must be an integer >= 1")
+        if stochastic_multistage and stage_count < 2:
+            raise ValueError("stochastic_multistage requires stage_count >= 2")
+        if type(model_aware_can_force_actual) is not bool:
+            raise ValueError("model_aware_can_force_actual must be boolean")
+        if separate_stage_histories is not None and type(separate_stage_histories) is not bool:
+            raise ValueError("separate_stage_histories must be boolean or None")
+        resolved_stage_histories = (
+            bool(stochastic_multistage)
+            if separate_stage_histories is None
+            else bool(separate_stage_histories)
+        )
+        if resolved_stage_histories and not stochastic_multistage:
+            raise ValueError(
+                "separate_stage_histories requires stochastic_multistage"
+            )
+        if forecastable_stage_indices is not None:
+            normalized_forecastable_stages = tuple(forecastable_stage_indices)
+            if len(set(normalized_forecastable_stages)) != len(normalized_forecastable_stages):
+                raise ValueError("forecastable_stage_indices must not contain duplicates")
+            if any(
+                isinstance(index, bool)
+                or not isinstance(index, int)
+                or index < 0
+                or index >= stage_count
+                for index in normalized_forecastable_stages
+            ):
+                raise ValueError(
+                    "forecastable_stage_indices entries must be integer stage indices "
+                    "within [0, stage_count)"
+                )
+        else:
+            normalized_forecastable_stages = None
         sigma_values = _as_cpu_float64_vector(sigmas)
-        total_steps = max(0, sigma_values.numel() - 1)
+        schedule_steps = max(0, sigma_values.numel() - 1)
+        if expected_model_calls is not None:
+            if (
+                isinstance(expected_model_calls, bool)
+                or not isinstance(expected_model_calls, int)
+                or expected_model_calls < schedule_steps
+            ):
+                raise ValueError(
+                    "expected_model_calls must be None or an integer >= the supplied sigma intervals"
+                )
+            total_steps = expected_model_calls
+        else:
+            total_steps = schedule_steps
         evaluated = sigma_values[:-1]
         finite_schedule = bool(evaluated.numel()) and bool(torch.isfinite(evaluated).all().item())
         sigma_min = float(evaluated.min().item()) if finite_schedule else 0.0
@@ -689,21 +768,57 @@ class SpectrumH3Runtime:
             run_id=self._run_counter,
             sampler_name=str(sampler_name),
             total_steps=total_steps,
+            policy_steps=schedule_steps,
+            stage_count=stage_count,
+            stochastic_multistage=bool(stochastic_multistage),
+            separate_stage_histories=resolved_stage_histories,
+            forecastable_stage_indices=normalized_forecastable_stages,
+            model_aware_can_force_actual=model_aware_can_force_actual,
             sigma_min=sigma_min,
             sigma_max=sigma_max,
             supported_sampler=effective_supported,
             max_consecutive_forecasts=max_consecutive_forecasts,
             min_actual_steps_after_forecast=min_actual_steps_after_forecast,
             min_tail_actual_steps=min_tail_actual_steps,
-            min_actual_prefix_steps=min(min_actual_prefix_steps, total_steps),
+            min_actual_prefix_steps=min(
+                min_actual_prefix_steps,
+                schedule_steps if stochastic_multistage else total_steps,
+            ),
         )
         self._step = None
-        self.forecaster.reset()
+        self._primary_forecaster.reset()
+        self.forecaster = self._primary_forecaster
+        self._stage_forecasters = {}
+        self._primary_model_aware.reset()
+        self._primary_model_aware.set_profile(self._model_profile)
+        self.model_aware = self._primary_model_aware
+        self._stage_model_aware = {}
+        if resolved_stage_histories:
+            self._stage_forecasters[0] = self._primary_forecaster
+            self._stage_model_aware[0] = self._primary_model_aware
+            for stage_index in range(1, stage_count):
+                self._stage_forecasters[stage_index] = HistoryWeightForecaster(
+                    degree=self.config.degree,
+                    ridge_lambda=self.config.ridge_lambda,
+                    max_history=self.config.max_history,
+                    history_storage=self.config.history_storage,
+                )
+                controller = ModelAwareController(
+                    self.config.model_aware_mode,
+                    self.config.model_aware_risk_threshold,
+                )
+                controller.set_profile(self._model_profile)
+                self._stage_model_aware[stage_index] = controller
         self._history_topology = None
         self._history_labels = None
         self._current_window = float(self.config.window_size)
         self._consecutive_forecasts = 0
         self._required_actual_refreshes = 0
+        self._stage_required_actual_refreshes = (
+            {stage_index: 0 for stage_index in range(stage_count)}
+            if resolved_stage_histories
+            else {}
+        )
         self._required_feedback_actuals = 0
         self._disabled = not effective_supported
         self._experiment_disabled = False
@@ -714,12 +829,10 @@ class SpectrumH3Runtime:
         self._forced_actual_reason = None
         self._forced_actual_is_replay = False
         self._rollback_replay_active = False
-        self.model_aware.reset()
-        self.model_aware.set_profile(self._model_profile)
         if not self.config.enabled:
             self._disable_reason = "forecasting disabled by configuration"
         elif not supported_sampler:
-            self._disable_reason = f"sampler {sampler_name!r} is not allowlisted for one-call solver-step tracking"
+            self._disable_reason = f"sampler {sampler_name!r} is not allowlisted for Spectrum model-call tracking"
         elif not schedule_valid:
             self._disable_reason = "supplied sigma schedule is empty, nonfinite, or has no usable range"
         elif total_steps <= 0:
@@ -766,11 +879,22 @@ class SpectrumH3Runtime:
             raise RuntimeError("attempted to end a stale Spectrum H3 run")
         self._step = None
         self._run = None
-        self.forecaster.reset()
+        for forecaster in self._stage_forecasters.values():
+            forecaster.reset()
+        self._stage_forecasters = {}
+        self._primary_forecaster.reset()
+        self.forecaster = self._primary_forecaster
+        for controller in self._stage_model_aware.values():
+            controller.reset()
+        self._stage_model_aware = {}
+        self._primary_model_aware.reset()
+        self._primary_model_aware.set_profile(self._model_profile)
+        self.model_aware = self._primary_model_aware
         self._history_topology = None
         self._history_labels = None
         self._consecutive_forecasts = 0
         self._required_actual_refreshes = 0
+        self._stage_required_actual_refreshes = {}
         self._required_feedback_actuals = 0
         self._rollback_requested = False
         self._forced_actual_reason = None
@@ -896,6 +1020,17 @@ class SpectrumH3Runtime:
         if step_id >= self._run.total_steps:
             raise RuntimeError("predict_noise call count exceeded the supplied sigma schedule")
         coordinate = self.coordinate_for_timestep(timestep)
+        stage_index = (
+            step_id % self._run.stage_count
+            if self._run.stochastic_multistage
+            else 0
+        )
+        if self._run.separate_stage_histories:
+            self.forecaster = self._stage_forecasters[stage_index]
+            self.model_aware = self._stage_model_aware[stage_index]
+        else:
+            self.forecaster = self._primary_forecaster
+            self.model_aware = self._primary_model_aware
 
         if self._offline_phase == "replay":
             archive = self._offline_archive
@@ -913,6 +1048,8 @@ class SpectrumH3Runtime:
                 adaptive_recompute=False,
                 mode="replay",
                 reason="offline smoothing replay",
+                stage_index=stage_index,
+                state_residual_mode=self._run.stochastic_multistage,
             )
             self._run.next_step_id += 1
             return {
@@ -923,8 +1060,18 @@ class SpectrumH3Runtime:
                 "reason": "offline smoothing replay",
             }
 
+        policy_step_id = (
+            step_id // self._run.stage_count
+            if self._run.stochastic_multistage
+            else step_id
+        )
+        policy_total_steps = (
+            self._run.policy_steps
+            if self._run.stochastic_multistage
+            else self._run.total_steps
+        )
         effective_tail = max(self.config.tail_actual_steps, self._run.min_tail_actual_steps)
-        tail_start = max(0, self._run.total_steps - effective_tail)
+        tail_start = max(0, policy_total_steps - effective_tail)
         advances_window = False
         bootstrap_forecast = False
         rollback_replay = False
@@ -942,16 +1089,27 @@ class SpectrumH3Runtime:
             actual, reason = True, "anchor residual feedback refresh"
             rollback_replay = False
             consumes_feedback_refresh = True
-        elif step_id < self._run.min_actual_prefix_steps:
+        elif policy_step_id < self._run.min_actual_prefix_steps:
             actual, reason = True, "H3 Continuum actual prefix"
-        elif step_id < self.config.warmup_steps:
+        elif policy_step_id < self.config.warmup_steps:
             actual, reason = True, "warmup"
-        elif step_id >= tail_start:
+        elif policy_step_id >= tail_start:
             actual, reason = True, "final actual tail"
         elif (
+            self._run.forecastable_stage_indices is not None
+            and stage_index not in self._run.forecastable_stage_indices
+        ):
+            actual, reason = True, "sampler-required exact stage"
+        elif (
+            self._run.separate_stage_histories
+            and self._stage_required_actual_refreshes.get(stage_index, 0) > 0
+        ):
+            actual, reason = True, "post-forecast stage-lane refresh"
+        elif (
             self.config.bootstrap_first_forecast
+            and not self._run.stochastic_multistage
             and self.config.degree == 1
-            and step_id == 1
+            and policy_step_id == 1
             and self.forecaster.history_length == 1
         ):
             actual, reason = False, "one-point bootstrap forecast"
@@ -1014,11 +1172,14 @@ class SpectrumH3Runtime:
                     model_aware_decision.video_subspace_telemetry.applied_bounded_norm_ratio,
                 )
                 if model_aware_decision.force_actual:
-                    actual = True
-                    reason = "model-aware forecast risk"
-                    advances_window = False
-                    bootstrap_forecast = False
-                    model_aware_forced_actual = True
+                    if self._run.model_aware_can_force_actual:
+                        actual = True
+                        reason = "model-aware forecast risk"
+                        advances_window = False
+                        bootstrap_forecast = False
+                        model_aware_forced_actual = True
+                    else:
+                        self.stats.model_aware_veto_suppressed += 1
             except (RuntimeError, TypeError, ValueError) as exc:
                 self._model_aware_disabled_reason = f"model-aware decision failed: {exc}"
                 self.stats.model_aware_failures += 1
@@ -1037,6 +1198,8 @@ class SpectrumH3Runtime:
             adaptive_recompute=advances_window,
             mode="actual" if actual else "forecast",
             reason=reason,
+            stage_index=stage_index,
+            state_residual_mode=self._run.stochastic_multistage,
             bootstrap_forecast=bootstrap_forecast,
             rollback_replay=rollback_replay,
             consumes_feedback_refresh=consumes_feedback_refresh,
@@ -1157,6 +1320,8 @@ class SpectrumH3Runtime:
         step_id: int,
         call_id: int,
         feature: torch.Tensor,
+        *,
+        take_ownership: bool = False,
     ) -> None:
         step = self._require_step(run_id, step_id)
         call = step.calls[int(call_id)]
@@ -1202,10 +1367,15 @@ class SpectrumH3Runtime:
                 # CPU while the full replay archive takes ownership on device.
                 capture_storage = "vram"
             if capture_storage == "vram":
-                # The observed target is a view into the complete final-block
-                # hidden state. A forced clone keeps only the compact target
-                # storage alive and prevents later reuse of the backing tensor.
-                archived = detached.clone(memory_format=torch.contiguous_format)
+                # Ordinary observations are views into the complete final-block
+                # hidden state and must be cloned. State-residual SEEDS callers
+                # already materialize a compact owned tensor and transfer
+                # ownership explicitly to avoid a second full target clone.
+                archived = (
+                    detached
+                    if take_ownership and detached.is_contiguous()
+                    else detached.clone(memory_format=torch.contiguous_format)
+                )
             else:
                 archived = detached.to(device="cpu", dtype=feature.dtype, copy=True).contiguous()
         finally:
@@ -2144,6 +2314,12 @@ class SpectrumH3Runtime:
                 raise ForecastRetryActual("forecast branch-row allocation was incomplete")
             self._consecutive_forecasts += 1
             self._required_actual_refreshes = self._run.min_actual_steps_after_forecast
+            if self._run.separate_stage_histories:
+                self._stage_required_actual_refreshes[step.stage_index] = max(
+                    1,
+                    self._stage_required_actual_refreshes.get(step.stage_index, 0),
+                    self._run.min_actual_steps_after_forecast,
+                )
             self.stats.forecast_steps += 1
             self.stats.forecast_model_calls += len(step.calls)
             if step.model_aware_decision is not None:
@@ -2286,6 +2462,15 @@ class SpectrumH3Runtime:
                     )
             self._consecutive_forecasts = 0
             self._required_actual_refreshes = max(0, self._required_actual_refreshes - 1)
+            if self._run.separate_stage_histories:
+                pending_stage_refresh = self._stage_required_actual_refreshes.get(
+                    step.stage_index,
+                    0,
+                )
+                if pending_stage_refresh > 0:
+                    self._stage_required_actual_refreshes[step.stage_index] = (
+                        pending_stage_refresh - 1
+                    )
             if step.consumes_feedback_refresh:
                 self._required_feedback_actuals = max(0, self._required_feedback_actuals - 1)
             self.stats.actual_steps += 1
@@ -2300,7 +2485,11 @@ class SpectrumH3Runtime:
                 step.adaptive_recompute
                 and not step.fallback
                 and not self._disabled
-                and step.step_id >= self.config.warmup_steps
+                and (
+                    step.step_id // self._run.stage_count
+                    if self._run.stochastic_multistage
+                    else step.step_id
+                ) >= self.config.warmup_steps
             ):
                 window_ceiling = max(float(self.config.window_size), float(self.config.max_history))
                 self._current_window = min(
@@ -2348,6 +2537,9 @@ class SpectrumH3Runtime:
             current_window=self._current_window,
             consecutive_forecasts=self._consecutive_forecasts,
             required_actual_refreshes=self._required_actual_refreshes,
+            stage_required_actual_refreshes=tuple(
+                sorted(self._stage_required_actual_refreshes.items())
+            ),
             required_feedback_actuals=self._required_feedback_actuals,
             disabled=self._disabled,
             disable_reason=self._disable_reason,
@@ -2469,6 +2661,9 @@ class SpectrumH3Runtime:
         self._current_window = snapshot.current_window
         self._consecutive_forecasts = snapshot.consecutive_forecasts
         self._required_actual_refreshes = snapshot.required_actual_refreshes
+        self._stage_required_actual_refreshes = dict(
+            snapshot.stage_required_actual_refreshes
+        )
         self._required_feedback_actuals = snapshot.required_feedback_actuals
         self._disabled = snapshot.disabled
         self._disable_reason = snapshot.disable_reason
@@ -2615,7 +2810,14 @@ class SpectrumH3Runtime:
         subspace_summary = " ".join(subspace_parts)
         return (
             f"run_id={self.stats.run_id} sampler={self.stats.sampler_name} "
-            f"steps={self.stats.total_steps} actual_steps={self.stats.actual_steps} "
+            f"steps={self.stats.total_steps} "
+            f"stage_count={self._run.stage_count if self._run is not None else 1} "
+            f"stochastic_multistage={self._run.stochastic_multistage if self._run is not None else False} "
+            f"stage_histories={'separate' if self._run is not None and self._run.separate_stage_histories else 'shared'} "
+            f"feature_geometry={('state_residual_stage_lanes' if self._run.separate_stage_histories else 'state_residual_shared_history') if self._run is not None and self._run.stochastic_multistage else 'absolute_hidden'} "
+            f"forecastable_stages={self._run.forecastable_stage_indices if self._run is not None else None} "
+            f"stage_refresh_pending={sum(self._stage_required_actual_refreshes.values())} "
+            f"actual_steps={self.stats.actual_steps} "
             f"forecast_steps={self.stats.forecast_steps} "
             f"actual_transformer_calls={self.stats.actual_transformer_calls} "
             f"forecast_calls={self.stats.forecast_model_calls} "
@@ -2692,6 +2894,7 @@ class SpectrumH3Runtime:
             f"model_aware_sensitivity={self.stats.model_profile_sensitivity:.6f} "
             f"model_aware_patch_perturbation={self.stats.model_profile_patch_perturbation:.6f} "
             f"model_aware_forecasts={self.stats.model_aware_forecasts} "
+            f"model_aware_veto_suppressed={self.stats.model_aware_veto_suppressed} "
             f"model_aware_anchor_updates={self.stats.model_aware_anchor_updates} "
             f"model_aware_failures={self.stats.model_aware_failures} "
             f"model_aware_risk_max={self.stats.model_aware_risk_max:.6f} "

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
+import math
 import sys
 import time
 from dataclasses import dataclass
@@ -54,6 +55,18 @@ SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset(
         "sample_res_multistep_cfg_pp",
     }
 )
+
+SEEDS_SAMPLERS = frozenset({"sample_seeds_2", "sample_seeds_3"})
+SUPPORTED_SAMPLERS = SUPPORTED_SINGLE_CALL_SAMPLERS | SEEDS_SAMPLERS
+SEEDS_STAGE_COUNTS = {"sample_seeds_2": 2, "sample_seeds_3": 3}
+SEEDS_NATIVE_FUNCTION_DIGESTS = {
+    "sample_seeds_2": "e7bcf519718453f77e7ade9b71678c1b593472c8e9b0af142f64f97a9267f383",
+    "sample_seeds_3": "8cb90838a30f6ed0d9ba267f0a16275ce8ec5d65a9a5475f1a10cb573d45ce42",
+}
+SEEDS_TRACKED_OPTIONS = {
+    "sample_seeds_2": frozenset({"eta", "s_noise", "noise_sampler", "r", "solver_type"}),
+    "sample_seeds_3": frozenset({"eta", "s_noise", "noise_sampler", "r_1", "r_2"}),
+}
 
 RES_MULTISTEP_SAMPLERS = frozenset(
     {
@@ -118,7 +131,176 @@ def sampler_name(sampler: Any) -> str:
 
 
 def sampler_is_supported(sampler: Any) -> bool:
-    return sampler_name(sampler) in SUPPORTED_SINGLE_CALL_SAMPLERS
+    return sampler_name(sampler) in SUPPORTED_SAMPLERS
+
+
+def _seeds_expected_model_calls(sampler: Any, sigmas: Any) -> int | None:
+    """Count native SEEDS denoiser calls for the supplied outer sigma schedule."""
+    stage_count = SEEDS_STAGE_COUNTS.get(sampler_name(sampler))
+    if stage_count is None or not torch.is_tensor(sigmas) or sigmas.ndim != 1:
+        return None
+    sigma_values = sigmas.detach().reshape(-1)
+    outer_steps = max(0, int(sigma_values.numel()) - 1)
+    if outer_steps == 0:
+        return 0
+    nonterminal_steps = int(torch.count_nonzero(sigma_values[1:]).item())
+    return outer_steps + (stage_count - 1) * nonterminal_steps
+
+
+def _seeds_prefix_model_calls(
+    sampler: Any,
+    sigmas: Any,
+    outer_prefix: int,
+) -> int | None:
+    """Translate an outer-step prefix contract into SEEDS logical model calls."""
+    if not torch.is_tensor(sigmas) or sigmas.ndim != 1:
+        return None
+    outer_steps = max(0, int(sigmas.numel()) - 1)
+    prefix_steps = min(max(0, int(outer_prefix)), outer_steps)
+    if prefix_steps == 0:
+        return 0
+    return _seeds_expected_model_calls(sampler, sigmas[: prefix_steps + 1])
+
+
+def _seeds_stage_schedule_reason(sigmas: Any) -> str | None:
+    """Validate the native stage lane topology used by stochastic SEEDS forecasting."""
+    if not torch.is_tensor(sigmas) or sigmas.ndim != 1 or sigmas.numel() < 2:
+        return "SEEDS sigma schedule is not a one-dimensional tensor with at least one interval"
+    values = sigmas.detach().reshape(-1)
+    if not bool(torch.isfinite(values).all().item()):
+        return "SEEDS sigma schedule contains nonfinite values"
+    if bool((values[:-1] <= 0).any().item()):
+        return "SEEDS sigma schedule contains a nonpositive pre-terminal sigma"
+    if float(values[-1].item()) < 0.0:
+        return "SEEDS sigma schedule ends at a negative sigma"
+    if bool((values[1:] >= values[:-1]).any().item()):
+        return "SEEDS sigma schedule is not strictly descending"
+    return None
+
+
+def _seeds_option_contract(name: str, options: Any) -> str | None:
+    """Validate the reviewed native SEEDS option and stage surface."""
+    if name not in SEEDS_SAMPLERS:
+        return f"{name!r} is not a reviewed SEEDS sampler"
+    if not isinstance(options, dict):
+        return "SEEDS sampler options are not a dictionary"
+
+    unknown = set(options) - SEEDS_TRACKED_OPTIONS[name]
+    if unknown:
+        return f"SEEDS sampler has unreviewed options: {sorted(unknown)}"
+
+    for option_name, default in (("eta", 1.0), ("s_noise", 1.0)):
+        value = options.get(option_name, default)
+        if isinstance(value, bool):
+            return f"SEEDS {option_name} must be numeric"
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return f"SEEDS {option_name} must be numeric"
+        if not math.isfinite(numeric):
+            return f"SEEDS {option_name} must be finite"
+
+    noise_sampler = options.get("noise_sampler")
+    if noise_sampler is not None and not callable(noise_sampler):
+        return "SEEDS noise_sampler must be callable or None"
+
+    if name == "sample_seeds_2":
+        if options.get("solver_type", "phi_1") not in {"phi_1", "phi_2"}:
+            return "SEEDS-2 solver_type must be 'phi_1' or 'phi_2'"
+        try:
+            r = float(options.get("r", 0.5))
+        except (TypeError, ValueError):
+            return "SEEDS-2 r is not numeric"
+        if not math.isfinite(r) or not 0.0 < r < 1.0:
+            return "SEEDS-2 requires a strictly interior stage coordinate 0 < r < 1"
+    else:
+        try:
+            r_1 = float(options.get("r_1", 1.0 / 3.0))
+            r_2 = float(options.get("r_2", 2.0 / 3.0))
+        except (TypeError, ValueError):
+            return "SEEDS-3 r_1 and r_2 must be numeric"
+        if (
+            not math.isfinite(r_1)
+            or not math.isfinite(r_2)
+            or not 0.0 < r_1 < r_2 < 1.0
+        ):
+            return "SEEDS-3 requires strictly interior ordered stages 0 < r_1 < r_2 < 1"
+    return None
+
+
+def _seeds_is_stochastic(sampler: Any) -> bool:
+    """Return whether native SEEDS is configured to inject stochastic latent state."""
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return True
+    try:
+        eta = float(options.get("eta", 1.0))
+        s_noise = float(options.get("s_noise", 1.0))
+    except (TypeError, ValueError):
+        return True
+    if not math.isfinite(eta) or not math.isfinite(s_noise):
+        return True
+    # Native SEEDS multiplies s_noise by model_sampling.noise_scale later.
+    # Treat configured-positive s_noise conservatively as stochastic: a model
+    # with an effective zero noise_scale merely takes the safe native fallback.
+    return eta > 0.0 and s_noise > 0.0
+
+
+def _seeds_sampler_contract(sampler: Any) -> tuple[bool, str | None]:
+    """Validate the reviewed native SEEDS multistage contract."""
+    import comfy.k_diffusion.sampling as native_sampling
+    import comfy.samplers
+
+    name = sampler_name(sampler)
+    if name not in SEEDS_SAMPLERS:
+        return False, f"{name!r} is not a reviewed SEEDS sampler"
+
+    function = getattr(sampler, "sampler_function", None)
+    if function is not getattr(native_sampling, name, None):
+        return False, f"sampler function is not native ComfyUI {name}"
+    if function_ast_digest(function) != SEEDS_NATIVE_FUNCTION_DIGESTS[name]:
+        return False, f"native {name} implementation is not a reviewed revision"
+
+    if type(sampler) is not comfy.samplers.KSAMPLER:
+        return False, "SEEDS sampler object is not native ComfyUI KSAMPLER"
+    if (
+        comfy.samplers.KSAMPLER.__module__ != "comfy.samplers"
+        or comfy.samplers.KSAMPLER.__name__ != "KSAMPLER"
+    ):
+        return False, "native ComfyUI KSAMPLER class provenance is unreviewed"
+    sample_contract = _ksampler_sample_contract(sampler)
+    if not sample_contract.accepted:
+        return False, (
+            f"KSAMPLER.sample contract rejected: {sample_contract.failure}; "
+            f"{sample_contract.provenance.log_fields()}"
+        )
+
+    options = getattr(sampler, "extra_options", {}) or {}
+    option_reason = _seeds_option_contract(name, options)
+    if option_reason is not None:
+        return False, option_reason
+    return True, None
+
+
+def _native_seeds_preflight_reason(
+    sampler: Any,
+    model_options: dict[str, Any] | None,
+) -> str | None:
+    """Fail closed before Spectrum retains any state for a native SEEDS run."""
+    supported, reason = _seeds_sampler_contract(sampler)
+    if not supported:
+        return reason or "native SEEDS contract is unproven"
+
+    import comfy.patcher_extension
+
+    wrappers = comfy.patcher_extension.get_all_wrappers(
+        comfy.patcher_extension.WrappersMP.SAMPLER_SAMPLE,
+        model_options or {},
+        is_model_options=True,
+    )
+    if len(wrappers) != 1 or wrappers[0] is not sampler_sample_wrapper:
+        return "another SAMPLER_SAMPLE wrapper makes SEEDS model-call ordering unproven"
+    return None
 
 
 def _er_sde_noise_scaler_supports_replay(noise_scaler: Any) -> bool:
@@ -164,7 +346,14 @@ def sampler_supports_seeded_replay(sampler: Any) -> bool:
     """Return whether a fresh invocation can reconstruct the sampler's random stream."""
     if not sampler_is_supported(sampler):
         return False
-    if sampler_name(sampler) not in ER_SDE_SAMPLERS:
+
+    name = sampler_name(sampler)
+    if name in SEEDS_SAMPLERS:
+        options = getattr(sampler, "extra_options", {}) or {}
+        if _seeds_option_contract(name, options) is not None:
+            return False
+        return not _seeds_is_stochastic(sampler)
+    if name not in ER_SDE_SAMPLERS:
         return True
 
     options = getattr(sampler, "extra_options", {}) or {}
@@ -362,7 +551,7 @@ def max_consecutive_forecasts(sampler: Any) -> int | None:
 
 
 def min_actual_steps_after_forecast(sampler: Any) -> int:
-    return 1 if sampler_name(sampler) in SUPPORTED_SINGLE_CALL_SAMPLERS else 0
+    return 1 if sampler_name(sampler) in SUPPORTED_SAMPLERS else 0
 
 
 def min_tail_actual_steps(sampler: Any) -> int:
@@ -479,6 +668,48 @@ def outer_sample_wrapper(
 
     runtime = binding.runtime
     name = sampler_name(sampler)
+    expected_model_calls = None
+    if name in SEEDS_SAMPLERS:
+        preflight_reason = _native_seeds_preflight_reason(
+            sampler,
+            getattr(guider, "model_options", None),
+        )
+        if preflight_reason is None:
+            preflight_reason = _seeds_stage_schedule_reason(sigmas)
+        if preflight_reason is not None:
+            LOG.warning(
+                "Spectrum H3 disabled for this SEEDS run; running the untouched "
+                "native sampler: %s",
+                preflight_reason,
+            )
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
+        expected_model_calls = _seeds_expected_model_calls(sampler, sigmas)
+        if expected_model_calls is None:
+            LOG.warning(
+                "Spectrum H3 disabled for this SEEDS run; running the untouched "
+                "native sampler because the model-call topology could not be resolved"
+            )
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
     if name in ER_SDE_SAMPLERS:
         preflight_reason = _native_er_sde_preflight_reason(
             sampler,
@@ -503,9 +734,11 @@ def outer_sample_wrapper(
             )
     continuum_prefix = _continuum_actual_prefix(getattr(guider, "model_options", None))
     continuum_log_emitted = False
+    stochastic_seeds = name in SEEDS_SAMPLERS and _seeds_is_stochastic(sampler)
     profile_eligible = sampler_is_supported(sampler) and (
         not runtime.config.offline_smoothing_replay
         or sampler_supports_seeded_replay(sampler)
+        or stochastic_seeds
     )
     if runtime.config.model_aware_mode != "off" and profile_eligible:
         try:
@@ -554,6 +787,15 @@ def outer_sample_wrapper(
     ):
         nonlocal continuum_log_emitted
         phase_prefix = _continuum_prefix_for_phase(continuum_prefix, phase)
+        if expected_model_calls is not None and not stochastic_seeds:
+            expanded_prefix = _seeds_prefix_model_calls(
+                sampler,
+                run_sigmas,
+                phase_prefix,
+            )
+            if expanded_prefix is None:
+                raise RuntimeError("SEEDS prefix model-call topology became unavailable")
+            phase_prefix = expanded_prefix
         run_id = runtime.start_run(
             run_sigmas,
             name,
@@ -562,6 +804,16 @@ def outer_sample_wrapper(
             min_actual_steps_after_forecast=min_actual_steps_after_forecast(sampler),
             min_tail_actual_steps=min_tail_actual_steps(sampler),
             min_actual_prefix_steps=phase_prefix,
+            expected_model_calls=expected_model_calls,
+            stage_count=SEEDS_STAGE_COUNTS.get(name, 1),
+            stochastic_multistage=stochastic_seeds,
+            separate_stage_histories=False if stochastic_seeds else None,
+            forecastable_stage_indices=(
+                tuple(range(1, SEEDS_STAGE_COUNTS[name]))
+                if stochastic_seeds
+                else None
+            ),
+            model_aware_can_force_actual=not stochastic_seeds,
         )
         if phase_prefix > 0 and runtime.supported_sampler and not continuum_log_emitted:
             LOG.warning(
@@ -576,14 +828,29 @@ def outer_sample_wrapper(
             runtime.disable_experiment(
                 "ER-SDE is reviewed only for ordinary Spectrum and offline smoothing replay"
             )
+        if stochastic_seeds and (
+            runtime.config.anchor_residual_feedback
+            or runtime.config.selective_rollback_correction
+        ):
+            runtime.disable_experiment(
+                "stochastic SEEDS uses stage-lane state-residual forecasting; "
+                "rollback/residual experiments are not reviewed for this geometry"
+            )
         if runtime.config.debug:
             LOG.warning(
-                "Spectrum H3 run start phase=%s run_id=%s sampler=%s steps=%s supported=%s",
+                "Spectrum H3 run start phase=%s run_id=%s sampler=%s steps=%s supported=%s "
+                "seeds_stochastic=%s stage_count=%s feature_geometry=%s stage_histories=%s "
+                "model_aware_force_actual=%s",
                 phase,
                 run_id,
                 name,
                 runtime.stats.total_steps,
                 runtime.supported_sampler,
+                stochastic_seeds,
+                SEEDS_STAGE_COUNTS.get(name, 1),
+                "state_residual_shared_history" if stochastic_seeds else "absolute_hidden",
+                "shared" if stochastic_seeds else "single",
+                not stochastic_seeds,
             )
         started = time.perf_counter()
         try:
@@ -648,6 +915,21 @@ def outer_sample_wrapper(
             latent_shapes=latent_shapes,
         )
     if not sampler_supports_seeded_replay(sampler):
+        if stochastic_seeds:
+            LOG.warning(
+                "Spectrum H3 offline smoothing replay is disabled for stochastic SEEDS "
+                "because replay must not replace its Markov-preserving noise-conditioned "
+                "stage evaluations; running one causal state-residual Spectrum pass"
+            )
+            return execute_run(
+                noise,
+                latent_image,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                phase="single_pass_replay_fallback",
+            )
         LOG.warning(
             "Spectrum H3 offline smoothing replay requires ER-SDE's native seeded "
             "noise_sampler and noise_scaler; running one native pass"
@@ -690,11 +972,17 @@ def outer_sample_wrapper(
         _copy_condition_structure(guider.conds) if hasattr(guider, "conds") else None
     )
     offline_steps = max(0, sigmas.numel() - 1)
+    offline_logical_steps = (
+        offline_steps if expected_model_calls is None else expected_model_calls
+    )
     capture_callback, replay_callback, complete_progress = _offline_progress_callbacks(
         callback,
         offline_steps,
     )
-    runtime.begin_offline_capture(total_steps=offline_steps, sampler_name=name)
+    runtime.begin_offline_capture(
+        total_steps=offline_logical_steps,
+        sampler_name=name,
+    )
     try:
         first_result = execute_run(
             noise,

--- a/tests/test_h3_wrapper.py
+++ b/tests/test_h3_wrapper.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from comfyui_spectrum_h3 import minimax_h3 as minimax_h3_module
 from comfyui_spectrum_h3.config import SpectrumH3Config
 from comfyui_spectrum_h3.minimax_h3 import (
+    _apply_exact_state_input_embedding_,
     _sanitize_prediction,
     diffusion_model_wrapper,
     is_native_minimax_h3,
@@ -38,6 +40,8 @@ def _native_shaped_fake(*, use_adaln_curves=False):
         "sigma_shift_video": 12.0,
         "sigma_shift_audio": 3.0,
         "use_adaln_curves": use_adaln_curves,
+        "video_patch_proj": object(),
+        "audio_patch_proj": object(),
     }.items():
         setattr(instance, name, value)
     if use_adaln_curves:
@@ -68,6 +72,59 @@ def test_model_detection_enforces_the_conditional_timestep_contract():
     missing_table = _native_shaped_fake(use_adaln_curves=True)
     del missing_table.adaln_t_table
     assert not is_native_minimax_h3(missing_table)
+
+
+def test_state_residual_basis_round_trip_uses_exact_current_h3_input(monkeypatch):
+    video_projection = torch.nn.Linear(1, 2, bias=False)
+    audio_projection = torch.nn.Linear(1, 2, bias=False)
+    with torch.no_grad():
+        video_projection.weight.copy_(torch.tensor([[2.0], [3.0]]))
+        audio_projection.weight.copy_(torch.tensor([[5.0], [7.0]]))
+
+    inner = SimpleNamespace(
+        hidden_size=2,
+        patch_size=(1, 1, 1),
+        video_patch_proj=video_projection,
+        audio_patch_proj=audio_projection,
+    )
+    native_module = SimpleNamespace(
+        patchify_video=lambda value, _patch: value.permute(0, 2, 3, 4, 1).reshape(-1, 1),
+        pack_audio=lambda value: value.reshape(-1, 1),
+    )
+    common_dit = SimpleNamespace(
+        pad_to_patch_size=lambda value, _patch: value,
+    )
+    monkeypatch.setattr(minimax_h3_module, "_native_module", lambda _inner: native_module)
+    real_import = minimax_h3_module.importlib.import_module
+    monkeypatch.setattr(
+        minimax_h3_module.importlib,
+        "import_module",
+        lambda name: common_dit if name == "comfy.ldm.common_dit" else real_import(name),
+    )
+
+    video = torch.tensor([[[[[1.0, 2.0], [3.0, 4.0]]]]])
+    audio = torch.tensor([[[[6.0, 8.0]]]])
+    residual = torch.full((1, 6, 2), 11.0)
+
+    reconstructed = residual.clone()
+    _apply_exact_state_input_embedding_(
+        reconstructed,
+        inner,
+        video,
+        audio,
+        scale=1.0,
+    )
+    recovered = reconstructed.clone()
+    _apply_exact_state_input_embedding_(
+        recovered,
+        inner,
+        video,
+        audio,
+        scale=-1.0,
+    )
+
+    torch.testing.assert_close(recovered, residual)
+    assert not torch.equal(reconstructed, residual)
 
 
 def test_non_native_diffusion_call_records_a_native_passthrough_fallback():

--- a/tests/test_native_equivalence.py
+++ b/tests/test_native_equivalence.py
@@ -78,6 +78,34 @@ def _tiny_model():
     return model, block
 
 
+def _tiny_state_residual_model():
+    _, MiniMaxH3Model, _ = _native_imports()
+    torch.manual_seed(37)
+    model = MiniMaxH3Model(
+        hidden_size=8,
+        num_layers=2,
+        token_refiner_num_layers=1,
+        num_attention_heads=1,
+        attention_head_dim=8,
+        ffn_hidden_size=16,
+        latents_dim=2,
+        audio_latents_dim=2,
+        patch_size=(1, 2, 2),
+        text_dim=8,
+        timestep_input_dim=4,
+        time_embed_hidden_size=8,
+        time_embed_dim=4,
+        rope_inv_freq_len=1,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        operations=torch.nn,
+    )
+    blocks = [_CountingBlock(), _CountingBlock()]
+    model.blocks[0] = blocks[0]
+    model.blocks[1] = blocks[1]
+    return model, blocks
+
+
 def _inputs(PackedLayout):
     video = torch.randn(1, 2, 1, 4, 4)
     audio = torch.randn(1, 2, 2, 3)
@@ -131,6 +159,75 @@ def _wrapped_call(model, runtime, sigma, model_timestep, x, context, payload, la
     output = executor.execute(x, torch.tensor([model_timestep]), context, options, minimax_payload=payload)
     runtime.finalize_step(decision["run_id"], decision["step_id"])
     return output, decision
+
+
+def test_stochastic_seeds_state_residual_forecast_uses_exact_current_input_and_skips_blocks():
+    _, _, PackedLayout = _native_imports()
+    model, blocks = _tiny_state_residual_model()
+    base_x, context, payload = _inputs(PackedLayout)
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            model_aware_mode="off",
+            warmup_steps=0,
+            tail_actual_steps=0,
+            bootstrap_first_forecast=False,
+            window_size=2.0,
+            flex_window=0.0,
+            offline_smoothing_replay=False,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=5,
+        stage_count=2,
+        stochastic_multistage=True,
+    )
+
+    for index, sigma in enumerate((1.0, 0.85, 0.7, 0.55)):
+        x = [
+            base_x[0] + 0.05 * index,
+            base_x[1] - 0.03 * index,
+        ]
+        output, decision = _wrapped_call(
+            model,
+            runtime,
+            sigma,
+            sigma * 1000.0,
+            x,
+            context,
+            payload,
+        )
+        assert decision["actual"]
+        assert all(torch.isfinite(part).all() for part in output)
+
+    calls_before_forecast = [block.calls for block in blocks]
+    forecast_x = [
+        base_x[0] + 0.4,
+        base_x[1] - 0.2,
+    ]
+    output, decision = _wrapped_call(
+        model,
+        runtime,
+        0.4,
+        400.0,
+        forecast_x,
+        context,
+        payload,
+    )
+
+    assert decision["actual"] is False
+    assert runtime.active_stage_index == 0
+    assert [block.calls for block in blocks] == calls_before_forecast
+    assert all(torch.isfinite(part).all() for part in output)
+    assert runtime.stats.actual_transformer_calls == 4
+    assert runtime.stats.forecast_model_calls == 1
+    runtime.end_run(run_id)
 
 
 def test_forced_actual_wrapper_is_native_equivalent_and_does_not_mutate_options():

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.model_aware import ModelForecastabilityProfile, ProfileLookup
 from comfyui_spectrum_h3.runtime import ForecastRetryActual, SpectrumH3Runtime
 
 TOPOLOGY = (
@@ -14,6 +15,33 @@ TOPOLOGY = (
     ("target_video_rows", 2),
 )
 LABEL = ((0, "positive"),)
+
+
+def _test_model_profile() -> ModelForecastabilityProfile:
+    return ModelForecastabilityProfile(
+        cache_key=("test",),
+        base_model_identity="test",
+        patch_identity="test",
+        active_patch_count=0,
+        active_patch_keys=0,
+        recognized_lora_count=0,
+        unknown_patch_count=0,
+        sampled_base_tensors=1,
+        profile_confidence=1.0,
+        aggregate_sensitivity=0.2,
+        patch_perturbation=0.0,
+        final_block_perturbation=0.0,
+        audio_sensitivity=1.0,
+        video_sensitivity=1.0,
+        audio_head_weight=None,
+        video_head_weight=None,
+        audio_head_gram_diagonal=None,
+        video_head_gram_diagonal=None,
+        forecast_risk_prior=0.2,
+        build_seconds=0.0,
+        estimated_bytes=0,
+        transient_workspace_bytes=0,
+    )
 
 
 def _runtime(**overrides):
@@ -121,6 +149,362 @@ def test_model_aware_off_never_enters_controller_and_keeps_legacy_forecast_path(
     assert runtime.stats.model_aware_decision_seconds == 0.0
     assert runtime.stats.model_aware_correction_seconds == 0.0
     runtime.end_run(run_id)
+
+
+def test_stochastic_seeds_uses_independent_stage_forecast_histories():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=0,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=False,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=5,
+        stage_count=2,
+        stochastic_multistage=True,
+    )
+
+    decisions = []
+    for timestep, feature_value in (
+        (1.0, 0.0),
+        (0.85, 100.0),
+        (0.7, 2.0),
+        (0.55, 102.0),
+    ):
+        decision = runtime.begin_step(torch.tensor([timestep]))
+        decisions.append(decision)
+        assert decision["actual"]
+        call_id, actual = runtime.begin_model_call(
+            decision["run_id"],
+            decision["step_id"],
+            topology=TOPOLOGY,
+            labels=LABEL,
+            expected_shape=(1, 3, 4),
+        )
+        assert actual
+        runtime.observe_actual(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            torch.full((1, 3, 4), feature_value),
+        )
+        runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    assert [decision["step_id"] for decision in decisions] == [0, 1, 2, 3]
+    assert runtime._stage_forecasters[0].history_length == 2
+    assert runtime._stage_forecasters[1].history_length == 2
+
+    forecast = runtime.begin_step(torch.tensor([0.4]))
+    assert forecast["step_id"] == 4
+    assert runtime.active_stage_index == 0
+    assert runtime.active_state_residual_mode is True
+    assert forecast["actual"] is False
+    call_id, actual = runtime.begin_model_call(
+        forecast["run_id"],
+        forecast["step_id"],
+        topology=TOPOLOGY,
+        labels=LABEL,
+        expected_shape=(1, 3, 4),
+    )
+    assert not actual
+    prediction = runtime.predict(
+        forecast["run_id"],
+        forecast["step_id"],
+        call_id,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    assert prediction is not None
+    assert float(prediction.abs().max()) < 20.0
+    runtime.finalize_step(forecast["run_id"], forecast["step_id"])
+    runtime.end_run(run_id)
+
+
+def test_stochastic_multistage_disables_one_point_bootstrap_per_stage_lane():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=1,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=True,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+        expected_model_calls=5,
+        stage_count=2,
+        stochastic_multistage=True,
+    )
+
+    first = _complete_step(runtime, 1.0)
+    second = _complete_step(runtime, 0.9)
+    third = _complete_step(runtime, 0.7)
+    fourth = _complete_step(runtime, 0.6)
+
+    assert first["actual"] and second["actual"]
+    assert third["actual"] and fourth["actual"]
+    assert third["reason"] == "insufficient actual history"
+    assert fourth["reason"] == "insufficient actual history"
+    assert "bootstrap" not in third["reason"]
+    assert "bootstrap" not in fourth["reason"]
+    assert runtime._stage_forecasters[0].history_length == 2
+    assert runtime._stage_forecasters[1].history_length == 2
+    runtime.end_run(run_id)
+
+
+def test_stochastic_multistage_requires_actual_refresh_in_the_same_lane():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=0,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=False,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.8, 0.6, 0.4, 0.2, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=9,
+        stage_count=2,
+        stochastic_multistage=True,
+    )
+
+    decisions = [
+        _complete_step(runtime, timestep)
+        for timestep in (1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2)
+    ]
+
+    # Two anchors per lane are required before the first forecast. A forecast in
+    # lane 0 cannot be "refreshed" by an actual evaluation in lane 1: lane 0's
+    # next occurrence is forced actual before it may forecast again. The same
+    # invariant applies symmetrically to lane 1.
+    assert [decision["actual"] for decision in decisions[:4]] == [True, True, True, True]
+    assert decisions[4]["actual"] is False
+    assert decisions[4]["step_id"] == 4
+    assert decisions[5]["actual"] is True
+    assert decisions[6]["actual"] is True
+    assert decisions[6]["reason"] == "post-forecast stage-lane refresh"
+    assert decisions[7]["actual"] is False
+    assert decisions[8]["actual"] is True
+    assert runtime._stage_required_actual_refreshes[0] == 0
+    assert runtime._stage_required_actual_refreshes[1] == 1
+    runtime.end_run(run_id)
+
+
+def test_stochastic_seeds_protects_outer_stage_and_forecasts_internal_stage_only():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=0,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=False,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.8, 0.6, 0.4, 0.2, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=9,
+        stage_count=2,
+        stochastic_multistage=True,
+        forecastable_stage_indices=(1,),
+    )
+
+    decisions = [
+        _complete_step(runtime, timestep)
+        for timestep in (1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2)
+    ]
+
+    stage0 = decisions[0::2]
+    stage1 = decisions[1::2]
+    assert all(decision["actual"] for decision in stage0)
+    assert all(
+        decision["reason"] == "sampler-required exact stage"
+        for decision in stage0[2:]
+    )
+    assert [decision["actual"] for decision in stage1] == [True, True, False, True]
+    assert stage1[2]["reason"] == "adaptive forecast"
+    assert stage1[3]["reason"] == "post-forecast stage-lane refresh"
+    runtime.end_run(run_id)
+
+
+def test_stochastic_seeds_shared_history_uses_exact_outer_anchors_without_lane_refresh():
+    runtime = _runtime(
+        model_aware_mode="schedule_confidence",
+        model_aware_risk_threshold=0.0,
+        warmup_steps=0,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=False,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    runtime.set_model_profile(
+        ProfileLookup(
+            profile=_test_model_profile(),
+            cache_hit=False,
+            lookup_seconds=0.0,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.8, 0.6, 0.4, 0.2, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+        expected_model_calls=9,
+        stage_count=2,
+        stochastic_multistage=True,
+        separate_stage_histories=False,
+        forecastable_stage_indices=(1,),
+        model_aware_can_force_actual=False,
+    )
+
+    decisions = [
+        _complete_step(runtime, timestep)
+        for timestep in (1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2)
+    ]
+
+    stage0 = decisions[0::2]
+    stage1 = decisions[1::2]
+
+    assert all(decision["actual"] for decision in stage0)
+    assert [decision["actual"] for decision in stage1] == [True, False, False, False]
+    assert all(
+        decision["reason"] == "adaptive forecast"
+        for decision in stage1[1:]
+    )
+    assert runtime._run is not None
+    assert runtime._run.separate_stage_histories is False
+    assert runtime._stage_forecasters == {}
+    assert runtime._stage_required_actual_refreshes == {}
+    assert runtime.forecaster is runtime._primary_forecaster
+    # Exact stage-0 calls continuously refresh the one shared residual history.
+    assert runtime.forecaster.history_length == 4
+    assert runtime.stats.actual_steps == 6
+    assert runtime.stats.forecast_steps == 3
+    # The deliberately zero risk threshold requests an actual on every
+    # forecast candidate. Stochastic SEEDS keeps that signal as telemetry and
+    # confidence/blend input, but the outer-stage safety policy owns the NFE
+    # decision for internal stages.
+    assert runtime.stats.model_aware_veto_suppressed == 3
+    assert runtime.stats.model_aware_forecasts == 3
+    runtime.end_run(run_id)
+
+
+def test_forecastable_stage_indices_validation():
+    runtime = _runtime(force_actual=True)
+    sigmas = torch.tensor([1.0, 0.5, 0.0])
+
+    with pytest.raises(ValueError, match="duplicates"):
+        runtime.start_run(
+            sigmas,
+            "sample_seeds_2",
+            supported_sampler=True,
+            expected_model_calls=3,
+            stage_count=2,
+            stochastic_multistage=True,
+            forecastable_stage_indices=(1, 1),
+        )
+
+    with pytest.raises(ValueError, match="within"):
+        runtime.start_run(
+            sigmas,
+            "sample_seeds_2",
+            supported_sampler=True,
+            expected_model_calls=3,
+            stage_count=2,
+            stochastic_multistage=True,
+            forecastable_stage_indices=(2,),
+        )
+
+
+def test_stochastic_seeds_3_stage_lane_indexing_matches_native_call_order():
+    runtime = _runtime(
+        model_aware_mode="off",
+        force_actual=True,
+        warmup_steps=0,
+        tail_actual_steps=0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_seeds_3",
+        supported_sampler=True,
+        expected_model_calls=4,
+        stage_count=3,
+        stochastic_multistage=True,
+    )
+
+    observed_stages = []
+    for timestep in (1.0, 0.8, 0.6, 0.5):
+        decision = runtime.begin_step(torch.tensor([timestep]))
+        observed_stages.append(runtime.active_stage_index)
+        call_id, actual = runtime.begin_model_call(
+            decision["run_id"],
+            decision["step_id"],
+            topology=TOPOLOGY,
+            labels=LABEL,
+            expected_shape=(1, 3, 4),
+        )
+        assert actual
+        runtime.observe_actual(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            torch.zeros((1, 3, 4)),
+        )
+        runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    assert observed_stages == [0, 1, 2, 0]
+    assert runtime._stage_forecasters[0].history_length == 2
+    assert runtime._stage_forecasters[1].history_length == 1
+    assert runtime._stage_forecasters[2].history_length == 1
+    runtime.end_run(run_id)
+
+
+def test_runtime_accepts_expanded_model_call_count_for_multistage_sampler():
+    runtime = _runtime(force_actual=True)
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        expected_model_calls=3,
+    )
+
+    for timestep in (1.0, 0.75, 0.5):
+        _complete_step(runtime, timestep)
+
+    assert runtime.stats.total_steps == 3
+    with pytest.raises(RuntimeError, match="predict_noise call count exceeded"):
+        runtime.begin_step(torch.tensor([0.25]))
+    runtime.end_run(run_id)
+
+
+def test_runtime_rejects_model_call_count_smaller_than_sigma_interval_count():
+    runtime = _runtime(force_actual=True)
+
+    with pytest.raises(ValueError, match="expected_model_calls"):
+        runtime.start_run(
+            torch.tensor([1.0, 0.75, 0.5, 0.0]),
+            "sample_seeds_2",
+            supported_sampler=True,
+            expected_model_calls=2,
+        )
 
 
 def test_preliminary_runtime_defaults():

--- a/tests/test_sampler_contract.py
+++ b/tests/test_sampler_contract.py
@@ -15,6 +15,7 @@ from comfyui_spectrum_h3.sampling import (
     ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST,
     ER_SDE_KSAMPLER_SAMPLE_DIGEST,
     ER_SDE_NATIVE_FUNCTION_DIGEST,
+    SEEDS_NATIVE_FUNCTION_DIGESTS,
 )
 
 RES_VARIANTS = (
@@ -28,6 +29,11 @@ ANCESTRAL_VARIANTS = (
     "sample_res_multistep_ancestral",
     "sample_res_multistep_ancestral_cfg_pp",
 )
+
+SEEDS_VARIANTS = {
+    "sample_seeds_2": 2,
+    "sample_seeds_3": 3,
+}
 
 
 def _native_tree(relative_path: str) -> ast.Module:
@@ -369,6 +375,63 @@ def test_native_euler_makes_one_model_call_per_solver_iteration():
     assert len(loops) == 1
     assert len(_named_calls(loops[0], "model")) == 1
     assert len(_named_calls(function, "model")) == 1
+
+
+def test_native_standard_seeds_2_defaults_match_reviewed_ksampler_contract():
+    function = _native_sampling_functions()["sample_seeds_2"]
+    positional = [arg.arg for arg in function.args.args]
+    defaults = {
+        name: value
+        for name, value in zip(
+            positional[-len(function.args.defaults) :],
+            function.args.defaults,
+            strict=True,
+        )
+    }
+
+    assert ast.literal_eval(defaults["eta"]) == 1.0
+    assert ast.literal_eval(defaults["s_noise"]) == 1.0
+    assert ast.literal_eval(defaults["noise_sampler"]) is None
+    assert ast.literal_eval(defaults["r"]) == 0.5
+    assert ast.literal_eval(defaults["solver_type"]) == "phi_1"
+
+
+def test_native_seeds_2_callback_is_bound_to_outer_stage_model_result():
+    function = _native_sampling_functions()["sample_seeds_2"]
+    loop = next(node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor)))
+    model_calls = [
+        node
+        for node in ast.walk(loop)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "model"
+    ]
+    callback_calls = [
+        node
+        for node in ast.walk(loop)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "callback"
+    ]
+
+    assert len(model_calls) == 2
+    assert len(callback_calls) == 1
+    first_model_line = min(node.lineno for node in model_calls)
+    second_model_line = max(node.lineno for node in model_calls)
+    callback_line = callback_calls[0].lineno
+    assert first_model_line < callback_line < second_model_line
+
+
+@pytest.mark.parametrize(("function_name", "stage_count"), SEEDS_VARIANTS.items())
+def test_native_seeds_stage_topology_matches_reviewed_contract(function_name, stage_count):
+    function = _native_sampling_functions()[function_name]
+    loops = [node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor))]
+
+    assert len(loops) == 1
+    assert len(_named_calls(loops[0], "model")) == stage_count
+    assert len(_named_calls(function, "model")) == stage_count
+    assert len(_named_calls(loops[0], "noise_sampler")) == stage_count
+    assert _ast_digest(function) == SEEDS_NATIVE_FUNCTION_DIGESTS[function_name]
 
 
 @pytest.mark.parametrize("function_name", RES_VARIANTS)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -23,6 +23,10 @@ from comfyui_spectrum_h3.sampling import (
     sampler_name,
     sampler_sample_wrapper,
     sampler_supports_seeded_replay,
+    _seeds_expected_model_calls,
+    _seeds_is_stochastic,
+    _seeds_option_contract,
+    _seeds_stage_schedule_reason,
 )
 
 
@@ -43,9 +47,11 @@ def _sampler(function_name: str) -> SimpleNamespace:
         "sample_refdelta_er_sde",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
+        "sample_seeds_2",
+        "sample_seeds_3",
     ),
 )
-def test_reviewed_single_call_samplers_are_supported(function_name):
+def test_reviewed_samplers_are_supported(function_name):
     sampler = _sampler(function_name)
 
     assert sampler_name(sampler) == function_name
@@ -77,6 +83,8 @@ def test_unreviewed_sampler_names_do_not_match_by_prefix(function_name):
         "sample_refdelta_er_sde",
         "sample_res_multistep",
         "sample_res_multistep_cfg_pp",
+        "sample_seeds_2",
+        "sample_seeds_3",
     ),
 )
 def test_supported_h3_samplers_limit_forecast_streaks(function_name):
@@ -93,7 +101,14 @@ def test_res_multistep_policy_refreshes_once_and_protects_tail(function_name):
 
 @pytest.mark.parametrize(
     "function_name",
-    ("sample_euler", "sample_er_sde", "sample_refdelta_er_sde", "_turbo_sampler"),
+    (
+        "sample_euler",
+        "sample_er_sde",
+        "sample_refdelta_er_sde",
+        "_turbo_sampler",
+        "sample_seeds_2",
+        "sample_seeds_3",
+    ),
 )
 def test_non_res_policy_keeps_one_refresh_and_user_tail(function_name):
     sampler = _sampler(function_name)
@@ -109,6 +124,233 @@ def test_unsupported_sampler_has_no_forecast_streak_policy():
     assert min_actual_steps_after_forecast(sampler) == 0
     assert min_tail_actual_steps(sampler) == 0
 
+
+
+
+
+@pytest.mark.parametrize(
+    ("function_name", "sigmas", "expected"),
+    (
+        ("sample_seeds_2", [1.0, 0.6, 0.2, 0.0], 5),
+        ("sample_seeds_3", [1.0, 0.6, 0.2, 0.0], 7),
+        ("sample_seeds_2", [1.0, 0.6, 0.2], 4),
+        ("sample_seeds_3", [1.0, 0.6, 0.2], 6),
+    ),
+)
+def test_seeds_expected_model_calls_tracks_internal_stages(
+    function_name, sigmas, expected
+):
+    assert (
+        _seeds_expected_model_calls(_sampler(function_name), torch.tensor(sigmas))
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("options", "stochastic"),
+    (
+        ({}, True),
+        ({"eta": 1.0, "s_noise": 1.0}, True),
+        ({"eta": 0.0}, False),
+        ({"s_noise": 0.0}, False),
+        ({"eta": -0.5, "s_noise": 1.0}, False),
+    ),
+)
+def test_seeds_stochastic_gate_matches_native_inject_noise_condition(options, stochastic):
+    sampler = _sampler("sample_seeds_2")
+    sampler.extra_options = options
+
+    assert _seeds_is_stochastic(sampler) is stochastic
+
+
+@pytest.mark.parametrize(
+    ("function_name", "options", "replay_safe"),
+    (
+        ("sample_seeds_2", {}, False),
+        ("sample_seeds_3", {}, False),
+        ("sample_seeds_2", {"eta": 0.0}, True),
+        ("sample_seeds_3", {"s_noise": 0.0}, True),
+        (
+            "sample_seeds_2",
+            {"eta": 0.0, "noise_sampler": lambda *_args: torch.zeros(1)},
+            True,
+        ),
+    ),
+)
+def test_seeds_replay_safety_requires_deterministic_native_configuration(
+    function_name, options, replay_safe
+):
+    sampler = _sampler(function_name)
+    sampler.extra_options = options
+
+    assert sampler_supports_seeded_replay(sampler) is replay_safe
+
+
+def test_seeds_2_endpoint_stage_is_rejected_for_spectrum_tracking():
+    reason = _seeds_option_contract("sample_seeds_2", {"r": 1.0})
+
+    assert reason is not None
+    assert "strictly interior stage coordinate" in reason
+
+
+def test_seeds_3_non_interior_stage_order_is_rejected_for_spectrum_tracking():
+    reason = _seeds_option_contract(
+        "sample_seeds_3",
+        {"r_1": 0.75, "r_2": 0.5},
+    )
+
+    assert reason is not None
+    assert "strictly interior ordered stages" in reason
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    (
+        ({"eta": float("nan")}, "eta"),
+        ({"s_noise": float("inf")}, "s_noise"),
+        ({"noise_sampler": object()}, "noise_sampler"),
+    ),
+)
+def test_seeds_invalid_options_fail_closed(options, message):
+    reason = _seeds_option_contract("sample_seeds_2", options)
+
+    assert reason is not None
+    assert message in reason
+
+
+def test_stochastic_seeds_outer_wrapper_enters_state_residual_spectrum(monkeypatch, caplog):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            model_aware_mode="off",
+            offline_smoothing_replay=False,
+            debug=True,
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {},
+        },
+        model_patcher=object(),
+    )
+    sampler = _sampler("sample_seeds_2")
+    sampler.extra_options = {}
+    calls = []
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_seeds_preflight_reason",
+        lambda _sampler, _model_options: None,
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            calls.append(
+                (
+                    runtime.active_run_id,
+                    runtime.stochastic_multistage,
+                    runtime.stats.total_steps,
+                    runtime._run.forecastable_stage_indices,
+                    runtime._run.separate_stage_histories,
+                    args,
+                    kwargs,
+                )
+            )
+            return "state-residual-seeds"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.5, 0.0]),
+            seed=17,
+        )
+
+    assert result == "state-residual-seeds"
+    assert len(calls) == 1
+    assert calls[0][0] is not None
+    assert calls[0][1] is True
+    assert calls[0][2] == 3
+    assert calls[0][3] == (1,)
+    assert calls[0][4] is False
+    assert runtime.active_run_id is None
+    assert "running the untouched native sampler" not in caplog.text
+    assert "feature_geometry=state_residual_shared_history" in caplog.text
+    assert "stage_histories=shared" in caplog.text
+
+
+def test_stochastic_seeds_offline_request_runs_one_causal_spectrum_pass(monkeypatch, caplog):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            model_aware_mode="off",
+            offline_smoothing_replay=True,
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {},
+        },
+        model_patcher=object(),
+    )
+    sampler = _sampler("sample_seeds_2")
+    sampler.extra_options = {}
+    active_runs = []
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_seeds_preflight_reason",
+        lambda _sampler, _model_options: None,
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            active_runs.append(
+                (runtime.active_run_id, runtime.stochastic_multistage, runtime.offline_phase)
+            )
+            return "causal-stochastic-seeds"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.5, 0.0]),
+            seed=17,
+        )
+
+    assert result == "causal-stochastic-seeds"
+    assert len(active_runs) == 1
+    assert active_runs[0][0] is not None
+    assert active_runs[0][1] is True
+    assert active_runs[0][2] is None
+    assert "one causal state-residual Spectrum pass" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("sigmas", "expected_fragment"),
+    (
+        (torch.tensor([1.0, 0.5, 0.0]), None),
+        (torch.tensor([1.0, 0.5, 0.25]), None),
+        (torch.tensor([1.0, 0.0, 0.0]), "nonpositive pre-terminal"),
+        (torch.tensor([1.0, float("nan"), 0.0]), "nonfinite"),
+    ),
+)
+def test_seeds_stage_schedule_contract(sigmas, expected_fragment):
+    reason = _seeds_stage_schedule_reason(sigmas)
+
+    if expected_fragment is None:
+        assert reason is None
+    else:
+        assert reason is not None
+        assert expected_fragment in reason
 
 def test_unsupported_sampler_does_not_build_unused_model_profile(monkeypatch):
     runtime = SpectrumH3Runtime(

--- a/tests/test_seeds_deterministic_contract.py
+++ b/tests/test_seeds_deterministic_contract.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import ast
+import copy
+import os
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _native_seeds_function(function_name: str):
+    comfyui_path = os.environ.get("COMFYUI_PATH")
+    if not comfyui_path:
+        pytest.skip("COMFYUI_PATH is required for the native SEEDS contract test")
+    source_path = Path(comfyui_path) / "comfy/k_diffusion/sampling.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    function = copy.deepcopy(function)
+    function.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {
+        "torch": torch,
+        "trange": lambda count, disable=None: range(count),
+        "partial": partial,
+        "default_noise_sampler": object(),
+        "offset_first_sigma_for_snr": lambda sigmas, _model_sampling: sigmas,
+        "sigma_to_half_log_snr": lambda sigma, model_sampling: -torch.log(sigma),
+        "half_log_snr_to_sigma": lambda value, model_sampling: torch.exp(-value),
+        "ei_h_phi_1": torch.expm1,
+        "ei_h_phi_2": lambda value: (torch.expm1(value) - value) / value,
+    }
+    exec(  # noqa: S102 - execute reviewed native source in a closed test namespace
+        compile(module, f"<native {function_name}>", "exec"),
+        namespace,
+    )
+    return namespace[function_name]
+
+
+def _run_native(
+    function_name: str,
+    *,
+    eta: float,
+    s_noise: float,
+    noise_value: float,
+):
+    native = _native_seeds_function(function_name)
+    model_sampling = SimpleNamespace(noise_scale=1.0)
+    model_calls = 0
+    noise_calls = 0
+
+    class Patcher:
+        def get_model_object(self, name):
+            assert name == "model_sampling"
+            return model_sampling
+
+    class Model:
+        inner_model = SimpleNamespace(model_patcher=Patcher())
+
+        def __call__(self, x, sigma, **_extra_args):
+            nonlocal model_calls
+            model_calls += 1
+            sigma_view = sigma.reshape(-1, *([1] * (x.ndim - 1)))
+            return x * 0.2 + sigma_view * 0.1
+
+    def noise_sampler(_sigma, _sigma_next):
+        nonlocal noise_calls
+        noise_calls += 1
+        return torch.full((1, 2), noise_value, dtype=torch.float32)
+
+    sigmas = torch.tensor([0.9, 0.7, 0.5, 0.0], dtype=torch.float32)
+    result = native(
+        Model(),
+        torch.ones((1, 2), dtype=torch.float32),
+        sigmas,
+        disable=True,
+        eta=eta,
+        s_noise=s_noise,
+        noise_sampler=noise_sampler,
+    )
+    return result, model_calls, noise_calls
+
+
+@pytest.mark.parametrize(
+    ("function_name", "expected_model_calls"),
+    (
+        ("sample_seeds_2", 5),
+        ("sample_seeds_3", 7),
+    ),
+)
+@pytest.mark.parametrize(
+    ("eta", "s_noise"),
+    (
+        (0.0, 1.0),
+        (1.0, 0.0),
+        (-0.5, 1.0),
+    ),
+)
+def test_native_deterministic_seeds_keeps_multistage_calls_but_never_draws_noise(
+    function_name,
+    expected_model_calls,
+    eta,
+    s_noise,
+):
+    _, model_calls, noise_calls = _run_native(
+        function_name,
+        eta=eta,
+        s_noise=s_noise,
+        noise_value=123.0,
+    )
+
+    assert model_calls == expected_model_calls
+    assert noise_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("function_name", "expected_noise_calls"),
+    (
+        ("sample_seeds_2", 4),
+        ("sample_seeds_3", 6),
+    ),
+)
+def test_native_default_stochastic_seeds_draws_noise_between_model_calls(
+    function_name,
+    expected_noise_calls,
+):
+    _, _, noise_calls = _run_native(
+        function_name,
+        eta=1.0,
+        s_noise=1.0,
+        noise_value=0.25,
+    )
+
+    assert noise_calls == expected_noise_calls
+
+
+@pytest.mark.parametrize("function_name", ("sample_seeds_2", "sample_seeds_3"))
+def test_deterministic_seeds_output_is_independent_of_noise_sampler_values(function_name):
+    first, first_calls, first_noise_calls = _run_native(
+        function_name,
+        eta=0.0,
+        s_noise=1.0,
+        noise_value=-1000.0,
+    )
+    second, second_calls, second_noise_calls = _run_native(
+        function_name,
+        eta=0.0,
+        s_noise=1.0,
+        noise_value=1000.0,
+    )
+
+    assert first_calls == second_calls
+    assert first_noise_calls == second_noise_calls == 0
+    assert torch.equal(first, second)


### PR DESCRIPTION
## Summary

Add reviewed Spectrum support for native ComfyUI SEEDS-2 and SEEDS-3, including the default stochastic solver path.

The implementation follows the actual higher-stage SEEDS construction rather than treating the sampler as a sequence of ordinary one-call diffusion steps. In SEEDS-2/3, intermediate denoiser calls are evaluated after correlated stochastic increments have changed the latent. The NeurIPS 2023 SEEDS paper treats that Markov-preserving noise decomposition as a core part of the solver, and its ablation shows that naive noise substitutions materially degrade sampling quality.

Earlier revisions of this PR tried sampler-space stochastic correction / denoised extrapolation. Real MiniMax H3 tests rejected both: they caused propagated noise, quality loss, and a start-frame distortion. Those approaches are removed.

## Stochastic SEEDS architecture

Spectrum now leaves the native SEEDS stochastic process completely untouched:

- no subtraction or rescaling of SEEDS noise;
- no replacement/reordering of the native noise sampler;
- no denoised/x0 extrapolation;
- no additional transformer NFE.

Instead, stochastic SEEDS uses **state-conditioned residual forecasting**.

For every H3 model call:

```text
final target hidden
  = exact current-state target input embedding
  + transformer residual
```

On an actual call, Spectrum captures the exact target input hidden state immediately before the first native H3 transformer block, captures the final target hidden at the last block, and stores only:

```text
transformer_residual = final_hidden - input_hidden
```

On a forecast call, Spectrum:

1. starts from the exact current SEEDS latent produced by the native solver/noise path;
2. runs only the native H3 target audio/video input projections, chunked to bound temporary output memory;
3. forecasts the transformer residual;
4. adds the exact current-state input embedding back;
5. feeds the reconstructed hidden state through the ordinary native H3 final layer.

This directly preserves the stochastic state information that the previous absolute-hidden forecast lost.

Stochastic SEEDS uses one shared forecast/model-aware residual history over the true interleaved model-call coordinates. The exact outer stage therefore becomes a fresh anchor for the following internal-stage forecast instead of being discarded from an isolated stage lane.

## Solver accounting and contracts

- SEEDS-2 terminal-zero schedule: `2N - 1` H3 model-call opportunities.
- SEEDS-3 terminal-zero schedule: `3N - 2`.
- Exact native function ASTs and `KSAMPLER.sample` semantics are pinned fail-closed.
- Stochastic stage-lane mapping requires a finite, strictly descending schedule with no pre-terminal zero.
- Continuum's actual prefix remains an outer-step contract for stochastic SEEDS.
- Deterministic SEEDS retains expanded logical-call behavior.
- SEEDS-2 requires `0 < r < 1`; the native `r=1` exponential-Heun alias remains fail-closed because it creates duplicate timestep coordinates for distinct solver states.
- SEEDS-3 requires `0 < r_1 < r_2 < 1`.

## Offline replay

Deterministic SEEDS can use the existing seeded offline replay path.

Stochastic SEEDS intentionally does not use offline smoothing replay: replaying the model-call sequence independently of the native noise-conditioned stage trajectory would violate the solver geometry this integration is designed to preserve. If replay is enabled in the Spectrum node, stochastic SEEDS performs one causal state-residual Spectrum pass instead of bypassing Spectrum.

## Stochastic scheduling and forecast efficiency

A real default `KSamplerSelect -> seeds_2` run first exposed two safety problems in the original multistage scheduler: one-point bootstrap was possible inside a stage lane, and global refresh bookkeeping could allow one stage to satisfy another stage's refresh requirement. Those issues were fixed, but the conservative lane design then exposed a different practical problem: with stage 0 protected, a 19-call SEEDS-2 trajectory completed with **16 actual / 3 forecast** H3 evaluations.

That ratio is not an acceptable steady-state policy. The cause was structural rather than model-aware gating: stage 1 had its own isolated residual history, so every stage-1 forecast forced the next stage-1 occurrence actual even though the exact stage-0 evaluation in between had already produced a fresh H3 residual anchor at the nearest trajectory coordinate.

The revised stochastic policy keeps the safety boundary that eliminated the delayed heavy-noise artifact while removing that redundant refresh:

- the native **outer stage (stage 0) remains exact on every outer interval**;
- stochastic SEEDS still disables one-point bootstrap;
- internal stages remain forecast-only candidates;
- all actual stochastic-SEEDS residuals now feed one shared history ordered by their true model-call coordinates;
- the ordinary global no-back-to-back forecast guard remains active;
- an internal SEEDS-2 forecast is therefore naturally refreshed by the next exact outer-stage H3 evaluation instead of requiring another internal-stage actual call.

This is specifically appropriate for the state-conditioned residual geometry. The exact current-state input embedding is recomputed from the native latent on every call, so the shared history models only the transformer residual along the continuous SEEDS trajectory. The exact outer call is the closest available fresh anchor and should contribute to that trajectory fit rather than being ignored because of solver-stage identity.

The outer-stage protection itself is unchanged. Real H3 testing isolated the delayed heavy-noise preview pattern exactly to stage-0 forecasts. Native SEEDS-2 calls its callback immediately after stage 0, and the forecasted callback-visible stage-0 calls matched the artifact cadence. Keeping stage 0 exact preserves every preview/callback denoiser evaluation and avoids asking a time-only transformer-residual forecast to reproduce H3's nonlinear response to a freshly sampled stochastic realization.

For a 10-outer-step terminal-zero SEEDS-2 run there are 19 logical H3 evaluations: 10 outer-stage calls and 9 internal calls. With no additional hard transition or Continuum prefix, the revised shared-history policy needs one initial internal actual anchor and can make the remaining internal calls forecast-eligible, giving a practical ceiling near **11 actual / 8 forecast**.

A subsequent real run on the shared-history head isolated the remaining runtime loss. The first chunk completed at **15 actual / 4 forecast**; the Continuum chunk completed at **16 / 3**. Stage 0 was behaving as intended and there were no redundant same-lane refreshes. The missing forecasts were internal steps 11 and 15, both rejected only by the ordinary model-aware risk veto at combined risks around 0.66, just above the default 0.65 threshold. The hard external-patch transitions at steps 9 and 17 and the Continuum prefix were separate expected actual boundaries.

That model-aware veto is now advisory for stochastic SEEDS internal stages. The controller still computes risk, confidence, adaptive degree/ridge, blend scaling, and generic correction; it simply cannot spend an extra transformer NFE there. The reason is architectural rather than threshold tuning: its scheduler risk was designed for ordinary one-lane trajectories, while stochastic SEEDS deliberately uses a shared interleaved outer/internal residual trajectory. The protected exact outer stage already supplies the fresh anchor and is the sampler-specific safety boundary. Raising the global threshold would weaken ordinary samplers; bypassing only this veto preserves their behavior.

The follow-up real run on this head now hits that scheduling target exactly. The first chunk completed at **13 actual / 6 forecast** in **202.352 s** with internal forecasts at steps 3, 5, 7, 11, 13, and 15. The Continuum chunk completed at **14 / 5** in **223.781 s** with internal forecasts at 5, 7, 11, 13, and 15. There were no fallbacks or stage-lane refreshes. The model-aware controller remained active and reported `model_aware_veto_suppressed=4` and `3`, respectively, confirming that the generic risk veto no longer spends extra transformer NFEs on this sampler-specific path.

The remaining actual boundaries are exactly the intended ones for this workflow: every stochastic outer stage, the Diff-Aid hard transition, the Untwist-RoPE hard transition, the Continuum prefix where present, warmup/readiness, and the final actual tail. Runtime scheduling is therefore no longer the blocker for this SEEDS-2 configuration. Decoded-media quality still requires the separate real-output gate; the log alone cannot establish perceptual parity.

SEEDS-3 remains more conservative because two internal stages occur consecutively between exact outer anchors; its global forecast-refresh guard still prevents unchecked multi-stage forecast streaks.

## Regression coverage

Coverage includes:

- native SEEDS-2/3 AST and model/noise-call topology across the compatibility matrix;
- exact `2N - 1` / `3N - 2` accounting;
- stochastic vs deterministic native noise-draw behavior;
- deterministic output independence from unused noise sampler values;
- native stage indexing, shared stochastic residual history, and protected stage-0 scheduling;
- regression coverage proving exact outer anchors refresh the shared SEEDS-2 history without a redundant same-stage actual;
- exact current-state input-embedding add/subtract round trip;
- native MiniMax H3 integration proving a stochastic SEEDS residual forecast skips transformer blocks while reconstructing from the current latent;
- stochastic replay-request fallback to one causal Spectrum pass;
- deterministic replay behavior;
- invalid schedule/stage/option fail-closed paths;
- existing external-patch, masked-H3, ER-SDE, Continuum, model-aware, Ruff and compileall coverage.

The latest one-commit head is `282d9c3cfce5081b6700aa21bf795ac7a97e155d`. Actions run #495 is green across all seven supported ComfyUI/Python lanes. On the pinned PDD-capable lane the focused suite reports 243 passed / 4 skipped and the remaining native suite 497 passed / 3 skipped; Ruff and compileall are green.


## Final real-media validation

A final native `seeds_2` run on the one-commit head completed cleanly with the full stacked workflow, including DiffAid, Untwist-RoPE, and H3 Continuum.

- Initial chunk: **11 actual / 8 forecast**, **0 fallbacks**, forecasts at steps **3, 5, 7, 9, 11, 13, 15, 17**.
- Continuum chunk: **12 actual / 7 forecast**, **0 fallbacks**. The additional exact call is the expected Continuum actual-prefix/readiness boundary; forecasts then resume at **5, 7, 9, 11, 13, 15, 17**.
- Stage 0 remains exact throughout; only internal stage 1 is forecasted.
- DiffAid and Untwist hard transitions land on already-actual coordinates and add no compatibility NFE.
- The decoded result was manually reviewed and reported clean, with no recurrence of the delayed heavy-noise pattern.

This closes the real-media gate for SEEDS-2. The final head remains `282d9c3cfce5081b6700aa21bf795ac7a97e155d`, with Actions #495 green across all seven supported ComfyUI/Python lanes.

No version/release bump is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for SEEDS-2 and SEEDS-3 samplers.
  - Added deterministic and stochastic replay modes with improved multistage forecasting.
  - Improved state-residual forecasting for supported H3 workflows.
  - Added validation for sampler options, schedules, and stage configurations.

- **Bug Fixes**
  - Invalid or unsupported stochastic configurations now safely fall back to native sampling.
  - Improved handling of actual-versus-forecast steps for reliable replay.

- **Documentation**
  - Documented SEEDS behavior, stage mapping, endpoint constraints, and replay differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->