### PR TITLE
Add Spectrum support for native SA-Solver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,7 @@ jobs:
             tests/test_continuum_interop.py \
             tests/test_er_sde_solver_dense_output.py \
             tests/test_er_sde_stochastic_compensation.py \
+            tests/test_sa_solver_state_conditioning.py \
             tests/test_seeds_deterministic_contract.py \
             tests/test_generic_correction.py \
             tests/test_generic_correction_calibration.py \
@@ -151,7 +152,8 @@ jobs:
             tests/test_sampling.py \
             tests/test_model_aware.py \
             tests/test_native_equivalence.py \
-            tests/test_er_sde_stochastic_compensation.py
+            tests/test_er_sde_stochastic_compensation.py \
+            tests/test_sa_solver_state_conditioning.py
 
       - name: Run tests against native MiniMax H3
         env:
@@ -170,4 +172,5 @@ jobs:
             --ignore=tests/test_sampling.py \
             --ignore=tests/test_model_aware.py \
             --ignore=tests/test_native_equivalence.py \
-            --ignore=tests/test_er_sde_stochastic_compensation.py
+            --ignore=tests/test_er_sde_stochastic_compensation.py \
+            --ignore=tests/test_sa_solver_state_conditioning.py

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Forecasting is fail-closed and allowlisted for reviewed sampler contracts.
 | RES multistep CFG++ | `sample_res_multistep_cfg_pp` | Same RES safeguards. |
 | SEEDS-2 | `sample_seeds_2` | Reviewed two-stage topology with state-conditioned residual forecasting for stochastic internal stages. |
 | SEEDS-3 | `sample_seeds_3` | Reviewed three-stage topology with state-conditioned residual forecasting for stochastic internal stages. |
+| SA-Solver PEC | `sample_sa_solver` | Reviewed one-call-per-outer-step Stochastic Adams path with state-conditioned residual forecasting when native stochasticity is active. |
+| SA-Solver PECE | `sample_sa_solver` / `sample_sa_solver_pece` | Supported only with `corrector_order=0`; active corrected-state PECE remains native/fail-closed. |
 
 Unknown or changed sampler contracts fall back to native execution rather than guessing.
 
@@ -224,6 +226,92 @@ Deterministic SEEDS remains supported as before. Setting either `eta=0` or `s_no
 
 The `SamplerSEEDS2` node can emulate exponential-Heun variants with `r=1`. Spectrum leaves that endpoint-stage configuration native because the intermediate model call lands on the next outer sigma, producing duplicate timestep coordinates for different solver states. Reviewed Spectrum tracking therefore requires `0 < r < 1` for SEEDS-2 and `0 < r_1 < r_2 < 1` for SEEDS-3.
 
+### SA-Solver compatibility details
+
+Spectrum supports the reviewed native Stochastic Adams `sample_sa_solver` PEC topology and the PECE wrappers only when `corrector_order=0`, where no second corrected-state H3 evaluation occurs. For `N = len(sigmas) - 1`, those accepted forms perform exactly `N` H3 model calls and `N` native callback events.
+
+Native SA-Solver may inject noise after a predictor when `tau > 0` and `s_noise > 0`. That stochastic increment is part of `x_pred`, and the **next outer H3 evaluation and callback consume that exact freshly perturbed state**. Real H3 testing showed delayed heavy-noise corruption on forecasted SA evaluations. Calls that consume a fresh stochastic increment are therefore treated as a directly identified high-risk subset: preserving the exact input embedding alone does not reproduce the transformer's nonlinear response to that new random realization.
+
+Spectrum therefore protects SA's native stochastic interval explicitly. For reviewed `tau_func` configurations it resolves the interval without speculative callback execution:
+
+- `tau_func=None` uses the exact native default bounds from `model_sampling.percent_to_sigma(0.2)` and `percent_to_sigma(0.8)`;
+- the reviewed native `get_tau_interval_func` closure is inspected for `start_sigma`, `end_sigma`, and `eta`;
+- effective `s_noise` includes the model's native `noise_scale`.
+
+Every outer step whose input `x_pred` contains a fresh SA stochastic increment is forced actual. Spectrum does not pre-roll this mask through the Adams memory: forecasted denoisers before the interval are already part of the accelerated trajectory, while the exactness requirement identified by the stochastic failure is the H3 evaluation of the freshly perturbed current state itself. Native `pred_list` remains untouched.
+
+Outside that protected stochastic region, SA may still use state-conditioned residual forecasting:
+
+```text
+final H3 target hidden = exact current-state input embedding
+                       + forecasted transformer residual
+```
+
+For stochastic PEC, Spectrum now uses a solver-aware Adams-history adapter rather than trying to make generic forecast scheduling safe by forcing most of the stochastic interval actual. That previous direction was fundamentally wrong for acceleration: protecting steps 6 through 13 and then protecting the terminal tail could only converge toward 15/4 or worse.
+
+The key invariant is that a Spectrum forecast is **not an SA observation**. Native SA normally appends every denoised result to `pred_list` and reuses that list in later corrector and predictor equations. Treating a forecasted denoiser as an ordinary persistent entry makes forecast error recursive. The rejected 13/6 real-media run demonstrated the failure directly: four consecutive tail forecasts filled the active Adams stencil with forecasted values and completely corrupted the decoded result.
+
+The Spectrum SA adapter therefore separates persistent and ephemeral solver evidence:
+
+```text
+persistent Adams history = exact H3 denoisers only
+forecasted denoiser      = current corrector + predictor only
+forecast-step corrector  = native PEC, ephemeral current endpoint
+next exact H3 call       = re-anchor Spectrum + Adams history
+```
+
+Exact denoisers retain their real lambda coordinates. When an intervening step is forecast, the next exact corrector uses an irregular-time stencil of actual observations rather than pretending the forecast was measured data. The native SA coefficient routine already accepts arbitrary lambda nodes, so the predictor/corrector equations, stochastic noise draw, tau schedule, callback order, sigma schedule, and final denoising semantics remain the reviewed native equations.
+
+This also removes the blanket fresh-noise exact block. `sa_stochastic_input_steps` remains logged because those states are still important diagnostics, but they are no longer forced actual merely because they contain a fresh stochastic increment. State-conditioned Spectrum forecasting sees the current `x_pred`, while the solver adapter prevents any forecast made there from becoming persistent Adams memory.
+
+Stochastic SA is intentionally scheduled around **isolated forecasts** with `max_consecutive_forecasts=1`. With the default 19-call trace, one warmup/readiness pair and one final actual tail naturally target **11 actual / 8 forecast**, not 15/4:
+
+```text
+A A F A F A F A F A F A F A F A F A A
+    2   4   6   8  10  12  14  16
+```
+
+A hard external-patch transition can convert its candidate forecast into an actual call, but because stochastic SA carries no post-forecast actual debt, the alternating phase resumes on the next eligible call rather than permanently losing the forecast budget. In the current DiffAid/Untwist workflow this shifts the step-8 candidate to step 9 and still leaves an eight-forecast target.
+
+Real 11/8 validation confirmed that this NFE target is reachable and that removing forecasted values from persistent Adams history eliminates the catastrophic full-video corruption. It also exposed a second, narrower bug: visible delayed-noise artifacts appeared on actual steps 10, 12, 14, and 16, immediately after forecast steps 9, 11, 13, and 15. The adapter was excluding the forecast from persistent history **and also skipping the current PEC corrector**. That left `x = x_pred` across every forecasted interval, so the approximation error was carried directly into the next exact H3 input and appeared one step late.
+
+Restoring the current PEC corrector was a useful falsification step but did **not** remove the delayed-noise artifacts in real media. The follow-up run positively confirmed that the current-corrector revision was active, yet the same one-step-late corruption remained after stochastic forecasts.
+
+The next real-media test also falsified a simpler output-space fix. The adapter subtracted the exact pending stochastic increment from the forecasted denoised result on every active-tau forecast, and the log confirmed that compensation executed at steps 4, 6, 9, 11, 13, and 15. The delayed-noise artifacts still remained. The direct `+q` term by itself is therefore not the root cause.
+
+The surviving mismatch is the **partial stochastic response inside the feature forecast**. MiniMax H3 is FLOW_AV and the Spectrum stochastic geometry reconstructs `final_hidden = exact_current_input_embedding + forecasted_transformer_residual`. For a native SA actual call, the transformer evaluates the full noisy `x_pred = x_base + q` and can respond nonlinearly to `q`. On a Spectrum forecast, rebuilding only the exact input embedding of that noisy state injects `q` into the hidden/output path without the transformer response that should accompany it. Subtracting `q` after the output cannot undo that partial hidden-space response.
+
+Repeated real runs showed that the split-input experiment was spending validation time on an unreliable cross-layer `q` handoff rather than the actual SA quality problem: the adapter announced split ownership, but the mandatory split breadcrumb never appeared. CI #507 and #508 also rejected the focused transport tests. That path has been removed completely rather than asking for another media run of a transport mechanism that is not proven.
+
+Active stochastic SA forecasts now use **solver-space causal dense output**. Spectrum still performs the cheap feature forecast so the normal runtime transaction, telemetry, and scheduler semantics remain intact, but the resulting hidden-feature denoised tensor is **not fed into SA's corrector/predictor while the current model input contains fresh stochastic predictor noise**. Instead SA receives a denoised estimate built only from exact H3 actual anchors:
+
+- with one trustworthy anchor, hold the latest exact denoised value;
+- after consecutive exact anchors (warmup, hard transition, forced refresh), hold the latest value rather than invent a slope;
+- otherwise extrapolate the exact denoised trajectory in SA lambda space using the two newest actual anchors;
+- clamp the extrapolation horizon to one previous anchor interval; invalid, reversed, nonfinite, or overlong geometry degenerates to a latest-actual hold.
+
+The first full real-media run of this design removed the delayed heavy-noise corruption at 11/8. It exposed a separate Continuum-only artifact in chunk 2: brief whole-frame vertical oscillation and flashing. The distinguishing runtime condition is the active Continuum continuation contract; chunk 1 has no Continuum interop request, while chunk 2 reports `accepted H3 Continuum API v1, actual prefix=2`.
+
+A follow-up run removed secant extrapolation from every **stochastic** Continuum forecast (steps 4, 6, 9, 11, 13, and 15) by holding the latest exact denoised anchor. The artifact was unchanged. That falsifies stochastic secant extrapolation as the cause, but the run still had two Continuum forecast coordinates whose raw hidden-feature denoisers entered SA because tau was zero: the early step 2 forecast and late step 17 forecast.
+
+Continuation chunks now use the latest-exact hold for **every forecast coordinate**, including non-stochastic steps 2 and 17. Spectrum still executes the cheap hidden-feature forecast to preserve its runtime transaction and telemetry, but no forecasted hidden-feature denoised value is allowed into the SA numerical trajectory anywhere in a Continuum chunk. This keeps the 11/8 schedule and adds no H3 NFEs. It is a deliberately narrow diagnostic/fix: if the oscillation/flashing remains, hidden-feature forecast value error is ruled out for Continuum and the next target is the modified Adams/corrector trajectory itself.
+
+Outside Continuum, bounded lambda-space dense output remains restricted to stochastic SA forecasts. Native SA still owns the untouched stochastic `x_pred`, the exact noise draw, tau, corrector, predictor equations, and RNG order. Persistent Adams history remains actual-only.
+
+The model-aware controller remains active for telemetry, confidence, adaptive fit/blend, and generic correction, but its ordinary scheduler `force_actual` veto is advisory on stochastic SA. NFE reduction is a first-class contract here; risk should influence how a forecast is used, not silently collapse an 11/8 target into 15/4. The rejected 13/6 run is retained as negative evidence against **persistent forecast history**, not as justification for restoring a high-NFE exact mask.
+
+Deterministic SA (`s_noise=0` or reviewed `eta=0`) does not receive that stochastic exact-block credit, retains the ordinary model-aware scheduler veto, and keeps the conservative full-Adams-memory refresh until its independent aggressive cadence is validated.
+
+The native SA noise sampler, tau evaluation, Adams coefficients, stochastic increment, and predictor/corrector equations remain unchanged. The only stochastic adaptation is the model input presented to a skipped H3 evaluation: active-tau forecasts see `x_pred - q`, while actual calls see native `x_pred`. Spectrum does not add a second solver-space extrapolator on top of Stochastic Adams.
+
+The state-conditioned feature geometry and solver topology are separate runtime concepts. Stochastic SEEDS uses a shared residual history across its interleaved model-call coordinates while retaining explicit stage identity for the exact-stage mask; SA PEC uses one residual history plus the sampler-required exact-step mask above. Sequential SA and SEEDS runs tear those histories and masks down independently so one sampler cannot inherit another sampler's state.
+
+Active PECE (`corrector_order > 0`) remains fail-closed to untouched native execution. From the second outer interval onward it performs a callback-invisible corrected-state H3 evaluation at the same sigma as the predictor evaluation but on a different latent, producing `2N - 1` true H3 evaluations. That requires an explicit predictor/corrector stage identity rather than the single-coordinate runtime contract used by PEC.
+
+Supported tau configuration is `tau_func=None` or the exact closure produced by native `get_tau_interval_func`; arbitrary callables fail closed and are never invoked during validation. Custom callable `noise_sampler` values are accepted without inspection or speculative draws. `simple_order_2` changes only the Adams coefficient calculation and does not alter the reviewed call topology.
+
+Offline smoothing replay is intentionally disabled for SA-Solver because replaying changed denoiser values changes the solver's Adams history even if the random stream is reproducible. With the normal Spectrum default `offline_smoothing_replay=true`, reviewed SA-Solver therefore runs one **causal Spectrum pass** rather than bypassing Spectrum.
+
 ### ER-SDE compatibility details
 
 The v0.2.11 path keeps the exact native ER-SDE sampler implementation and RNG stream. Spectrum tracks the native stochastic increment only to maintain state ownership and replay compatibility; it does not disable or rescale ER-SDE noise.
@@ -239,7 +327,7 @@ ComfyUI-TiledDiffusion's current `KSAMPLER.sample(*args, **kwargs)` passthrough 
 
 Warmup and tail constraints are always actual. Reviewed samplers also limit the causal forecast horizon and require actual refreshes.
 
-For ordinary one-lane samplers, the default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins. Stochastic SEEDS deliberately suppresses that bootstrap; its exact outer stages instead provide fresh anchors to the shared state-conditioned residual history.
+For ordinary one-lane samplers, the default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins. State-conditioned stochastic samplers deliberately suppress that bootstrap. Stochastic SEEDS uses its exact outer stages as fresh anchors for the shared residual history; SA-Solver uses its sampler-specific stochastic interval and Adams-memory safeguards described above.
 
 Typical 20-step Euler/ER-SDE single-pass cadence is approximately:
 

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -142,9 +142,9 @@ def _apply_exact_state_input_embedding_(
 ) -> torch.Tensor:
     """Add/subtract H3's exact target input embedding without running transformer blocks."""
     if target.ndim != 3 or target.shape[0] != 1:
-        raise ValueError("state-residual target must be a batch-one [1, rows, hidden] tensor")
+        raise ValueError("state-conditioned residual target must be a batch-one [1, rows, hidden] tensor")
     if target.shape[-1] != int(inner.hidden_size):
-        raise ValueError("state-residual target hidden width does not match native H3")
+        raise ValueError("state-conditioned residual target hidden width does not match native H3")
 
     module = _native_module(inner)
     common_dit = importlib.import_module("comfy.ldm.common_dit")
@@ -161,7 +161,7 @@ def _apply_exact_state_input_embedding_(
     total_rows = int(audio_rows.shape[0] + video_rows.shape[0])
     if compact.shape[0] != total_rows:
         raise ValueError(
-            "state-residual target rows do not match native H3 audio/video input rows"
+            "state-conditioned residual target rows do not match native H3 audio/video input rows"
         )
 
     element_size = torch.empty((), dtype=compact.dtype).element_size()
@@ -434,14 +434,14 @@ def _execute_actual(
     actual_target = None
     state_input_target = None
 
-    if runtime.active_state_residual_mode and first_index != last_index:
+    if runtime.active_state_conditioned_residual and first_index != last_index:
         def capture_state_input(args, replacement_context):
             nonlocal state_input_target
             hidden = args.get("img")
             (aa, _), (_, vb) = target_segments(layout)
             if not torch.is_tensor(hidden) or hidden.ndim != 2 or hidden.shape[0] < vb:
                 raise RuntimeError(
-                    "initial MiniMax H3 hidden feature is incompatible with state-residual forecasting"
+                    "initial MiniMax H3 hidden feature is incompatible with state-conditioned residual forecasting"
                 )
             state_input_target = hidden[aa:vb].detach().clone(
                 memory_format=torch.contiguous_format
@@ -468,7 +468,7 @@ def _execute_actual(
         # second full target tensor on the GPU before the required CPU archive.
         target = hidden[aa:vb].unsqueeze(0)
         actual_target = target
-        if runtime.active_state_residual_mode:
+        if runtime.active_state_conditioned_residual:
             try:
                 if state_input_target is None:
                     # This only applies to an unexpected one-block native contract.
@@ -502,7 +502,7 @@ def _execute_actual(
                 runtime.fallback_current_step(
                     run_id,
                     step_id,
-                    f"SEEDS state-residual actual transform failed: {exc}",
+                    f"state-conditioned residual actual transform failed: {exc}",
                 )
                 runtime.observe_actual(run_id, step_id, call_id, target)
         else:
@@ -775,7 +775,7 @@ def diffusion_model_wrapper(
             kwargs,
         )
 
-    if runtime.active_state_residual_mode:
+    if runtime.active_state_conditioned_residual:
         try:
             _apply_exact_state_input_embedding_(
                 predicted,
@@ -790,7 +790,7 @@ def diffusion_model_wrapper(
             runtime.fallback_current_step(
                 int(run_id),
                 int(step_id),
-                f"SEEDS state-residual forecast reconstruction failed: {exc}",
+                f"state-conditioned residual forecast reconstruction failed: {exc}",
             )
             return _execute_actual(
                 executor,
@@ -855,7 +855,7 @@ def diffusion_model_wrapper(
             run_id,
             step_id,
             runtime.active_stage_index,
-            "state_residual" if runtime.active_state_residual_mode else "absolute_hidden",
+            "state_conditioned_residual" if runtime.active_state_conditioned_residual else "absolute_hidden",
             runtime.last_prediction_chunk_count,
             runtime.prediction_history_length,
         )

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -230,9 +230,11 @@ class _RunState:
     total_steps: int
     policy_steps: int
     stage_count: int
-    stochastic_multistage: bool
+    state_conditioned_residual: bool
     separate_stage_histories: bool
     forecastable_stage_indices: tuple[int, ...] | None
+    forced_actual_step_ids: frozenset[int]
+    forced_actual_steps_advance_window: bool
     model_aware_can_force_actual: bool
     sigma_min: float
     sigma_max: float
@@ -331,12 +333,26 @@ class SpectrumH3Runtime:
         return 0 if self._step is None else self._step.stage_index
 
     @property
-    def active_state_residual_mode(self) -> bool:
+    def active_state_conditioned_residual(self) -> bool:
         return bool(self._step is not None and self._step.state_residual_mode)
 
     @property
+    def active_state_residual_mode(self) -> bool:
+        """Backward-compatible alias for the generalized state-conditioned geometry."""
+        return self.active_state_conditioned_residual
+
+    @property
+    def state_conditioned_residual(self) -> bool:
+        return bool(self._run is not None and self._run.state_conditioned_residual)
+
+    @property
     def stochastic_multistage(self) -> bool:
-        return bool(self._run is not None and self._run.stochastic_multistage)
+        """Compatibility view used by SEEDS-specific diagnostics/tests."""
+        return bool(
+            self._run is not None
+            and self._run.state_conditioned_residual
+            and self._run.stage_count > 1
+        )
 
     @property
     def supported_sampler(self) -> bool:
@@ -686,9 +702,12 @@ class SpectrumH3Runtime:
         min_actual_prefix_steps: int = 0,
         expected_model_calls: int | None = None,
         stage_count: int = 1,
-        stochastic_multistage: bool = False,
+        state_conditioned_residual: bool = False,
+        stochastic_multistage: bool | None = None,
         separate_stage_histories: bool | None = None,
         forecastable_stage_indices: tuple[int, ...] | None = None,
+        forced_actual_step_ids: tuple[int, ...] | None = None,
+        forced_actual_steps_advance_window: bool = False,
         model_aware_can_force_actual: bool = True,
     ) -> int:
         if self._run is not None:
@@ -708,20 +727,31 @@ class SpectrumH3Runtime:
                 raise ValueError(f"{name} must be an integer >= 0")
         if isinstance(stage_count, bool) or not isinstance(stage_count, int) or stage_count < 1:
             raise ValueError("stage_count must be an integer >= 1")
-        if stochastic_multistage and stage_count < 2:
-            raise ValueError("stochastic_multistage requires stage_count >= 2")
+        if type(state_conditioned_residual) is not bool:
+            raise ValueError("state_conditioned_residual must be boolean")
+        if type(forced_actual_steps_advance_window) is not bool:
+            raise ValueError("forced_actual_steps_advance_window must be boolean")
         if type(model_aware_can_force_actual) is not bool:
             raise ValueError("model_aware_can_force_actual must be boolean")
+        if stochastic_multistage is not None:
+            if type(stochastic_multistage) is not bool:
+                raise ValueError("stochastic_multistage must be boolean or None")
+            if stochastic_multistage:
+                if stage_count < 2:
+                    raise ValueError("stochastic_multistage requires stage_count >= 2")
+                state_conditioned_residual = True
         if separate_stage_histories is not None and type(separate_stage_histories) is not bool:
             raise ValueError("separate_stage_histories must be boolean or None")
         resolved_stage_histories = (
-            bool(stochastic_multistage)
+            bool(state_conditioned_residual and stage_count > 1)
             if separate_stage_histories is None
             else bool(separate_stage_histories)
         )
-        if resolved_stage_histories and not stochastic_multistage:
+        if resolved_stage_histories and (
+            not state_conditioned_residual or stage_count < 2
+        ):
             raise ValueError(
-                "separate_stage_histories requires stochastic_multistage"
+                "separate_stage_histories requires multistage state-conditioned residual mode"
             )
         if forecastable_stage_indices is not None:
             normalized_forecastable_stages = tuple(forecastable_stage_indices)
@@ -740,6 +770,21 @@ class SpectrumH3Runtime:
                 )
         else:
             normalized_forecastable_stages = None
+        if forced_actual_step_ids is not None:
+            normalized_forced_actual_steps = tuple(forced_actual_step_ids)
+            if len(set(normalized_forced_actual_steps)) != len(normalized_forced_actual_steps):
+                raise ValueError("forced_actual_step_ids must not contain duplicates")
+            if any(
+                isinstance(index, bool)
+                or not isinstance(index, int)
+                or index < 0
+                for index in normalized_forced_actual_steps
+            ):
+                raise ValueError(
+                    "forced_actual_step_ids entries must be nonnegative integer step indices"
+                )
+        else:
+            normalized_forced_actual_steps = ()
         sigma_values = _as_cpu_float64_vector(sigmas)
         schedule_steps = max(0, sigma_values.numel() - 1)
         if expected_model_calls is not None:
@@ -754,6 +799,10 @@ class SpectrumH3Runtime:
             total_steps = expected_model_calls
         else:
             total_steps = schedule_steps
+        if any(index >= total_steps for index in normalized_forced_actual_steps):
+            raise ValueError(
+                "forced_actual_step_ids entries must be smaller than total model-call count"
+            )
         evaluated = sigma_values[:-1]
         finite_schedule = bool(evaluated.numel()) and bool(torch.isfinite(evaluated).all().item())
         sigma_min = float(evaluated.min().item()) if finite_schedule else 0.0
@@ -770,9 +819,11 @@ class SpectrumH3Runtime:
             total_steps=total_steps,
             policy_steps=schedule_steps,
             stage_count=stage_count,
-            stochastic_multistage=bool(stochastic_multistage),
+            state_conditioned_residual=bool(state_conditioned_residual),
             separate_stage_histories=resolved_stage_histories,
             forecastable_stage_indices=normalized_forecastable_stages,
+            forced_actual_step_ids=frozenset(normalized_forced_actual_steps),
+            forced_actual_steps_advance_window=forced_actual_steps_advance_window,
             model_aware_can_force_actual=model_aware_can_force_actual,
             sigma_min=sigma_min,
             sigma_max=sigma_max,
@@ -782,7 +833,9 @@ class SpectrumH3Runtime:
             min_tail_actual_steps=min_tail_actual_steps,
             min_actual_prefix_steps=min(
                 min_actual_prefix_steps,
-                schedule_steps if stochastic_multistage else total_steps,
+                schedule_steps
+                if state_conditioned_residual and stage_count > 1
+                else total_steps,
             ),
         )
         self._step = None
@@ -1020,10 +1073,11 @@ class SpectrumH3Runtime:
         if step_id >= self._run.total_steps:
             raise RuntimeError("predict_noise call count exceeded the supplied sigma schedule")
         coordinate = self.coordinate_for_timestep(timestep)
+        use_multistage_topology = (
+            self._run.state_conditioned_residual and self._run.stage_count > 1
+        )
         stage_index = (
-            step_id % self._run.stage_count
-            if self._run.stochastic_multistage
-            else 0
+            step_id % self._run.stage_count if use_multistage_topology else 0
         )
         if self._run.separate_stage_histories:
             self.forecaster = self._stage_forecasters[stage_index]
@@ -1049,7 +1103,7 @@ class SpectrumH3Runtime:
                 mode="replay",
                 reason="offline smoothing replay",
                 stage_index=stage_index,
-                state_residual_mode=self._run.stochastic_multistage,
+                state_residual_mode=self._run.state_conditioned_residual,
             )
             self._run.next_step_id += 1
             return {
@@ -1060,15 +1114,14 @@ class SpectrumH3Runtime:
                 "reason": "offline smoothing replay",
             }
 
+        use_multistage_topology = (
+            self._run.state_conditioned_residual and self._run.stage_count > 1
+        )
         policy_step_id = (
-            step_id // self._run.stage_count
-            if self._run.stochastic_multistage
-            else step_id
+            step_id // self._run.stage_count if use_multistage_topology else step_id
         )
         policy_total_steps = (
-            self._run.policy_steps
-            if self._run.stochastic_multistage
-            else self._run.total_steps
+            self._run.policy_steps if use_multistage_topology else self._run.total_steps
         )
         effective_tail = max(self.config.tail_actual_steps, self._run.min_tail_actual_steps)
         tail_start = max(0, policy_total_steps - effective_tail)
@@ -1095,6 +1148,9 @@ class SpectrumH3Runtime:
             actual, reason = True, "warmup"
         elif policy_step_id >= tail_start:
             actual, reason = True, "final actual tail"
+        elif step_id in self._run.forced_actual_step_ids:
+            actual, reason = True, "sampler-required exact step"
+            advances_window = self._run.forced_actual_steps_advance_window
         elif (
             self._run.forecastable_stage_indices is not None
             and stage_index not in self._run.forecastable_stage_indices
@@ -1107,7 +1163,7 @@ class SpectrumH3Runtime:
             actual, reason = True, "post-forecast stage-lane refresh"
         elif (
             self.config.bootstrap_first_forecast
-            and not self._run.stochastic_multistage
+            and not self._run.state_conditioned_residual
             and self.config.degree == 1
             and policy_step_id == 1
             and self.forecaster.history_length == 1
@@ -1199,7 +1255,7 @@ class SpectrumH3Runtime:
             mode="actual" if actual else "forecast",
             reason=reason,
             stage_index=stage_index,
-            state_residual_mode=self._run.stochastic_multistage,
+            state_residual_mode=self._run.state_conditioned_residual,
             bootstrap_forecast=bootstrap_forecast,
             rollback_replay=rollback_replay,
             consumes_feedback_refresh=consumes_feedback_refresh,
@@ -2487,7 +2543,7 @@ class SpectrumH3Runtime:
                 and not self._disabled
                 and (
                     step.step_id // self._run.stage_count
-                    if self._run.stochastic_multistage
+                    if self._run.state_conditioned_residual and self._run.stage_count > 1
                     else step.step_id
                 ) >= self.config.warmup_steps
             ):
@@ -2704,6 +2760,17 @@ class SpectrumH3Runtime:
     def end_rollback_replay(self) -> None:
         self._rollback_replay_active = False
 
+    def _feature_geometry_name(self) -> str:
+        if self._run is None or not self._run.state_conditioned_residual:
+            return "absolute_hidden"
+        if self._run.stage_count > 1:
+            return (
+                "state_conditioned_residual_stage_lanes"
+                if self._run.separate_stage_histories
+                else "state_conditioned_residual_shared_history"
+            )
+        return "state_conditioned_residual"
+
     def debug_summary(self) -> str:
         offline_archive_device = (
             self._offline_archive.history_device
@@ -2812,10 +2879,11 @@ class SpectrumH3Runtime:
             f"run_id={self.stats.run_id} sampler={self.stats.sampler_name} "
             f"steps={self.stats.total_steps} "
             f"stage_count={self._run.stage_count if self._run is not None else 1} "
-            f"stochastic_multistage={self._run.stochastic_multistage if self._run is not None else False} "
+            f"state_conditioned_residual={self._run.state_conditioned_residual if self._run is not None else False} "
             f"stage_histories={'separate' if self._run is not None and self._run.separate_stage_histories else 'shared'} "
-            f"feature_geometry={('state_residual_stage_lanes' if self._run.separate_stage_histories else 'state_residual_shared_history') if self._run is not None and self._run.stochastic_multistage else 'absolute_hidden'} "
+            f"feature_geometry={self._feature_geometry_name()} "
             f"forecastable_stages={self._run.forecastable_stage_indices if self._run is not None else None} "
+            f"forced_actual_steps={len(self._run.forced_actual_step_ids) if self._run is not None else 0} "
             f"stage_refresh_pending={sum(self._stage_required_actual_refreshes.values())} "
             f"actual_steps={self.stats.actual_steps} "
             f"forecast_steps={self.stats.forecast_steps} "

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -57,7 +57,8 @@ SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset(
 )
 
 SEEDS_SAMPLERS = frozenset({"sample_seeds_2", "sample_seeds_3"})
-SUPPORTED_SAMPLERS = SUPPORTED_SINGLE_CALL_SAMPLERS | SEEDS_SAMPLERS
+SA_SOLVER_SAMPLERS = frozenset({"sample_sa_solver", "sample_sa_solver_pece"})
+SUPPORTED_SAMPLERS = SUPPORTED_SINGLE_CALL_SAMPLERS | SEEDS_SAMPLERS | SA_SOLVER_SAMPLERS
 SEEDS_STAGE_COUNTS = {"sample_seeds_2": 2, "sample_seeds_3": 3}
 SEEDS_NATIVE_FUNCTION_DIGESTS = {
     "sample_seeds_2": "e7bcf519718453f77e7ade9b71678c1b593472c8e9b0af142f64f97a9267f383",
@@ -66,6 +67,41 @@ SEEDS_NATIVE_FUNCTION_DIGESTS = {
 SEEDS_TRACKED_OPTIONS = {
     "sample_seeds_2": frozenset({"eta", "s_noise", "noise_sampler", "r", "solver_type"}),
     "sample_seeds_3": frozenset({"eta", "s_noise", "noise_sampler", "r_1", "r_2"}),
+}
+
+
+SA_SOLVER_NATIVE_FUNCTION_DIGESTS = {
+    "sample_sa_solver": "37bd2f94f27426b9e3e6f0cc2a0f439c95d3fec927339e0a7cc2c64e731647a4",
+    "sample_sa_solver_pece": "6ce4b3d604ef789d69a8abf832cf93637646e387039e494e37bf9ed35e9b23a0",
+}
+SA_SOLVER_HELPER_DIGESTS = {
+    "compute_exponential_coeffs": "d1bcd6cfa194ceec7a4e497c205ba59dfb3824d2816a5e159df67b57845ce72e",
+    "compute_simple_stochastic_adams_b_coeffs": "46d46ac17ec32e6c0a047d0f45d9e0e3734efb9fbf64b2fb984aa9311354c4c6",
+    "compute_stochastic_adams_b_coeffs": "f2480f0fc36f70f48909779e9604fa9dcb4e2a475b0040fd83c6e9e01f65e6e2",
+    "get_tau_interval_func": "f301a5d271a219a7f8b709e264327477945ddb7b2cadd40d700392c987afb3bb",
+}
+SA_SOLVER_TRACKED_OPTIONS = {
+    "sample_sa_solver": frozenset(
+        {
+            "tau_func",
+            "s_noise",
+            "noise_sampler",
+            "predictor_order",
+            "corrector_order",
+            "use_pece",
+            "simple_order_2",
+        }
+    ),
+    "sample_sa_solver_pece": frozenset(
+        {
+            "tau_func",
+            "s_noise",
+            "noise_sampler",
+            "predictor_order",
+            "corrector_order",
+            "simple_order_2",
+        }
+    ),
 }
 
 RES_MULTISTEP_SAMPLERS = frozenset(
@@ -175,6 +211,310 @@ def _seeds_stage_schedule_reason(sigmas: Any) -> str | None:
         return "SEEDS sigma schedule ends at a negative sigma"
     if bool((values[1:] >= values[:-1]).any().item()):
         return "SEEDS sigma schedule is not strictly descending"
+    return None
+
+
+def _sa_solver_expected_model_calls(sampler: Any, sigmas: Any) -> int | None:
+    """Count native SA-Solver denoiser calls, including active PECE evaluations."""
+    name = sampler_name(sampler)
+    if name not in SA_SOLVER_SAMPLERS:
+        return None
+    if not torch.is_tensor(sigmas) or sigmas.ndim != 1:
+        return None
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return None
+    corrector_order = options.get("corrector_order", 4)
+    if type(corrector_order) is not int or corrector_order < 0:
+        return None
+    use_pece = name == "sample_sa_solver_pece" or options.get("use_pece", False) is True
+    outer_steps = max(0, int(sigmas.numel()) - 1)
+    if not use_pece or corrector_order == 0 or outer_steps == 0:
+        return outer_steps
+    return 2 * outer_steps - 1
+
+
+def _sa_solver_prefix_model_calls(
+    sampler: Any,
+    sigmas: Any,
+    outer_prefix: int,
+) -> int | None:
+    """Translate Continuum's outer-step prefix into native SA model-call space."""
+    if not torch.is_tensor(sigmas) or sigmas.ndim != 1:
+        return None
+    outer_steps = max(0, int(sigmas.numel()) - 1)
+    prefix_steps = min(max(0, int(outer_prefix)), outer_steps)
+    if prefix_steps == 0:
+        return 0
+    return _sa_solver_expected_model_calls(sampler, sigmas[: prefix_steps + 1])
+
+
+def _sa_solver_tau_values(tau_func: Any) -> dict[str, float] | None:
+    """Return reviewed native tau closure values without executing the callback."""
+    if tau_func is None:
+        return None
+
+    try:
+        import comfy.k_diffusion.sa_solver as native_sa_solver
+    except ImportError:
+        return None
+
+    if getattr(tau_func, "__module__", None) != "comfy.k_diffusion.sa_solver":
+        return None
+    if getattr(tau_func, "__qualname__", None) != (
+        "get_tau_interval_func.<locals>.tau_func"
+    ):
+        return None
+    code = getattr(tau_func, "__code__", None)
+    if code is None or tuple(code.co_freevars) != (
+        "end_sigma",
+        "eta",
+        "start_sigma",
+    ):
+        return None
+    if getattr(tau_func, "__globals__", None) is not vars(native_sa_solver):
+        return None
+    outer_code = getattr(native_sa_solver.get_tau_interval_func, "__code__", None)
+    if outer_code is None or code not in outer_code.co_consts:
+        return None
+    closure = getattr(tau_func, "__closure__", None) or ()
+    if len(closure) != 3:
+        return None
+
+    values: dict[str, float] = {}
+    for name, cell in zip(code.co_freevars, closure, strict=True):
+        try:
+            value = cell.cell_contents
+        except ValueError:
+            return None
+        if type(value) not in (int, float):
+            return None
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            return None
+        values[name] = numeric
+    return values
+
+
+def _sa_solver_tau_func_is_reviewed(tau_func: Any) -> bool:
+    if tau_func is None:
+        return True
+    values = _sa_solver_tau_values(tau_func)
+    return values is not None and values["eta"] >= 0.0
+
+
+def _sa_solver_is_stochastic(sampler: Any) -> bool:
+    """Conservatively detect whether native SA may inject noise during this run."""
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return True
+    s_noise = options.get("s_noise", 1.0)
+    if type(s_noise) not in (int, float) or not math.isfinite(float(s_noise)):
+        return True
+    if float(s_noise) <= 0.0:
+        return False
+    tau_func = options.get("tau_func")
+    if tau_func is None:
+        return True
+    values = _sa_solver_tau_values(tau_func)
+    if values is None:
+        return True
+    return values["eta"] > 0.0
+
+
+def _sa_solver_stochastic_protection(
+    sampler: Any,
+    sigmas: Any,
+    model_sampling: Any,
+) -> tuple[tuple[int, ...] | None, tuple[int, ...] | None, str | None]:
+    """Resolve native SA stochastic-input steps for telemetry and fail-closed review.
+
+    Spectrum's SA adapter no longer blanket-forces these calls actual. The
+    previous policy attacked the symptom by removing most usable forecasts.
+    Instead the solver-aware adapter prevents a forecasted denoiser from entering
+    persistent Adams history: a forecast is an ephemeral predictor input for its
+    current interval only, while exact H3 evaluations are the only values kept as
+    multistep history. Fresh stochastic x_pred states can therefore be forecast
+    without recursively poisoning later Adams stencils.
+    """
+    if not torch.is_tensor(sigmas) or sigmas.ndim != 1 or sigmas.numel() < 2:
+        return None, None, "SA-Solver sigma schedule is not a one-dimensional tensor"
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return None, None, "SA-Solver sampler options are not a dictionary"
+
+    try:
+        configured_s_noise = float(options.get("s_noise", 1.0))
+        noise_scale = float(getattr(model_sampling, "noise_scale", 1.0))
+        effective_s_noise = configured_s_noise * noise_scale
+    except (TypeError, ValueError):
+        return None, None, "SA-Solver effective s_noise is not numeric"
+    if not math.isfinite(effective_s_noise) or effective_s_noise < 0.0:
+        return None, None, "SA-Solver effective s_noise is not finite and nonnegative"
+    if effective_s_noise == 0.0:
+        return (), (), None
+
+    tau_func = options.get("tau_func")
+    if tau_func is None:
+        try:
+            start_sigma = float(model_sampling.percent_to_sigma(0.2))
+            end_sigma = float(model_sampling.percent_to_sigma(0.8))
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            return None, None, f"SA-Solver default tau interval is unavailable: {exc}"
+        eta = 1.0
+    else:
+        values = _sa_solver_tau_values(tau_func)
+        if values is None:
+            return None, None, "SA-Solver tau interval provenance is unavailable"
+        start_sigma = values["start_sigma"]
+        end_sigma = values["end_sigma"]
+        eta = values["eta"]
+
+    if not all(math.isfinite(value) for value in (start_sigma, end_sigma, eta)):
+        return None, None, "SA-Solver tau interval contains nonfinite values"
+    if eta <= 0.0:
+        return (), (), None
+
+    sigma_values = sigmas.detach().reshape(-1).to(device="cpu", dtype=torch.float64)
+    if not bool(torch.isfinite(sigma_values).all().item()):
+        return None, None, "SA-Solver sigma schedule contains nonfinite values"
+    outer_steps = max(0, int(sigma_values.numel()) - 1)
+    stochastic_input_steps = tuple(
+        step_id
+        for step_id in range(1, outer_steps)
+        if start_sigma >= float(sigma_values[step_id].item()) >= end_sigma
+    )
+    if not stochastic_input_steps:
+        return (), (), None
+
+    return (), stochastic_input_steps, None
+
+
+def _sa_solver_option_contract(name: str, options: Any) -> str | None:
+    """Validate the native SA option surface without executing user callbacks."""
+    if name not in SA_SOLVER_SAMPLERS:
+        return f"{name!r} is not a reviewed SA-Solver sampler"
+    if not isinstance(options, dict):
+        return "SA-Solver sampler options are not a dictionary"
+
+    unknown = set(options) - SA_SOLVER_TRACKED_OPTIONS[name]
+    if unknown:
+        return f"SA-Solver sampler has unreviewed options: {sorted(unknown)}"
+
+    s_noise = options.get("s_noise", 1.0)
+    if type(s_noise) not in (int, float) or not math.isfinite(float(s_noise)):
+        return "SA-Solver s_noise must be a finite numeric value"
+    if float(s_noise) < 0.0:
+        return "SA-Solver s_noise must be nonnegative"
+
+    for option_name, default, minimum in (
+        ("predictor_order", 3, 1),
+        ("corrector_order", 4, 0),
+    ):
+        value = options.get(option_name, default)
+        if type(value) is not int or not minimum <= value <= 6:
+            return f"SA-Solver {option_name} must be an integer in [{minimum}, 6]"
+
+    if type(options.get("simple_order_2", False)) is not bool:
+        return "SA-Solver simple_order_2 must be boolean"
+
+    use_pece = name == "sample_sa_solver_pece"
+    if name == "sample_sa_solver":
+        configured_use_pece = options.get("use_pece", False)
+        if type(configured_use_pece) is not bool:
+            return "SA-Solver use_pece must be boolean"
+        use_pece = configured_use_pece
+    if use_pece and options.get("corrector_order", 4) > 0:
+        return (
+            "SA-Solver PECE with an active corrector has duplicate-sigma "
+            "predicted/corrected states and is not reviewed for Spectrum forecasting"
+        )
+
+    noise_sampler = options.get("noise_sampler")
+    if noise_sampler is not None and not callable(noise_sampler):
+        return "SA-Solver noise_sampler must be callable or None"
+    if not _sa_solver_tau_func_is_reviewed(options.get("tau_func")):
+        return (
+            "SA-Solver tau_func must be None or the reviewed native "
+            "get_tau_interval_func closure"
+        )
+    return None
+
+
+def _sa_solver_sampler_contract(sampler: Any) -> tuple[bool, str | None]:
+    """Validate native SA-Solver topology, solver helpers, and adapter ownership."""
+    import comfy.k_diffusion.sa_solver as native_sa_solver
+    import comfy.k_diffusion.sampling as native_sampling
+    import comfy.samplers
+
+    name = sampler_name(sampler)
+    if name not in SA_SOLVER_SAMPLERS:
+        return False, f"{name!r} is not a reviewed SA-Solver sampler"
+
+    function = getattr(sampler, "sampler_function", None)
+    if function is not getattr(native_sampling, name, None):
+        return False, f"sampler function is not native ComfyUI {name}"
+    if function_ast_digest(function) != SA_SOLVER_NATIVE_FUNCTION_DIGESTS[name]:
+        return False, f"native {name} implementation is not a reviewed revision"
+    if (
+        function_ast_digest(native_sampling.sample_sa_solver)
+        != SA_SOLVER_NATIVE_FUNCTION_DIGESTS["sample_sa_solver"]
+    ):
+        return False, "native sample_sa_solver core is not a reviewed revision"
+    for helper_name, expected_digest in SA_SOLVER_HELPER_DIGESTS.items():
+        helper = getattr(native_sa_solver, helper_name, None)
+        if function_ast_digest(helper) != expected_digest:
+            return False, f"native SA-Solver helper {helper_name} is unreviewed"
+    if (
+        function_ast_digest(native_sampling.default_noise_sampler)
+        != ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST
+    ):
+        return False, "native default_noise_sampler implementation is not reviewed"
+
+    if type(sampler) is not comfy.samplers.KSAMPLER:
+        return False, "SA-Solver sampler object is not native ComfyUI KSAMPLER"
+    if (
+        comfy.samplers.KSAMPLER.__module__ != "comfy.samplers"
+        or comfy.samplers.KSAMPLER.__name__ != "KSAMPLER"
+    ):
+        return False, "native ComfyUI KSAMPLER class provenance is unreviewed"
+    if (
+        comfy.samplers.KSamplerX0Inpaint.__module__ != "comfy.samplers"
+        or comfy.samplers.KSamplerX0Inpaint.__name__ != "KSamplerX0Inpaint"
+    ):
+        return False, "native KSamplerX0Inpaint adapter provenance is unreviewed"
+    sample_contract = _ksampler_sample_contract(sampler)
+    if not sample_contract.accepted:
+        return False, (
+            f"KSAMPLER.sample contract rejected: {sample_contract.failure}; "
+            f"{sample_contract.provenance.log_fields()}"
+        )
+
+    options = getattr(sampler, "extra_options", {}) or {}
+    option_reason = _sa_solver_option_contract(name, options)
+    if option_reason is not None:
+        return False, option_reason
+    return True, None
+
+
+def _native_sa_solver_preflight_reason(
+    sampler: Any,
+    model_options: dict[str, Any] | None,
+) -> str | None:
+    """Resolve reviewed SA failures before Spectrum retains any run state."""
+    supported, reason = _sa_solver_sampler_contract(sampler)
+    if not supported:
+        return reason or "native SA-Solver contract is unproven"
+
+    import comfy.patcher_extension
+
+    wrappers = comfy.patcher_extension.get_all_wrappers(
+        comfy.patcher_extension.WrappersMP.SAMPLER_SAMPLE,
+        model_options or {},
+        is_model_options=True,
+    )
+    if len(wrappers) != 1 or wrappers[0] is not sampler_sample_wrapper:
+        return "another SAMPLER_SAMPLE wrapper makes SA-Solver ordering unproven"
     return None
 
 
@@ -348,6 +688,10 @@ def sampler_supports_seeded_replay(sampler: Any) -> bool:
         return False
 
     name = sampler_name(sampler)
+    if name in SA_SOLVER_SAMPLERS:
+        # SA-Solver is a multistep method: replaying altered denoiser values
+        # changes its Adams history even when the RNG itself is reproducible.
+        return False
     if name in SEEDS_SAMPLERS:
         options = getattr(sampler, "extra_options", {}) or {}
         if _seeds_option_contract(name, options) is not None:
@@ -408,6 +752,490 @@ def _copy_ksampler_with_options(
     except Exception as exc:  # noqa: BLE001 - fail closed on custom runtime state
         return None, f"KSAMPLER copied-state validation failed: {type(exc).__name__}: {exc}"
     return copied, None
+
+
+def _sa_predict_causal_denoised(
+    actual_preds: list[torch.Tensor],
+    actual_lambdas: list[torch.Tensor],
+    actual_steps: list[int],
+    *,
+    target_lambda: torch.Tensor,
+    target_step: int,
+    continuum_active: bool = False,
+) -> tuple[torch.Tensor, str, tuple[int, ...], torch.Tensor]:
+    """Predict SA's denoised variable directly from exact actual anchors.
+
+    Fresh SA predictor noise changes the model input in a direction that cannot be
+    reconstructed exactly when the H3 transformer is skipped. During an active
+    stochastic interval, do not feed the hidden-feature forecast into SA's Adams
+    equations. Instead extrapolate the solver-space denoised trajectory from exact
+    H3 anchors only. The extrapolation is causal and bounded to one previous
+    anchor interval; any untrusted geometry degenerates to a latest-actual hold.
+    """
+    if not (
+        len(actual_preds) == len(actual_lambdas) == len(actual_steps)
+        and actual_preds
+    ):
+        raise RuntimeError(
+            "stochastic SA dense output requires aligned non-empty actual anchors"
+        )
+
+    latest_value = actual_preds[-1]
+    latest_lambda = actual_lambdas[-1]
+    latest_step = int(actual_steps[-1])
+    if latest_step >= int(target_step):
+        raise RuntimeError(
+            "stochastic SA dense-output anchor is not strictly earlier than target"
+        )
+    if int(target_step) != latest_step + 1:
+        raise RuntimeError(
+            "stochastic SA dense output requires the latest actual anchor immediately "
+            f"before the forecast (anchor={latest_step}, forecast={target_step})"
+        )
+
+    zero = target_lambda.new_zeros(())
+    if continuum_active:
+        return (
+            latest_value.clone(memory_format=torch.contiguous_format),
+            "latest_actual_hold_continuum",
+            (latest_step,),
+            zero,
+        )
+    if len(actual_preds) == 1:
+        return (
+            latest_value.clone(memory_format=torch.contiguous_format),
+            "latest_actual_hold",
+            (latest_step,),
+            zero,
+        )
+
+    previous_value = actual_preds[-2]
+    previous_lambda = actual_lambdas[-2]
+    previous_step = int(actual_steps[-2])
+    if (
+        previous_value.shape != latest_value.shape
+        or previous_value.device != latest_value.device
+        or previous_value.dtype != latest_value.dtype
+    ):
+        raise RuntimeError("stochastic SA dense-output actual anchors are incompatible")
+
+    # Consecutive exact anchors usually mean warmup, a hard transition, or an
+    # externally forced refresh. There is no crossed forecast interval to justify
+    # a secant extrapolation yet, so hold the newest exact denoised value.
+    if latest_step - previous_step == 1:
+        return (
+            latest_value.clone(memory_format=torch.contiguous_format),
+            "latest_actual_hold_consecutive_anchors",
+            (latest_step,),
+            zero,
+        )
+
+    denominator = latest_lambda - previous_lambda
+    advance = target_lambda - latest_lambda
+    alpha = advance / denominator
+    scale = torch.maximum(
+        torch.maximum(previous_lambda.abs(), latest_lambda.abs()),
+        torch.ones_like(latest_lambda),
+    )
+    valid = (
+        torch.isfinite(alpha)
+        & torch.isfinite(denominator)
+        & (denominator.abs() > 1e-12 * scale)
+        & (denominator * advance >= 0.0)
+        & (alpha >= -1e-6)
+        & (alpha <= 1.0 + 1e-6)
+    )
+    bounded_alpha = alpha.clamp(0.0, 1.0)
+    weight = torch.where(valid, bounded_alpha, torch.zeros_like(bounded_alpha))
+    weight = weight.to(device=latest_value.device, dtype=latest_value.dtype)
+    predicted = torch.lerp(latest_value, previous_value, -weight)
+    return (
+        predicted,
+        "lambda_bounded_extrapolation",
+        (previous_step, latest_step),
+        weight,
+    )
+
+
+def _sample_sa_solver_forecast_isolated(
+    runtime: SpectrumH3Runtime,
+    model: Any,
+    x: torch.Tensor,
+    sigmas: torch.Tensor,
+    *,
+    extra_args: dict[str, Any] | None = None,
+    callback: Any = None,
+    disable: bool = False,
+    tau_func: Any = None,
+    s_noise: float = 1.0,
+    noise_sampler: Any = None,
+    predictor_order: int = 3,
+    corrector_order: int = 4,
+    use_pece: bool = False,
+    simple_order_2: bool = False,
+    continuum_active: bool = False,
+) -> torch.Tensor:
+    """Run reviewed SA equations without persisting forecasted denoisers in Adams history.
+
+    Exact H3 evaluations are retained with their real lambda coordinates.
+    Forecasted denoisers are ephemeral: they participate in the native current-step
+    PEC corrector and predictor, but they are never inserted into persistent
+    multistep history. The next exact evaluation therefore re-anchors both the
+    Spectrum forecaster and the SA Adams stencil instead of recursively consuming
+    old forecasts.
+
+    Stochastic SA owns its predictor noise separately from the denoiser history.
+    The exact H3 model can respond to the random increment already present in
+    x_pred; a skipped transformer cannot reconstruct that response. During active
+    stochastic intervals, a Spectrum feature forecast is therefore used only to
+    complete the runtime transaction; SA itself consumes a bounded causal
+    solver-space denoised prediction built from exact actual anchors.
+
+    Continuum continuation chunks are a stricter regime because part of the H3
+    target is an exact protected prefix while the remaining temporal region is
+    generated. The first Continuum hold experiment removed secant extrapolation
+    only inside SA's stochastic interval, but real media retained the same
+    oscillation/flashing artifact. That run still used raw Spectrum denoisers at
+    the non-stochastic forecast endpoints (steps 2 and 17 in the 19-step default
+    schedule). Continuum therefore uses the newest exact denoised anchor as a
+    zero-order dense output for every forecast coordinate, not only stochastic
+    ones. This completely removes hidden-feature forecast values from the SA
+    numerical trajectory for continuation chunks while preserving the 11/8 NFE
+    budget. Native x_pred, stochastic noise, corrector equations, predictor
+    equations, and RNG draws remain unchanged.
+    """
+    if use_pece and corrector_order > 0:
+        raise RuntimeError("active SA-Solver PECE is not supported by the isolated-history adapter")
+    if len(sigmas) <= 1:
+        return x
+
+    import comfy.k_diffusion.sa_solver as native_sa_solver
+    import comfy.k_diffusion.sampling as native_sampling
+    from tqdm.auto import trange
+
+    extra_args = {} if extra_args is None else extra_args
+    seed = extra_args.get("seed", None)
+    noise_sampler = (
+        native_sampling.default_noise_sampler(x, seed=seed)
+        if noise_sampler is None
+        else noise_sampler
+    )
+    s_in = x.new_ones([x.shape[0]])
+
+    model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
+    s_noise = s_noise * getattr(model_sampling, "noise_scale", 1.0)
+    sigmas = native_sampling.offset_first_sigma_for_snr(sigmas, model_sampling)
+    lambdas = native_sampling.sigma_to_half_log_snr(
+        sigmas,
+        model_sampling=model_sampling,
+    )
+
+    if tau_func is None:
+        start_sigma = model_sampling.percent_to_sigma(0.2)
+        end_sigma = model_sampling.percent_to_sigma(0.8)
+        tau_func = native_sa_solver.get_tau_interval_func(
+            start_sigma,
+            end_sigma,
+            eta=1.0,
+        )
+
+    max_used_order = max(predictor_order, corrector_order)
+    x_pred = x
+    h = 0.0
+    tau_t = 0.0
+    noise = 0.0
+    actual_preds: list[torch.Tensor] = []
+    actual_lambdas: list[torch.Tensor] = []
+    actual_steps: list[int] = []
+    lower_order_to_end = sigmas[-1].item() == 0
+
+    for i in trange(len(sigmas) - 1, disable=disable):
+        raw_denoised = model(
+            x_pred,
+            sigmas[i] * s_in,
+            **extra_args,
+        )
+
+        mode = runtime.last_completed_mode
+        if mode not in {"actual", "forecast"}:
+            raise RuntimeError(
+                "Spectrum SA adapter could not determine whether the H3 evaluation "
+                f"at outer step {i} was actual or forecast"
+            )
+        actual = mode == "actual"
+        denoised = raw_denoised
+        solver_space_forecast = bool(
+            not actual
+            and (
+                continuum_active
+                or (tau_t > 0 and s_noise > 0)
+            )
+        )
+        if solver_space_forecast:
+            denoised, dense_mode, anchor_steps, dense_alpha = _sa_predict_causal_denoised(
+                actual_preds,
+                actual_lambdas,
+                actual_steps,
+                target_lambda=lambdas[i],
+                target_step=i,
+                continuum_active=continuum_active,
+            )
+            if runtime.config.debug:
+                alpha_value = float(dense_alpha.detach().to(device="cpu").item())
+                LOG.warning(
+                    "Spectrum H3 SA dense output step=%s scope=%s mode=%s "
+                    "anchor_steps=%s alpha=%.8f raw_feature_forecast=ignored "
+                    "solver_history=actual_only",
+                    i,
+                    "continuum_all_forecasts" if continuum_active else "stochastic",
+                    dense_mode,
+                    anchor_steps,
+                    alpha_value,
+                )
+
+        if callback is not None:
+            callback(
+                {
+                    "x": x_pred,
+                    "i": i,
+                    "sigma": sigmas[i],
+                    "sigma_hat": sigmas[i],
+                    "denoised": denoised,
+                }
+            )
+
+        if actual:
+            actual_preds.append(denoised)
+            actual_lambdas.append(lambdas[i])
+            actual_steps.append(i)
+            if len(actual_preds) > max_used_order:
+                actual_preds = actual_preds[-max_used_order:]
+                actual_lambdas = actual_lambdas[-max_used_order:]
+                actual_steps = actual_steps[-max_used_order:]
+
+        stencil_preds = list(actual_preds)
+        stencil_lambdas = list(actual_lambdas)
+        if not actual:
+            stencil_preds.append(denoised)
+            stencil_lambdas.append(lambdas[i])
+        if len(stencil_preds) > max_used_order:
+            stencil_preds = stencil_preds[-max_used_order:]
+            stencil_lambdas = stencil_lambdas[-max_used_order:]
+        if not stencil_preds:
+            raise RuntimeError("Spectrum SA adapter has no denoiser value for the active predictor")
+
+        predictor_order_used = min(predictor_order, len(stencil_preds))
+        if i == 0 or (sigmas[i + 1] == 0 and not use_pece):
+            corrector_order_used = 0
+        else:
+            # A forecast is not persistent Adams evidence, but it is still the
+            # current SA endpoint estimate. Native PEC uses that endpoint in the
+            # current corrector before constructing the next predictor state.
+            # Dropping this correction causes the forecast error to appear one
+            # step later in the next exact model input.
+            corrector_order_used = min(corrector_order, len(stencil_preds))
+
+        if lower_order_to_end:
+            predictor_order_used = min(
+                predictor_order_used,
+                len(sigmas) - 2 - i,
+            )
+            corrector_order_used = min(
+                corrector_order_used,
+                len(sigmas) - 1 - i,
+            )
+
+        if corrector_order_used == 0:
+            x = x_pred
+        else:
+            curr_lambdas = torch.stack(
+                stencil_lambdas[-corrector_order_used:]
+            )
+            b_coeffs = native_sa_solver.compute_stochastic_adams_b_coeffs(
+                sigmas[i],
+                curr_lambdas,
+                lambdas[i - 1],
+                lambdas[i],
+                tau_t,
+                simple_order_2,
+                is_corrector_step=True,
+            )
+            pred_mat = torch.stack(
+                stencil_preds[-corrector_order_used:],
+                dim=1,
+            )
+            corr_res = torch.tensordot(
+                pred_mat,
+                b_coeffs,
+                dims=([1], [0]),
+            )
+            x = (
+                sigmas[i]
+                / sigmas[i - 1]
+                * (-(tau_t**2) * h).exp()
+                * x
+                + corr_res
+            )
+            if tau_t > 0 and s_noise > 0:
+                x = x + noise
+
+        if sigmas[i + 1] == 0:
+            x_pred = denoised
+            continue
+
+        tau_t = tau_func(sigmas[i + 1])
+        curr_lambdas = torch.stack(
+            stencil_lambdas[-predictor_order_used:]
+        )
+        b_coeffs = native_sa_solver.compute_stochastic_adams_b_coeffs(
+            sigmas[i + 1],
+            curr_lambdas,
+            lambdas[i],
+            lambdas[i + 1],
+            tau_t,
+            simple_order_2,
+            is_corrector_step=False,
+        )
+        pred_mat = torch.stack(
+            stencil_preds[-predictor_order_used:],
+            dim=1,
+        )
+        pred_res = torch.tensordot(
+            pred_mat,
+            b_coeffs,
+            dims=([1], [0]),
+        )
+        h = lambdas[i + 1] - lambdas[i]
+        x_pred = (
+            sigmas[i + 1]
+            / sigmas[i]
+            * (-(tau_t**2) * h).exp()
+            * x
+            + pred_res
+        )
+
+        if tau_t > 0 and s_noise > 0:
+            noise = (
+                noise_sampler(sigmas[i], sigmas[i + 1])
+                * sigmas[i + 1]
+                * (-2 * tau_t**2 * h).expm1().neg().sqrt()
+                * s_noise
+            )
+            x_pred = x_pred + noise
+
+    return x_pred
+
+
+def _run_solver_aware_sa(
+    executor: Any,
+    runtime: SpectrumH3Runtime,
+    model_wrap: Any,
+    sigmas: torch.Tensor,
+    extra_args: dict[str, Any],
+    callback: Any,
+    noise: torch.Tensor,
+    latent_image: Any,
+    denoise_mask: Any,
+    disable_pbar: bool,
+) -> torch.Tensor:
+    """Execute SA through the reviewed isolated-history adapter."""
+    sampler = executor.class_obj
+    name = sampler_name(sampler)
+    if len(executor.wrappers) != 1:
+        runtime.disable_forecasting_for_run(
+            "another SAMPLER_SAMPLE wrapper makes SA isolated-history ordering unproven"
+        )
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+
+    options = dict(getattr(sampler, "extra_options", {}) or {})
+    copied, copy_failure = _copy_ksampler_with_options(sampler, options)
+    if copy_failure is not None or copied is None:
+        runtime.disable_forecasting_for_run(
+            copy_failure or "SA KSAMPLER copy failed"
+        )
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+
+    use_pece = bool(
+        name == "sample_sa_solver_pece"
+        or options.get("use_pece", False) is True
+    )
+    continuum_active = _continuum_actual_prefix(
+        (extra_args or {}).get("model_options")
+    ) > 0
+    if use_pece and int(options.get("corrector_order", 4)) > 0:
+        raise RuntimeError(
+            "active SA-Solver PECE reached the isolated-history adapter after preflight"
+        )
+
+    def spectrum_sa_function(
+        model,
+        x,
+        run_sigmas,
+        extra_args=None,
+        callback=None,
+        disable=False,
+        **run_options,
+    ):
+        return _sample_sa_solver_forecast_isolated(
+            runtime,
+            model,
+            x,
+            run_sigmas,
+            extra_args=extra_args,
+            callback=callback,
+            disable=disable,
+            use_pece=use_pece,
+            continuum_active=continuum_active,
+            **run_options,
+        )
+
+    spectrum_sa_function.__name__ = f"{name}_spectrum_isolated_history"
+    copied.sampler_function = spectrum_sa_function
+    if getattr(sampler, "sampler_function", None) is getattr(
+        copied,
+        "sampler_function",
+        None,
+    ):
+        raise RuntimeError("SA isolated-history adapter mutated the original sampler")
+
+    if runtime.config.debug:
+        LOG.warning(
+            "Spectrum H3 SA adapter mode=isolated_adams_history "
+            "persistent=actual_only forecast_use=current_corrector+predictor_ephemeral "
+            "forecast_corrector=ephemeral_current_only "
+            "stochastic_forecast=solver_space_causal_dense_output "
+            "continuum_dense_mode=%s continuum_dense_scope=%s",
+            "latest_actual_hold" if continuum_active else "lambda_bounded_extrapolation",
+            "all_forecasts" if continuum_active else "stochastic_only",
+        )
+    return copied.sample(
+        model_wrap,
+        sigmas,
+        extra_args,
+        callback,
+        noise,
+        latent_image,
+        denoise_mask,
+        disable_pbar,
+    )
 
 
 def _refdelta_sampler_contract(
@@ -547,11 +1375,31 @@ def _native_er_sde_preflight_reason(
 
 
 def max_consecutive_forecasts(sampler: Any) -> int | None:
+    name = sampler_name(sampler)
+    if name in SA_SOLVER_SAMPLERS and _sa_solver_is_stochastic(sampler):
+        # Native SA stores every denoised result in pred_list and feeds that
+        # history back into both its corrector and predictor. Real H3 media
+        # validation showed that a multi-forecast tail can therefore become
+        # self-referential and catastrophically corrupt x_pred. Keep stochastic
+        # SA forecasts isolated so every skipped denoiser is bracketed by exact
+        # solver observations instead of allowing a forecast-only Adams window.
+        return 1
     return 1 if sampler_is_supported(sampler) else None
 
 
 def min_actual_steps_after_forecast(sampler: Any) -> int:
-    return 1 if sampler_name(sampler) in SUPPORTED_SAMPLERS else 0
+    name = sampler_name(sampler)
+    if name in SA_SOLVER_SAMPLERS:
+        if _sa_solver_is_stochastic(sampler):
+            return 0
+        options = getattr(sampler, "extra_options", {}) or {}
+        if isinstance(options, dict):
+            predictor_order = options.get("predictor_order", 3)
+            corrector_order = options.get("corrector_order", 4)
+            if type(predictor_order) is int and type(corrector_order) is int:
+                return max(1, predictor_order, corrector_order)
+        return 4
+    return 1 if name in SUPPORTED_SAMPLERS else 0
 
 
 def min_tail_actual_steps(sampler: Any) -> int:
@@ -669,6 +1517,30 @@ def outer_sample_wrapper(
     runtime = binding.runtime
     name = sampler_name(sampler)
     expected_model_calls = None
+    if name in SA_SOLVER_SAMPLERS:
+        preflight_reason = _native_sa_solver_preflight_reason(
+            sampler,
+            getattr(guider, "model_options", None),
+        )
+        expected_model_calls = _sa_solver_expected_model_calls(sampler, sigmas)
+        if preflight_reason is not None or expected_model_calls is None:
+            reason = preflight_reason or "SA-Solver model-call topology is unavailable"
+            LOG.warning(
+                "Spectrum H3 disabled for this SA-Solver run; running the untouched "
+                "native sampler because its predictor/corrector contract is unavailable: %s",
+                reason,
+            )
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
     if name in SEEDS_SAMPLERS:
         preflight_reason = _native_seeds_preflight_reason(
             sampler,
@@ -735,10 +1607,60 @@ def outer_sample_wrapper(
     continuum_prefix = _continuum_actual_prefix(getattr(guider, "model_options", None))
     continuum_log_emitted = False
     stochastic_seeds = name in SEEDS_SAMPLERS and _seeds_is_stochastic(sampler)
+    stochastic_sa = name in SA_SOLVER_SAMPLERS and _sa_solver_is_stochastic(sampler)
+    state_conditioned_residual = stochastic_seeds or stochastic_sa
+    sa_forced_actual_steps: tuple[int, ...] = ()
+    sa_stochastic_input_steps: tuple[int, ...] = ()
+    if name in SA_SOLVER_SAMPLERS:
+        try:
+            model_sampling = guider.model_patcher.get_model_object("model_sampling")
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            LOG.warning(
+                "Spectrum H3 disabled for this SA-Solver run; running the untouched "
+                "native sampler because model_sampling is unavailable: %s",
+                exc,
+            )
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
+        protected, stochastic_steps, protection_reason = _sa_solver_stochastic_protection(
+            sampler,
+            sigmas,
+            model_sampling,
+        )
+        if protection_reason is not None or protected is None or stochastic_steps is None:
+            reason = protection_reason or "SA-Solver stochastic protection is unavailable"
+            LOG.warning(
+                "Spectrum H3 disabled for this SA-Solver run; running the untouched "
+                "native sampler because its stochastic-state schedule is unavailable: %s",
+                reason,
+            )
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
+        sa_stochastic_input_steps = stochastic_steps
+        sa_forced_actual_steps = protected
     profile_eligible = sampler_is_supported(sampler) and (
         not runtime.config.offline_smoothing_replay
         or sampler_supports_seeded_replay(sampler)
         or stochastic_seeds
+        or name in SA_SOLVER_SAMPLERS
     )
     if runtime.config.model_aware_mode != "off" and profile_eligible:
         try:
@@ -787,7 +1709,7 @@ def outer_sample_wrapper(
     ):
         nonlocal continuum_log_emitted
         phase_prefix = _continuum_prefix_for_phase(continuum_prefix, phase)
-        if expected_model_calls is not None and not stochastic_seeds:
+        if name in SEEDS_SAMPLERS and expected_model_calls is not None and not stochastic_seeds:
             expanded_prefix = _seeds_prefix_model_calls(
                 sampler,
                 run_sigmas,
@@ -806,14 +1728,20 @@ def outer_sample_wrapper(
             min_actual_prefix_steps=phase_prefix,
             expected_model_calls=expected_model_calls,
             stage_count=SEEDS_STAGE_COUNTS.get(name, 1),
-            stochastic_multistage=stochastic_seeds,
+            state_conditioned_residual=state_conditioned_residual,
             separate_stage_histories=False if stochastic_seeds else None,
             forecastable_stage_indices=(
                 tuple(range(1, SEEDS_STAGE_COUNTS[name]))
                 if stochastic_seeds
                 else None
             ),
-            model_aware_can_force_actual=not stochastic_seeds,
+            forced_actual_step_ids=(
+                sa_forced_actual_steps if name in SA_SOLVER_SAMPLERS else None
+            ),
+            forced_actual_steps_advance_window=bool(
+                name in SA_SOLVER_SAMPLERS and stochastic_sa
+            ),
+            model_aware_can_force_actual=not (stochastic_seeds or stochastic_sa),
         )
         if phase_prefix > 0 and runtime.supported_sampler and not continuum_log_emitted:
             LOG.warning(
@@ -828,18 +1756,22 @@ def outer_sample_wrapper(
             runtime.disable_experiment(
                 "ER-SDE is reviewed only for ordinary Spectrum and offline smoothing replay"
             )
-        if stochastic_seeds and (
+        if state_conditioned_residual and (
             runtime.config.anchor_residual_feedback
             or runtime.config.selective_rollback_correction
         ):
             runtime.disable_experiment(
-                "stochastic SEEDS uses stage-lane state-residual forecasting; "
-                "rollback/residual experiments are not reviewed for this geometry"
+                "state-conditioned sampler forecasting is not reviewed with "
+                "rollback/residual experiments"
             )
         if runtime.config.debug:
             LOG.warning(
                 "Spectrum H3 run start phase=%s run_id=%s sampler=%s steps=%s supported=%s "
-                "seeds_stochastic=%s stage_count=%s feature_geometry=%s stage_histories=%s "
+                "seeds_stochastic=%s sa_stochastic=%s stage_count=%s feature_geometry=%s "
+                "stage_histories=%s sa_stochastic_input_steps=%s "
+                "sa_forced_actual_steps=%s sa_post_forecast_refresh=%s "
+                "sa_max_forecast_streak=%s sa_exact_window_credit=%s "
+                "sa_adams_history=%s "
                 "model_aware_force_actual=%s",
                 phase,
                 run_id,
@@ -847,10 +1779,27 @@ def outer_sample_wrapper(
                 runtime.stats.total_steps,
                 runtime.supported_sampler,
                 stochastic_seeds,
+                stochastic_sa,
                 SEEDS_STAGE_COUNTS.get(name, 1),
-                "state_residual_shared_history" if stochastic_seeds else "absolute_hidden",
+                (
+                    "state_conditioned_residual_shared_history"
+                    if stochastic_seeds
+                    else "state_conditioned_residual"
+                    if state_conditioned_residual
+                    else "absolute_hidden"
+                ),
                 "shared" if stochastic_seeds else "single",
-                not stochastic_seeds,
+                sa_stochastic_input_steps,
+                sa_forced_actual_steps,
+                min_actual_steps_after_forecast(sampler) if name in SA_SOLVER_SAMPLERS else 0,
+                max_consecutive_forecasts(sampler) if name in SA_SOLVER_SAMPLERS else 0,
+                bool(name in SA_SOLVER_SAMPLERS and stochastic_sa),
+                (
+                    "actual_only_persistent+ephemeral_forecast"
+                    if name in SA_SOLVER_SAMPLERS
+                    else "-"
+                ),
+                not (stochastic_seeds or stochastic_sa),
             )
         started = time.perf_counter()
         try:
@@ -919,7 +1868,22 @@ def outer_sample_wrapper(
             LOG.warning(
                 "Spectrum H3 offline smoothing replay is disabled for stochastic SEEDS "
                 "because replay must not replace its Markov-preserving noise-conditioned "
-                "stage evaluations; running one causal state-residual Spectrum pass"
+                "stage evaluations; running one causal state-conditioned Spectrum pass"
+            )
+            return execute_run(
+                noise,
+                latent_image,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                phase="single_pass_replay_fallback",
+            )
+        if name in SA_SOLVER_SAMPLERS:
+            LOG.warning(
+                "Spectrum H3 offline smoothing replay is disabled for SA-Solver because "
+                "replaying changed denoiser values would change native Adams history; "
+                "running one causal Spectrum pass"
             )
             return execute_run(
                 noise,
@@ -1463,6 +2427,19 @@ def sampler_sample_wrapper(
         )
     runtime = binding.runtime
     sampler = executor.class_obj
+    if sampler_name(sampler) in SA_SOLVER_SAMPLERS:
+        return _run_solver_aware_sa(
+            executor,
+            runtime,
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
     if sampler_name(sampler) in ER_SDE_SAMPLERS:
         return _run_tracked_er_sde(
             executor,

--- a/tests/test_native_equivalence.py
+++ b/tests/test_native_equivalence.py
@@ -230,6 +230,77 @@ def test_stochastic_seeds_state_residual_forecast_uses_exact_current_input_and_s
     runtime.end_run(run_id)
 
 
+def test_sa_solver_state_conditioned_forecast_uses_exact_current_input_and_skips_blocks():
+    _, _, PackedLayout = _native_imports()
+    model, blocks = _tiny_state_residual_model()
+    base_x, context, payload = _inputs(PackedLayout)
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            model_aware_mode="off",
+            warmup_steps=0,
+            tail_actual_steps=0,
+            bootstrap_first_forecast=False,
+            window_size=2.0,
+            flex_window=0.0,
+            offline_smoothing_replay=False,
+        )
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        "sample_sa_solver",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=3,
+        stage_count=1,
+        state_conditioned_residual=True,
+    )
+
+    for index, sigma in enumerate((1.0, 0.7)):
+        x = [
+            base_x[0] + 0.12 * index,
+            base_x[1] - 0.09 * index,
+        ]
+        output, decision = _wrapped_call(
+            model,
+            runtime,
+            sigma,
+            sigma * 1000.0,
+            x,
+            context,
+            payload,
+        )
+        assert decision["actual"]
+        assert all(torch.isfinite(part).all() for part in output)
+
+    calls_before_forecast = [block.calls for block in blocks]
+    forecast_x = [
+        base_x[0] + 0.55,
+        base_x[1] - 0.35,
+    ]
+    output, decision = _wrapped_call(
+        model,
+        runtime,
+        0.4,
+        400.0,
+        forecast_x,
+        context,
+        payload,
+    )
+
+    assert decision["actual"] is False
+    assert runtime.active_stage_index == 0
+    assert runtime.state_conditioned_residual is True
+    assert runtime.stochastic_multistage is False
+    assert [block.calls for block in blocks] == calls_before_forecast
+    assert all(torch.isfinite(part).all() for part in output)
+    assert runtime.stats.actual_transformer_calls == 2
+    assert runtime.stats.forecast_model_calls == 1
+    runtime.end_run(run_id)
+
+
 def test_forced_actual_wrapper_is_native_equivalent_and_does_not_mutate_options():
     _, _, PackedLayout = _native_imports()
     model, _ = _tiny_model()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -244,7 +244,7 @@ def test_stochastic_multistage_disables_one_point_bootstrap_per_stage_lane():
         min_actual_steps_after_forecast=1,
         expected_model_calls=5,
         stage_count=2,
-        stochastic_multistage=True,
+        state_conditioned_residual=True,
     )
 
     first = _complete_step(runtime, 1.0)
@@ -280,7 +280,7 @@ def test_stochastic_multistage_requires_actual_refresh_in_the_same_lane():
         min_actual_steps_after_forecast=0,
         expected_model_calls=9,
         stage_count=2,
-        stochastic_multistage=True,
+        state_conditioned_residual=True,
     )
 
     decisions = [
@@ -288,13 +288,8 @@ def test_stochastic_multistage_requires_actual_refresh_in_the_same_lane():
         for timestep in (1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2)
     ]
 
-    # Two anchors per lane are required before the first forecast. A forecast in
-    # lane 0 cannot be "refreshed" by an actual evaluation in lane 1: lane 0's
-    # next occurrence is forced actual before it may forecast again. The same
-    # invariant applies symmetrically to lane 1.
     assert [decision["actual"] for decision in decisions[:4]] == [True, True, True, True]
     assert decisions[4]["actual"] is False
-    assert decisions[4]["step_id"] == 4
     assert decisions[5]["actual"] is True
     assert decisions[6]["actual"] is True
     assert decisions[6]["reason"] == "post-forecast stage-lane refresh"
@@ -302,6 +297,38 @@ def test_stochastic_multistage_requires_actual_refresh_in_the_same_lane():
     assert decisions[8]["actual"] is True
     assert runtime._stage_required_actual_refreshes[0] == 0
     assert runtime._stage_required_actual_refreshes[1] == 1
+    runtime.end_run(run_id)
+
+
+def test_state_conditioned_single_lane_disables_one_point_bootstrap():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=1,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=True,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        "sample_sa_solver",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+        expected_model_calls=3,
+        stage_count=1,
+        state_conditioned_residual=True,
+    )
+
+    first = _complete_step(runtime, 1.0)
+    second = _complete_step(runtime, 0.7)
+    third = _complete_step(runtime, 0.4)
+
+    assert first["actual"]
+    assert second["actual"]
+    assert second["reason"] == "insufficient actual history"
+    assert third["actual"] is False
+    assert "bootstrap" not in second["reason"]
     runtime.end_run(run_id)
 
 
@@ -322,7 +349,7 @@ def test_stochastic_seeds_protects_outer_stage_and_forecasts_internal_stage_only
         min_actual_steps_after_forecast=0,
         expected_model_calls=9,
         stage_count=2,
-        stochastic_multistage=True,
+        state_conditioned_residual=True,
         forecastable_stage_indices=(1,),
     )
 
@@ -330,7 +357,6 @@ def test_stochastic_seeds_protects_outer_stage_and_forecasts_internal_stage_only
         _complete_step(runtime, timestep)
         for timestep in (1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2)
     ]
-
     stage0 = decisions[0::2]
     stage1 = decisions[1::2]
     assert all(decision["actual"] for decision in stage0)
@@ -369,7 +395,7 @@ def test_stochastic_seeds_shared_history_uses_exact_outer_anchors_without_lane_r
         min_actual_steps_after_forecast=1,
         expected_model_calls=9,
         stage_count=2,
-        stochastic_multistage=True,
+        state_conditioned_residual=True,
         separate_stage_histories=False,
         forecastable_stage_indices=(1,),
         model_aware_can_force_actual=False,
@@ -382,7 +408,6 @@ def test_stochastic_seeds_shared_history_uses_exact_outer_anchors_without_lane_r
 
     stage0 = decisions[0::2]
     stage1 = decisions[1::2]
-
     assert all(decision["actual"] for decision in stage0)
     assert [decision["actual"] for decision in stage1] == [True, False, False, False]
     assert all(
@@ -394,17 +419,39 @@ def test_stochastic_seeds_shared_history_uses_exact_outer_anchors_without_lane_r
     assert runtime._stage_forecasters == {}
     assert runtime._stage_required_actual_refreshes == {}
     assert runtime.forecaster is runtime._primary_forecaster
-    # Exact stage-0 calls continuously refresh the one shared residual history.
     assert runtime.forecaster.history_length == 4
     assert runtime.stats.actual_steps == 6
     assert runtime.stats.forecast_steps == 3
-    # The deliberately zero risk threshold requests an actual on every
-    # forecast candidate. Stochastic SEEDS keeps that signal as telemetry and
-    # confidence/blend input, but the outer-stage safety policy owns the NFE
-    # decision for internal stages.
     assert runtime.stats.model_aware_veto_suppressed == 3
     assert runtime.stats.model_aware_forecasts == 3
     runtime.end_run(run_id)
+
+
+def test_separate_stage_histories_validation():
+    runtime = _runtime(force_actual=True)
+    sigmas = torch.tensor([1.0, 0.5, 0.0])
+
+    with pytest.raises(ValueError, match="boolean or None"):
+        runtime.start_run(
+            sigmas,
+            "sample_seeds_2",
+            supported_sampler=True,
+            expected_model_calls=3,
+            stage_count=2,
+            state_conditioned_residual=True,
+            separate_stage_histories=1,
+        )
+
+    with pytest.raises(ValueError, match="requires multistage"):
+        runtime.start_run(
+            sigmas,
+            "sample_sa_solver",
+            supported_sampler=True,
+            expected_model_calls=2,
+            stage_count=1,
+            state_conditioned_residual=True,
+            separate_stage_histories=True,
+        )
 
 
 def test_forecastable_stage_indices_validation():
@@ -418,7 +465,7 @@ def test_forecastable_stage_indices_validation():
             supported_sampler=True,
             expected_model_calls=3,
             stage_count=2,
-            stochastic_multistage=True,
+            state_conditioned_residual=True,
             forecastable_stage_indices=(1, 1),
         )
 
@@ -429,8 +476,111 @@ def test_forecastable_stage_indices_validation():
             supported_sampler=True,
             expected_model_calls=3,
             stage_count=2,
-            stochastic_multistage=True,
+            state_conditioned_residual=True,
             forecastable_stage_indices=(2,),
+        )
+
+
+def test_sampler_required_exact_step_overrides_ready_single_lane_forecast():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=0,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=False,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.8, 0.6, 0.4, 0.0]),
+        "sample_sa_solver",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=4,
+        state_conditioned_residual=True,
+        forced_actual_step_ids=(2,),
+    )
+
+    first = _complete_step(runtime, 1.0)
+    second = _complete_step(runtime, 0.8)
+    third = _complete_step(runtime, 0.6)
+    fourth = _complete_step(runtime, 0.4)
+
+    assert first["actual"]
+    assert second["actual"]
+    assert third["actual"]
+    assert third["reason"] == "sampler-required exact step"
+    assert fourth["actual"] is False
+    assert fourth["reason"] == "adaptive forecast"
+    runtime.end_run(run_id)
+
+
+def test_stochastic_sa_targets_eight_alternating_forecasts_without_noise_block():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=1,
+        tail_actual_steps=1,
+        max_history=8,
+        window_size=2.0,
+        flex_window=0.75,
+    )
+    sigmas = torch.linspace(1.0, 0.0, 20)
+    run_id = runtime.start_run(
+        sigmas,
+        "sample_sa_solver",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=19,
+        state_conditioned_residual=True,
+        forced_actual_step_ids=(),
+        forced_actual_steps_advance_window=False,
+        model_aware_can_force_actual=False,
+    )
+
+    decisions = [
+        _complete_step(runtime, float(timestep))
+        for timestep in sigmas[:-1]
+    ]
+    forecast_steps = [
+        decision["step_id"] for decision in decisions if not decision["actual"]
+    ]
+
+    assert forecast_steps == [2, 4, 6, 8, 10, 12, 14, 16]
+    assert runtime.stats.actual_steps == 11
+    assert runtime.stats.forecast_steps == 8
+    runtime.end_run(run_id)
+
+
+def test_forced_actual_step_ids_validation():
+    runtime = _runtime(force_actual=True)
+    sigmas = torch.tensor([1.0, 0.5, 0.0])
+
+    with pytest.raises(ValueError, match="duplicates"):
+        runtime.start_run(
+            sigmas,
+            "sample_sa_solver",
+            supported_sampler=True,
+            expected_model_calls=2,
+            forced_actual_step_ids=(1, 1),
+        )
+
+    with pytest.raises(ValueError, match="nonnegative"):
+        runtime.start_run(
+            sigmas,
+            "sample_sa_solver",
+            supported_sampler=True,
+            expected_model_calls=2,
+            forced_actual_step_ids=(-1,),
+        )
+
+    with pytest.raises(ValueError, match="smaller than total"):
+        runtime.start_run(
+            sigmas,
+            "sample_sa_solver",
+            supported_sampler=True,
+            expected_model_calls=2,
+            forced_actual_step_ids=(2,),
         )
 
 
@@ -474,6 +624,128 @@ def test_stochastic_seeds_3_stage_lane_indexing_matches_native_call_order():
     assert runtime._stage_forecasters[0].history_length == 2
     assert runtime._stage_forecasters[1].history_length == 1
     assert runtime._stage_forecasters[2].history_length == 1
+    runtime.end_run(run_id)
+
+
+def test_state_conditioned_single_lane_is_independent_from_multistage_seeds():
+    runtime = _runtime(
+        model_aware_mode="off",
+        warmup_steps=0,
+        tail_actual_steps=0,
+        bootstrap_first_forecast=False,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        "sample_sa_solver",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=0,
+        expected_model_calls=3,
+        stage_count=1,
+        state_conditioned_residual=True,
+    )
+
+    assert runtime.state_conditioned_residual is True
+    assert runtime.stochastic_multistage is False
+    assert runtime._stage_forecasters == {}
+
+    for timestep, value in ((1.0, 1.0), (0.7, 2.0)):
+        decision = runtime.begin_step(torch.tensor([timestep]))
+        assert decision["actual"]
+        assert runtime.active_stage_index == 0
+        assert runtime.active_state_conditioned_residual is True
+        call_id, actual = runtime.begin_model_call(
+            decision["run_id"],
+            decision["step_id"],
+            topology=TOPOLOGY,
+            labels=LABEL,
+            expected_shape=(1, 3, 4),
+        )
+        assert actual
+        runtime.observe_actual(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            torch.full((1, 3, 4), value),
+        )
+        runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    forecast = runtime.begin_step(torch.tensor([0.4]))
+    assert forecast["actual"] is False
+    assert runtime.active_stage_index == 0
+    assert runtime.prediction_history_length == 2
+    runtime.abort_step(forecast["run_id"], forecast["step_id"])
+    runtime.end_run(run_id)
+
+
+def test_sa_and_seeds_state_conditioned_runs_do_not_leak_stage_histories():
+    runtime = _runtime(
+        model_aware_mode="off",
+        force_actual=True,
+        warmup_steps=0,
+        tail_actual_steps=0,
+    )
+
+    sa_run = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_sa_solver",
+        supported_sampler=True,
+        expected_model_calls=2,
+        stage_count=1,
+        state_conditioned_residual=True,
+    )
+    for timestep in (1.0, 0.5):
+        _complete_step(runtime, timestep)
+    assert runtime.state_conditioned_residual is True
+    assert runtime.stochastic_multistage is False
+    assert runtime._stage_forecasters == {}
+    runtime.end_run(sa_run)
+
+    seeds_run = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        expected_model_calls=3,
+        stage_count=2,
+        state_conditioned_residual=True,
+    )
+    assert runtime.state_conditioned_residual is True
+    assert runtime.stochastic_multistage is True
+    assert set(runtime._stage_forecasters) == {0, 1}
+    for timestep in (1.0, 0.75, 0.5):
+        _complete_step(runtime, timestep)
+    runtime.end_run(seeds_run)
+
+    sa_again = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_sa_solver",
+        supported_sampler=True,
+        expected_model_calls=2,
+        stage_count=1,
+        state_conditioned_residual=True,
+    )
+    assert runtime._stage_forecasters == {}
+    assert runtime.prediction_history_length == 0
+    assert runtime.stochastic_multistage is False
+    runtime.end_run(sa_again)
+
+
+def test_legacy_stochastic_multistage_keyword_maps_to_generic_state_conditioning():
+    runtime = _runtime(force_actual=True)
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.5, 0.0]),
+        "sample_seeds_2",
+        supported_sampler=True,
+        expected_model_calls=3,
+        stage_count=2,
+        stochastic_multistage=True,
+    )
+
+    assert runtime.state_conditioned_residual is True
+    assert runtime.stochastic_multistage is True
+    assert set(runtime._stage_forecasters) == {0, 1}
     runtime.end_run(run_id)
 
 

--- a/tests/test_sa_solver_state_conditioning.py
+++ b/tests/test_sa_solver_state_conditioning.py
@@ -1,0 +1,955 @@
+from __future__ import annotations
+
+import ast
+import copy
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import sampling as sampling_module
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
+from comfyui_spectrum_h3.sampling import (
+    BINDING_KEY,
+    SpectrumH3Binding,
+    _sa_solver_expected_model_calls,
+    _sa_solver_is_stochastic,
+    _sa_solver_option_contract,
+    _sa_solver_prefix_model_calls,
+    _sa_solver_sampler_contract,
+    _sa_solver_tau_values,
+    outer_sample_wrapper,
+    sampler_supports_seeded_replay,
+)
+
+
+def _sampler(function_name: str, options: dict | None = None):
+    def sampler_function():
+        return None
+
+    sampler_function.__name__ = function_name
+    return SimpleNamespace(
+        sampler_function=sampler_function,
+        extra_options={} if options is None else dict(options),
+    )
+
+
+def _native_sa_functions():
+    comfyui_path = os.environ.get("COMFYUI_PATH")
+    if not comfyui_path:
+        pytest.skip("COMFYUI_PATH is required for synthetic native SA-Solver tests")
+    source_path = Path(comfyui_path) / "comfy/k_diffusion/sampling.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    functions = []
+    for name in ("sample_sa_solver", "sample_sa_solver_pece"):
+        function = copy.deepcopy(
+            next(
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name == name
+            )
+        )
+        function.decorator_list = []
+        functions.append(function)
+
+    def coefficients(
+        _sigma_next,
+        curr_lambdas,
+        _lambda_s,
+        _lambda_t,
+        _tau_t,
+        _simple_order_2=False,
+        is_corrector_step=False,
+    ):
+        scale = 0.15 if is_corrector_step else 0.2
+        return torch.full_like(curr_lambdas, scale / curr_lambdas.numel())
+
+    def interval_factory(start_sigma, end_sigma, eta=1.0):
+        def tau_func(sigma):
+            value = (
+                float(sigma.detach().cpu().item())
+                if torch.is_tensor(sigma)
+                else float(sigma)
+            )
+            return float(eta) if float(start_sigma) >= value >= float(end_sigma) else 0.0
+
+        return tau_func
+
+    namespace = {
+        "torch": torch,
+        "trange": lambda count, disable=None: range(count),
+        "default_noise_sampler": lambda x, seed=None: (
+            lambda _sigma, _sigma_next: torch.randn(
+                x.shape,
+                generator=torch.Generator(device=x.device).manual_seed(seed or 0),
+                device=x.device,
+                dtype=x.dtype,
+            )
+        ),
+        "offset_first_sigma_for_snr": lambda sigmas, _sampling: sigmas,
+        "sigma_to_half_log_snr": lambda sigma, model_sampling: -torch.log(sigma),
+        "sa_solver": SimpleNamespace(
+            compute_stochastic_adams_b_coeffs=coefficients,
+            get_tau_interval_func=interval_factory,
+        ),
+    }
+    module = ast.fix_missing_locations(ast.Module(body=functions, type_ignores=[]))
+    exec(compile(module, "<native SA-Solver>", "exec"), namespace)  # noqa: S102
+    return namespace
+
+
+class _ModelSampling:
+    noise_scale = 1.0
+
+    @staticmethod
+    def percent_to_sigma(percent):
+        return 1.0 - float(percent)
+
+
+class _Patcher:
+    @staticmethod
+    def get_model_object(name):
+        assert name == "model_sampling"
+        return _ModelSampling()
+
+
+def _run_native(
+    *,
+    function_name="sample_sa_solver",
+    sigmas=(0.9, 0.7, 0.5, 0.3, 0.0),
+    use_pece=False,
+    corrector_order=4,
+    simple_order_2=False,
+    tau_func="piecewise",
+    s_noise=0.7,
+):
+    native = _native_sa_functions()[function_name]
+    generator = torch.Generator(device="cpu").manual_seed(8675309)
+    noise_draws = []
+    noise_args = []
+    callbacks = []
+    model_events = []
+    tau_args = []
+
+    def noise_sampler(sigma, sigma_next):
+        noise_args.append((float(sigma), float(sigma_next)))
+        value = torch.randn((1, 2), generator=generator, dtype=torch.float32)
+        noise_draws.append(value.clone())
+        return value
+
+    if tau_func == "piecewise":
+        def configured_tau(sigma):
+            value = float(sigma)
+            tau_args.append(value)
+            return 0.8 if 0.3 <= value <= 0.7 else 0.0
+    elif tau_func == "zero":
+        def configured_tau(sigma):
+            value = float(sigma)
+            tau_args.append(value)
+            return 0.0
+    elif tau_func is None:
+        configured_tau = None
+    else:
+        raise AssertionError(f"unknown tau fixture {tau_func!r}")
+
+    class Model:
+        inner_model = SimpleNamespace(model_patcher=_Patcher())
+
+        def __call__(self, x, sigma, **_extra_args):
+            coordinate = float(sigma.detach().cpu().item())
+            model_events.append((x.detach().clone(), coordinate))
+            return torch.full_like(x, 0.25 + 0.5 * coordinate)
+
+    sigma_tensor = torch.tensor(sigmas, dtype=torch.float32)
+    kwargs = dict(
+        extra_args={"seed": 123},
+        callback=lambda state: callbacks.append(
+            {
+                "x": state["x"].detach().clone(),
+                "sigma": float(state["sigma"]),
+                "denoised": state["denoised"].detach().clone(),
+            }
+        ),
+        disable=True,
+        tau_func=configured_tau,
+        s_noise=s_noise,
+        noise_sampler=noise_sampler,
+        predictor_order=3,
+        corrector_order=corrector_order,
+        simple_order_2=simple_order_2,
+    )
+    if function_name == "sample_sa_solver":
+        kwargs["use_pece"] = use_pece
+    result = native(
+        Model(),
+        torch.ones((1, 2), dtype=torch.float32),
+        sigma_tensor,
+        **kwargs,
+    )
+    return SimpleNamespace(
+        result=result,
+        callbacks=callbacks,
+        model_events=model_events,
+        noise_draws=noise_draws,
+        noise_args=noise_args,
+        tau_args=tau_args,
+    )
+
+
+def _run_isolated(
+    modes,
+    *,
+    sigmas=(0.9, 0.7, 0.5, 0.3, 0.0),
+    tau_func="piecewise",
+    s_noise=0.7,
+    predictor_order=3,
+    corrector_order=4,
+    continuum_active=False,
+):
+    generator = torch.Generator(device="cpu").manual_seed(8675309)
+    noise_draws = []
+    noise_args = []
+    callbacks = []
+    model_events = []
+    tau_args = []
+    runtime = SimpleNamespace(last_completed_mode=None)
+    mode_iter = iter(modes)
+
+    def noise_sampler(sigma, sigma_next):
+        noise_args.append((float(sigma), float(sigma_next)))
+        value = torch.randn((1, 2), generator=generator, dtype=torch.float32)
+        noise_draws.append(value.clone())
+        return value
+
+    if tau_func == "piecewise":
+        def configured_tau(sigma):
+            value = float(sigma)
+            tau_args.append(value)
+            return 0.8 if 0.3 <= value <= 0.7 else 0.0
+    elif tau_func == "zero":
+        def configured_tau(sigma):
+            value = float(sigma)
+            tau_args.append(value)
+            return 0.0
+    elif tau_func is None:
+        configured_tau = None
+    else:
+        raise AssertionError(f"unknown tau fixture {tau_func!r}")
+
+    class Model:
+        inner_model = SimpleNamespace(model_patcher=_Patcher())
+
+        def __call__(self, x, sigma, **_extra_args):
+            coordinate = float(sigma.detach().cpu().item())
+            model_events.append((x.detach().clone(), coordinate))
+            runtime.last_completed_mode = next(mode_iter)
+            return torch.full_like(x, 0.25 + 0.5 * coordinate)
+
+    sigma_tensor = torch.tensor(sigmas, dtype=torch.float32)
+    result = sampling_module._sample_sa_solver_forecast_isolated(
+        runtime,
+        Model(),
+        torch.ones((1, 2), dtype=torch.float32),
+        sigma_tensor,
+        extra_args={"seed": 123},
+        callback=lambda state: callbacks.append(
+            {
+                "x": state["x"].detach().clone(),
+                "sigma": float(state["sigma"]),
+                "denoised": state["denoised"].detach().clone(),
+            }
+        ),
+        disable=True,
+        tau_func=configured_tau,
+        s_noise=s_noise,
+        noise_sampler=noise_sampler,
+        predictor_order=predictor_order,
+        corrector_order=corrector_order,
+        simple_order_2=False,
+        continuum_active=continuum_active,
+    )
+    return SimpleNamespace(
+        result=result,
+        callbacks=callbacks,
+        model_events=model_events,
+        noise_draws=noise_draws,
+        noise_args=noise_args,
+        tau_args=tau_args,
+        runtime=runtime,
+    )
+
+
+def test_sa_dense_output_holds_latest_when_only_one_actual_anchor():
+    latest = torch.tensor([[2.0, 4.0]], dtype=torch.float32)
+    predicted, mode, anchors, alpha = sampling_module._sa_predict_causal_denoised(
+        [latest],
+        [torch.tensor(0.2)],
+        [3],
+        target_lambda=torch.tensor(0.3),
+        target_step=4,
+    )
+
+    torch.testing.assert_close(predicted, latest, rtol=0, atol=0)
+    assert predicted.data_ptr() != latest.data_ptr()
+    assert mode == "latest_actual_hold"
+    assert anchors == (3,)
+    assert float(alpha) == pytest.approx(0.0)
+
+
+def test_sa_dense_output_continuum_holds_latest_even_with_valid_slope():
+    previous = torch.tensor([[1.0, 3.0]], dtype=torch.float32)
+    latest = torch.tensor([[2.0, 5.0]], dtype=torch.float32)
+    predicted, mode, anchors, alpha = sampling_module._sa_predict_causal_denoised(
+        [previous, latest],
+        [torch.tensor(0.2), torch.tensor(0.4)],
+        [1, 3],
+        target_lambda=torch.tensor(0.5),
+        target_step=4,
+        continuum_active=True,
+    )
+
+    torch.testing.assert_close(predicted, latest, rtol=0, atol=0)
+    assert predicted.data_ptr() != latest.data_ptr()
+    assert mode == "latest_actual_hold_continuum"
+    assert anchors == (3,)
+    assert float(alpha) == pytest.approx(0.0)
+
+
+def test_continuum_uses_solver_space_hold_on_nonstochastic_forecast():
+    pytest.importorskip("scipy")
+    run = _run_isolated(
+        ["actual", "actual", "forecast", "actual"],
+        tau_func="zero",
+        s_noise=0.7,
+        continuum_active=True,
+    )
+
+    # The raw synthetic model value at sigma=0.5 would be 0.5. Continuum must
+    # ignore it even though tau is zero and reuse the exact step-1 denoised
+    # value (0.25 + 0.5*0.7 = 0.6).
+    torch.testing.assert_close(
+        run.callbacks[2]["denoised"],
+        torch.full((1, 2), 0.6, dtype=torch.float32),
+        rtol=0,
+        atol=1e-6,
+    )
+    assert run.runtime.last_completed_mode == "actual"
+
+
+def test_sa_dense_output_holds_after_consecutive_actual_refreshes():
+    previous = torch.tensor([[1.0, 3.0]], dtype=torch.float32)
+    latest = torch.tensor([[2.0, 4.0]], dtype=torch.float32)
+    predicted, mode, anchors, alpha = sampling_module._sa_predict_causal_denoised(
+        [previous, latest],
+        [torch.tensor(0.2), torch.tensor(0.3)],
+        [7, 8],
+        target_lambda=torch.tensor(0.4),
+        target_step=9,
+    )
+
+    torch.testing.assert_close(predicted, latest, rtol=0, atol=0)
+    assert mode == "latest_actual_hold_consecutive_anchors"
+    assert anchors == (8,)
+    assert float(alpha) == pytest.approx(0.0)
+
+
+def test_sa_dense_output_uses_bounded_lambda_extrapolation_from_actuals():
+    previous = torch.tensor([[1.0, 3.0]], dtype=torch.float32)
+    latest = torch.tensor([[2.0, 5.0]], dtype=torch.float32)
+    predicted, mode, anchors, alpha = sampling_module._sa_predict_causal_denoised(
+        [previous, latest],
+        [torch.tensor(0.2), torch.tensor(0.4)],
+        [1, 3],
+        target_lambda=torch.tensor(0.5),
+        target_step=4,
+    )
+
+    # alpha=(0.5-0.4)/(0.4-0.2)=0.5, so latest + 0.5*(latest-previous).
+    torch.testing.assert_close(
+        predicted,
+        torch.tensor([[2.5, 6.0]], dtype=torch.float32),
+        rtol=0,
+        atol=1e-6,
+    )
+    assert mode == "lambda_bounded_extrapolation"
+    assert anchors == (1, 3)
+    assert float(alpha) == pytest.approx(0.5)
+
+
+def test_sa_dense_output_guards_overlong_extrapolation_to_latest_hold():
+    previous = torch.tensor([[1.0, 3.0]], dtype=torch.float32)
+    latest = torch.tensor([[2.0, 5.0]], dtype=torch.float32)
+    predicted, mode, anchors, alpha = sampling_module._sa_predict_causal_denoised(
+        [previous, latest],
+        [torch.tensor(0.2), torch.tensor(0.21)],
+        [1, 3],
+        target_lambda=torch.tensor(0.5),
+        target_step=4,
+    )
+
+    torch.testing.assert_close(predicted, latest, rtol=0, atol=0)
+    assert mode == "lambda_bounded_extrapolation"
+    assert anchors == (1, 3)
+    assert float(alpha) == pytest.approx(0.0)
+
+
+def test_isolated_sa_adapter_is_exact_native_parity_when_every_call_is_actual():
+    pytest.importorskip("scipy")
+    native = _run_native()
+    isolated = _run_isolated(["actual"] * 4)
+
+    assert torch.allclose(isolated.result, native.result, atol=0.0, rtol=0.0)
+    assert isolated.noise_args == pytest.approx(native.noise_args)
+    assert isolated.tau_args == pytest.approx(native.tau_args)
+    assert len(isolated.callbacks) == len(native.callbacks)
+    for candidate, expected in zip(isolated.callbacks, native.callbacks, strict=True):
+        assert candidate["sigma"] == pytest.approx(expected["sigma"])
+        assert torch.allclose(candidate["x"], expected["x"], atol=0.0, rtol=0.0)
+        assert torch.allclose(
+            candidate["denoised"],
+            expected["denoised"],
+            atol=0.0,
+            rtol=0.0,
+        )
+
+
+def test_isolated_sa_adapter_uses_forecast_in_current_corrector_but_not_next_history(monkeypatch):
+    pytest.importorskip("scipy")
+    pytest.importorskip("torchsde")
+    import comfy.k_diffusion.sa_solver as native_sa_solver
+    import comfy.k_diffusion.sampling as native_sampling
+
+    original = native_sa_solver.compute_stochastic_adams_b_coeffs
+    calls = []
+
+    def capture(
+        sigma_next,
+        curr_lambdas,
+        lambda_s,
+        lambda_t,
+        tau_t,
+        simple_order_2=False,
+        is_corrector_step=False,
+    ):
+        calls.append(
+            {
+                "curr": curr_lambdas.detach().clone(),
+                "lambda_t": lambda_t.detach().clone(),
+                "corrector": bool(is_corrector_step),
+            }
+        )
+        return original(
+            sigma_next,
+            curr_lambdas,
+            lambda_s,
+            lambda_t,
+            tau_t,
+            simple_order_2,
+            is_corrector_step=is_corrector_step,
+        )
+
+    monkeypatch.setattr(
+        native_sa_solver,
+        "compute_stochastic_adams_b_coeffs",
+        capture,
+    )
+    sigmas = torch.tensor([0.9, 0.7, 0.5, 0.3, 0.0], dtype=torch.float32)
+    lambdas = native_sampling.sigma_to_half_log_snr(
+        sigmas,
+        model_sampling=_ModelSampling(),
+    )
+
+    _run_isolated(
+        ["actual", "actual", "forecast", "actual"],
+        sigmas=tuple(float(value) for value in sigmas),
+        s_noise=0.0,
+    )
+
+    # The forecast at step 2 is the current endpoint estimate and therefore
+    # participates in that step's PEC correction.
+    step2_correctors = [
+        call
+        for call in calls
+        if call["corrector"] and torch.allclose(call["lambda_t"], lambdas[2])
+    ]
+    assert len(step2_correctors) == 1
+    step2 = step2_correctors[0]["curr"]
+    assert any(torch.allclose(value, lambdas[2]) for value in step2)
+
+    # The same forecast is ephemeral: once step 2 completes, lambda[2] must not
+    # survive into the persistent Adams stencil used by the next exact step.
+    step3_correctors = [
+        call
+        for call in calls
+        if call["corrector"] and torch.allclose(call["lambda_t"], lambdas[3])
+    ]
+    assert len(step3_correctors) == 1
+    step3 = step3_correctors[0]["curr"]
+    assert any(torch.allclose(value, lambdas[3]) for value in step3)
+    assert not any(torch.allclose(value, lambdas[2]) for value in step3)
+
+
+@pytest.mark.parametrize(
+    ("function_name", "use_pece", "corrector_order", "sigmas", "expected_calls"),
+    (
+        ("sample_sa_solver", False, 4, (0.9,), 0),
+        ("sample_sa_solver", False, 4, (0.9, 0.0), 1),
+        ("sample_sa_solver", False, 4, (0.9, 0.7, 0.5, 0.0), 3),
+        ("sample_sa_solver", True, 4, (0.9, 0.7, 0.5, 0.0), 5),
+        ("sample_sa_solver", True, 0, (0.9, 0.7, 0.5, 0.0), 3),
+        ("sample_sa_solver_pece", False, 4, (0.9, 0.7, 0.5, 0.0), 5),
+        ("sample_sa_solver_pece", False, 0, (0.9, 0.7, 0.5, 0.0), 3),
+        ("sample_sa_solver", True, 4, (0.9, 0.7, 0.5, 0.3), 5),
+    ),
+)
+def test_compiled_native_sa_solver_proves_exact_model_call_topology(
+    function_name,
+    use_pece,
+    corrector_order,
+    sigmas,
+    expected_calls,
+):
+    run = _run_native(
+        function_name=function_name,
+        sigmas=sigmas,
+        use_pece=use_pece,
+        corrector_order=corrector_order,
+    )
+
+    assert len(run.model_events) == expected_calls
+    assert len(run.callbacks) == max(0, len(sigmas) - 1)
+
+
+def test_pece_second_evaluation_has_same_sigma_different_state_and_no_callback():
+    run = _run_native(use_pece=True)
+
+    model_sigmas = [event[1] for event in run.model_events]
+    callback_sigmas = [event["sigma"] for event in run.callbacks]
+    assert model_sigmas == pytest.approx([0.9, 0.7, 0.7, 0.5, 0.5, 0.3, 0.3])
+    assert callback_sigmas == pytest.approx([0.9, 0.7, 0.5, 0.3])
+    assert not torch.equal(run.model_events[1][0], run.model_events[2][0])
+    assert not torch.equal(run.model_events[3][0], run.model_events[4][0])
+
+
+@pytest.mark.parametrize("simple_order_2", (False, True))
+def test_simple_order_2_does_not_change_sa_model_call_or_noise_topology(simple_order_2):
+    run = _run_native(simple_order_2=simple_order_2)
+
+    assert len(run.model_events) == 4
+    assert len(run.callbacks) == 4
+    assert len(run.noise_draws) == 3
+
+
+def test_native_sa_noise_is_consumed_by_the_next_callback_visible_model_call():
+    run = _run_native(
+        sigmas=(0.9, 0.7, 0.5, 0.3, 0.0),
+        tau_func="piecewise",
+        s_noise=0.7,
+    )
+
+    assert len(run.model_events) == 4
+    assert len(run.callbacks) == 4
+    # tau(0.7), tau(0.5), and tau(0.3) are all active in this fixture.
+    # Native SA adds each corresponding draw to x_pred after the predictor, so
+    # the following outer model/callback consumes that fresh stochastic state.
+    assert len(run.noise_draws) == 3
+    for step_id in (1, 2, 3):
+        assert torch.equal(
+            run.model_events[step_id][0],
+            run.callbacks[step_id]["x"],
+        )
+        assert not torch.equal(
+            run.model_events[step_id][0],
+            run.model_events[step_id - 1][0],
+        )
+
+
+def test_tau_zero_suppresses_noise_without_extra_tau_or_noise_calls():
+    run = _run_native(tau_func="zero")
+
+    assert run.tau_args == pytest.approx([0.7, 0.5, 0.3])
+    assert run.noise_args == []
+    assert run.noise_draws == []
+
+
+def test_piecewise_tau_transitions_preserve_native_noise_order_and_arguments():
+    run = _run_native()
+
+    assert run.tau_args == pytest.approx([0.7, 0.5, 0.3])
+    assert len(run.noise_args) == 3
+    for candidate, expected in zip(
+        run.noise_args,
+        ((0.9, 0.7), (0.7, 0.5), (0.5, 0.3)),
+        strict=True,
+    ):
+        assert candidate == pytest.approx(expected)
+    assert len(run.noise_draws) == 3
+
+
+def test_tau_none_uses_native_default_interval_without_extra_validation_calls():
+    run = _run_native(tau_func=None)
+
+    assert run.tau_args == []
+    assert len(run.noise_draws) == 3
+
+
+def test_review_rejects_custom_tau_without_invoking_it():
+    calls = []
+
+    def custom_tau(sigma):
+        calls.append(sigma)
+        return 0.0
+
+    reason = _sa_solver_option_contract("sample_sa_solver", {"tau_func": custom_tau})
+
+    assert reason is not None
+    assert "tau_func" in reason
+    assert calls == []
+
+
+def test_review_accepts_native_tau_closure_and_reads_eta_without_executing_it():
+    if not os.environ.get("COMFYUI_PATH"):
+        pytest.skip("COMFYUI_PATH is required for native SA tau provenance")
+    from comfy.k_diffusion.sa_solver import get_tau_interval_func
+
+    tau_func = get_tau_interval_func(0.8, 0.2, eta=0.75)
+    values = _sa_solver_tau_values(tau_func)
+
+    assert values is not None
+    assert values["eta"] == pytest.approx(0.75)
+    assert _sa_solver_option_contract("sample_sa_solver", {"tau_func": tau_func}) is None
+
+
+@pytest.mark.parametrize(
+    ("options", "stochastic"),
+    (
+        ({}, True),
+        ({"s_noise": 0.0}, False),
+    ),
+)
+def test_sa_stochastic_gate_handles_default_and_disabled_noise(options, stochastic):
+    assert _sa_solver_is_stochastic(_sampler("sample_sa_solver", options)) is stochastic
+
+
+def test_sa_stochastic_gate_reads_native_eta_zero_closure():
+    if not os.environ.get("COMFYUI_PATH"):
+        pytest.skip("COMFYUI_PATH is required for native SA tau provenance")
+    from comfy.k_diffusion.sa_solver import get_tau_interval_func
+
+    sampler = _sampler(
+        "sample_sa_solver",
+        {"tau_func": get_tau_interval_func(0.8, 0.2, eta=0.0)},
+    )
+    assert _sa_solver_is_stochastic(sampler) is False
+
+
+def test_custom_noise_sampler_is_accepted_without_speculative_draws():
+    calls = []
+
+    def noise_sampler(sigma, sigma_next):
+        calls.append((sigma, sigma_next))
+        return torch.zeros((1, 2))
+
+    assert (
+        _sa_solver_option_contract(
+            "sample_sa_solver",
+            {"noise_sampler": noise_sampler},
+        )
+        is None
+    )
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("function_name", "options", "sigmas", "expected"),
+    (
+        ("sample_sa_solver", {}, [0.9, 0.6, 0.3, 0.0], 3),
+        ("sample_sa_solver", {}, [0.9], 0),
+        ("sample_sa_solver", {"use_pece": True}, [0.9, 0.6, 0.3, 0.0], 5),
+        (
+            "sample_sa_solver",
+            {"use_pece": True, "corrector_order": 0},
+            [0.9, 0.6, 0.3, 0.0],
+            3,
+        ),
+        ("sample_sa_solver_pece", {}, [0.9, 0.6, 0.3], 3),
+        (
+            "sample_sa_solver_pece",
+            {"corrector_order": 0},
+            [0.9, 0.6, 0.3],
+            2,
+        ),
+    ),
+)
+def test_sa_model_call_accounting_tracks_pec_and_pece(
+    function_name,
+    options,
+    sigmas,
+    expected,
+):
+    sampler = _sampler(function_name, options)
+
+    assert _sa_solver_expected_model_calls(sampler, torch.tensor(sigmas)) == expected
+
+
+def test_sa_continuum_prefix_is_outer_step_identity_for_reviewed_pec():
+    sampler = _sampler("sample_sa_solver")
+
+    assert (
+        _sa_solver_prefix_model_calls(
+            sampler,
+            torch.tensor([0.9, 0.7, 0.5, 0.3, 0.0]),
+            3,
+        )
+        == 3
+    )
+
+
+@pytest.mark.parametrize(
+    ("function_name", "options", "message"),
+    (
+        ("sample_sa_solver", {"use_pece": True}, "duplicate-sigma"),
+        ("sample_sa_solver_pece", {}, "duplicate-sigma"),
+        ("sample_sa_solver", {"predictor_order": True}, "predictor_order"),
+        ("sample_sa_solver", {"corrector_order": -1}, "corrector_order"),
+        ("sample_sa_solver", {"s_noise": float("nan")}, "s_noise"),
+        ("sample_sa_solver", {"noise_sampler": object()}, "noise_sampler"),
+        ("sample_sa_solver", {"tau_func": lambda _sigma: 0.0}, "tau_func"),
+    ),
+)
+def test_sa_unsupported_options_fail_closed(function_name, options, message):
+    reason = _sa_solver_option_contract(function_name, options)
+
+    assert reason is not None
+    assert message in reason
+
+
+def test_native_sa_sampler_contract_accepts_pec_and_inert_pece_options():
+    if not os.environ.get("COMFYUI_PATH"):
+        pytest.skip("COMFYUI_PATH is required for native SA sampler provenance")
+    pytest.importorskip("torchsde")
+    try:
+        import comfy.samplers
+    except ImportError as exc:
+        pytest.skip(f"optional ComfyUI runtime dependency is unavailable: {exc}")
+    from comfy.k_diffusion.sa_solver import get_tau_interval_func
+
+    tau_func = get_tau_interval_func(0.8, 0.2, eta=0.75)
+    pec = comfy.samplers.ksampler(
+        "sa_solver",
+        {
+            "tau_func": tau_func,
+            "noise_sampler": lambda _sigma, _sigma_next: torch.zeros((1, 2)),
+            "predictor_order": 3,
+            "corrector_order": 4,
+            "use_pece": False,
+            "simple_order_2": True,
+        },
+    )
+    inert_pece = comfy.samplers.ksampler(
+        "sa_solver_pece",
+        {"tau_func": tau_func, "corrector_order": 0},
+    )
+
+    assert _sa_solver_sampler_contract(pec) == (True, None)
+    assert _sa_solver_sampler_contract(inert_pece) == (True, None)
+
+
+@pytest.mark.parametrize(
+    ("sampler_name", "options"),
+    (
+        ("sa_solver", {"use_pece": True, "corrector_order": 4}),
+        ("sa_solver_pece", {"corrector_order": 4}),
+    ),
+)
+def test_native_sa_sampler_contract_rejects_active_pece(sampler_name, options):
+    if not os.environ.get("COMFYUI_PATH"):
+        pytest.skip("COMFYUI_PATH is required for native SA sampler provenance")
+    pytest.importorskip("torchsde")
+    try:
+        import comfy.samplers
+    except ImportError as exc:
+        pytest.skip(f"optional ComfyUI runtime dependency is unavailable: {exc}")
+
+    accepted, reason = _sa_solver_sampler_contract(
+        comfy.samplers.ksampler(sampler_name, options)
+    )
+
+    assert not accepted
+    assert reason is not None
+    assert "duplicate-sigma" in reason
+
+
+def test_sa_solver_replay_is_intentionally_causal_only():
+    assert not sampler_supports_seeded_replay(_sampler("sample_sa_solver"))
+    assert not sampler_supports_seeded_replay(
+        _sampler("sample_sa_solver", {"s_noise": 0.0})
+    )
+
+
+def test_sa_outer_wrapper_enters_state_conditioned_spectrum(monkeypatch, caplog):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            model_aware_mode="off",
+            offline_smoothing_replay=False,
+            debug=True,
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {},
+        },
+        model_patcher=_Patcher(),
+    )
+    sampler = _sampler("sample_sa_solver")
+    calls = []
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_sa_solver_preflight_reason",
+        lambda _sampler, _model_options: None,
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            calls.append(
+                (
+                    runtime.active_run_id,
+                    runtime.state_conditioned_residual,
+                    runtime.stochastic_multistage,
+                    runtime.stats.total_steps,
+                    args,
+                    kwargs,
+                )
+            )
+            return "state-conditioned-sa"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.7, 0.4, 0.0]),
+            seed=17,
+        )
+
+    assert result == "state-conditioned-sa"
+    assert len(calls) == 1
+    assert calls[0][0] is not None
+    assert calls[0][1] is True
+    assert calls[0][2] is False
+    assert calls[0][3] == 3
+    assert runtime.active_run_id is None
+    assert "feature_geometry=state_conditioned_residual" in caplog.text
+
+
+def test_sa_offline_request_runs_one_causal_spectrum_pass(monkeypatch, caplog):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            model_aware_mode="off",
+            offline_smoothing_replay=True,
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {},
+        },
+        model_patcher=_Patcher(),
+    )
+    sampler = _sampler("sample_sa_solver")
+    active_runs = []
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_sa_solver_preflight_reason",
+        lambda _sampler, _model_options: None,
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            active_runs.append(
+                (
+                    runtime.active_run_id,
+                    runtime.state_conditioned_residual,
+                    runtime.offline_phase,
+                )
+            )
+            return "causal-sa"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.7, 0.4, 0.0]),
+            seed=17,
+        )
+
+    assert result == "causal-sa"
+    assert len(active_runs) == 1
+    assert active_runs[0][0] is not None
+    assert active_runs[0][1] is True
+    assert active_runs[0][2] is None
+    assert "running one causal Spectrum pass" in caplog.text
+
+
+def test_active_pece_falls_back_before_runtime_state(monkeypatch, caplog):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(model_aware_mode="off", offline_smoothing_replay=False)
+    )
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {},
+        },
+        model_patcher=object(),
+    )
+    sampler = _sampler(
+        "sample_sa_solver",
+        {"use_pece": True, "corrector_order": 4},
+    )
+    calls = []
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_sa_solver_preflight_reason",
+        lambda _sampler, _model_options: (
+            "SA-Solver PECE with an active corrector has duplicate-sigma "
+            "predicted/corrected states and is not reviewed for Spectrum forecasting"
+        ),
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            calls.append((runtime.active_run_id, args, kwargs))
+            return "native-pece"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.7, 0.4, 0.0]),
+            seed=17,
+        )
+
+    assert result == "native-pece"
+    assert len(calls) == 1
+    assert calls[0][0] is None
+    assert runtime.active_run_id is None
+    assert "running the untouched native sampler" in caplog.text
+    assert "duplicate-sigma" in caplog.text

--- a/tests/test_sampler_contract.py
+++ b/tests/test_sampler_contract.py
@@ -15,6 +15,8 @@ from comfyui_spectrum_h3.sampling import (
     ER_SDE_DEFAULT_NOISE_SAMPLER_DIGEST,
     ER_SDE_KSAMPLER_SAMPLE_DIGEST,
     ER_SDE_NATIVE_FUNCTION_DIGEST,
+    SA_SOLVER_HELPER_DIGESTS,
+    SA_SOLVER_NATIVE_FUNCTION_DIGESTS,
     SEEDS_NATIVE_FUNCTION_DIGESTS,
 )
 
@@ -432,6 +434,83 @@ def test_native_seeds_stage_topology_matches_reviewed_contract(function_name, st
     assert len(_named_calls(function, "model")) == stage_count
     assert len(_named_calls(loops[0], "noise_sampler")) == stage_count
     assert _ast_digest(function) == SEEDS_NATIVE_FUNCTION_DIGESTS[function_name]
+
+
+def test_native_sa_solver_topology_matches_reviewed_pec_pece_contract():
+    function = _native_sampling_functions()["sample_sa_solver"]
+    loops = [node for node in function.body if isinstance(node, (ast.For, ast.AsyncFor))]
+
+    assert len(loops) == 1
+    model_calls = sorted(_named_calls(loops[0], "model"), key=lambda node: node.lineno)
+    callback_calls = sorted(
+        _named_calls(loops[0], "callback"), key=lambda node: node.lineno
+    )
+    noise_calls = sorted(
+        _named_calls(loops[0], "noise_sampler"), key=lambda node: node.lineno
+    )
+    assert len(model_calls) == 2
+    assert len(callback_calls) == 1
+    assert len(noise_calls) == 1
+    assert model_calls[0].lineno < callback_calls[0].lineno < model_calls[1].lineno
+    pece_branch = next(
+        node
+        for node in ast.walk(loops[0])
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "use_pece"
+    )
+    assert model_calls[1] in list(ast.walk(pece_branch))
+    assert _ast_digest(function) == SA_SOLVER_NATIVE_FUNCTION_DIGESTS[
+        "sample_sa_solver"
+    ]
+
+
+def test_native_sa_solver_pece_delegates_once_with_pece_enabled():
+    function = _native_sampling_functions()["sample_sa_solver_pece"]
+    calls = _named_calls(function, "sample_sa_solver")
+
+    assert len(calls) == 1
+    use_pece = next(keyword for keyword in calls[0].keywords if keyword.arg == "use_pece")
+    assert isinstance(use_pece.value, ast.Constant)
+    assert use_pece.value.value is True
+    assert _ast_digest(function) == SA_SOLVER_NATIVE_FUNCTION_DIGESTS[
+        "sample_sa_solver_pece"
+    ]
+
+
+def test_native_sa_solver_math_helpers_match_reviewed_contract():
+    helpers = {
+        node.name: node
+        for node in _native_tree("comfy/k_diffusion/sa_solver.py").body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    for name, expected_digest in SA_SOLVER_HELPER_DIGESTS.items():
+        assert _ast_digest(helpers[name]) == expected_digest
+
+
+@pytest.mark.parametrize("mutation", ("extra_model_call", "remove_noise_draw"))
+def test_sa_solver_topology_mutations_change_fail_closed_digest(mutation):
+    function = copy.deepcopy(_native_sampling_functions()["sample_sa_solver"])
+    loop = next(node for node in function.body if isinstance(node, ast.For))
+
+    if mutation == "extra_model_call":
+        first_model_assignment = next(
+            node
+            for node in loop.body
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "model"
+        )
+        loop.body.insert(loop.body.index(first_model_assignment) + 1, copy.deepcopy(first_model_assignment))
+    else:
+        noise_call = _named_calls(loop, "noise_sampler")[0]
+        noise_call.func = ast.Name(id="changed_noise_source", ctx=ast.Load())
+
+    assert _ast_digest(function) != SA_SOLVER_NATIVE_FUNCTION_DIGESTS[
+        "sample_sa_solver"
+    ]
 
 
 @pytest.mark.parametrize("function_name", RES_VARIANTS)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -49,6 +49,8 @@ def _sampler(function_name: str) -> SimpleNamespace:
         "sample_res_multistep_cfg_pp",
         "sample_seeds_2",
         "sample_seeds_3",
+        "sample_sa_solver",
+        "sample_sa_solver_pece",
     ),
 )
 def test_reviewed_samplers_are_supported(function_name):
@@ -117,6 +119,27 @@ def test_non_res_policy_keeps_one_refresh_and_user_tail(function_name):
     assert min_tail_actual_steps(sampler) == 0
 
 
+@pytest.mark.parametrize("function_name", ("sample_sa_solver", "sample_sa_solver_pece"))
+def test_sa_policy_separates_stochastic_tail_burst_from_deterministic_refresh(function_name):
+    sampler = _sampler(function_name)
+    sampler.extra_options = {}
+
+    assert max_consecutive_forecasts(sampler) == 1
+    assert min_actual_steps_after_forecast(sampler) == 0
+    assert min_tail_actual_steps(sampler) == 0
+
+    sampler.extra_options = {"s_noise": 0.0}
+    assert max_consecutive_forecasts(sampler) == 1
+    assert min_actual_steps_after_forecast(sampler) == 4
+
+    sampler.extra_options = {
+        "s_noise": 0.0,
+        "predictor_order": 2,
+        "corrector_order": 0,
+    }
+    assert min_actual_steps_after_forecast(sampler) == 2
+
+
 def test_unsupported_sampler_has_no_forecast_streak_policy():
     sampler = _sampler("sample_euler_ancestral")
 
@@ -144,6 +167,68 @@ def test_seeds_expected_model_calls_tracks_internal_stages(
         _seeds_expected_model_calls(_sampler(function_name), torch.tensor(sigmas))
         == expected
     )
+
+
+class _FakeSASampling:
+    noise_scale = 1.0
+
+    @staticmethod
+    def percent_to_sigma(percent):
+        return {0.2: 0.8, 0.8: 0.2}[percent]
+
+
+def test_sa_stochastic_protection_matches_native_tau_input_without_history_preroll():
+    sampler = _sampler("sample_sa_solver")
+    sampler.extra_options = {}
+    sigmas = torch.tensor([1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0])
+
+    forced, stochastic, reason = sampling_module._sa_solver_stochastic_protection(
+        sampler,
+        sigmas,
+        _FakeSASampling(),
+    )
+
+    assert reason is None
+    assert stochastic == (3, 4, 5, 6, 7, 8)
+    # Stochastic inputs remain observable, but the solver-aware adapter now
+    # handles them by isolating forecasted denoisers from persistent Adams
+    # history instead of blanket-forcing the whole interval actual.
+    assert forced == ()
+
+
+def test_sa_stochastic_protection_respects_zero_noise_and_zero_eta():
+    sigmas = torch.tensor([1.0, 0.8, 0.6, 0.4, 0.2, 0.0])
+
+    sampler = _sampler("sample_sa_solver")
+    sampler.extra_options = {"s_noise": 0.0}
+    forced, stochastic, reason = sampling_module._sa_solver_stochastic_protection(
+        sampler,
+        sigmas,
+        _FakeSASampling(),
+    )
+    assert reason is None
+    assert forced == ()
+    assert stochastic == ()
+
+    class ZeroEtaSampling(_FakeSASampling):
+        pass
+
+    native_sa_solver = pytest.importorskip(
+        "comfy.k_diffusion.sa_solver",
+        reason="native SA tau provenance requires an installed ComfyUI",
+    )
+
+    sampler.extra_options = {
+        "tau_func": native_sa_solver.get_tau_interval_func(0.8, 0.2, eta=0.0),
+    }
+    forced, stochastic, reason = sampling_module._sa_solver_stochastic_protection(
+        sampler,
+        sigmas,
+        ZeroEtaSampling(),
+    )
+    assert reason is None
+    assert forced == ()
+    assert stochastic == ()
 
 
 @pytest.mark.parametrize(
@@ -279,7 +364,7 @@ def test_stochastic_seeds_outer_wrapper_enters_state_residual_spectrum(monkeypat
     assert calls[0][4] is False
     assert runtime.active_run_id is None
     assert "running the untouched native sampler" not in caplog.text
-    assert "feature_geometry=state_residual_shared_history" in caplog.text
+    assert "feature_geometry=state_conditioned_residual_shared_history" in caplog.text
     assert "stage_histories=shared" in caplog.text
 
 
@@ -331,7 +416,7 @@ def test_stochastic_seeds_offline_request_runs_one_causal_spectrum_pass(monkeypa
     assert active_runs[0][0] is not None
     assert active_runs[0][1] is True
     assert active_runs[0][2] is None
-    assert "one causal state-residual Spectrum pass" in caplog.text
+    assert "one causal state-conditioned Spectrum pass" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Add fail-closed, native-contract-validated Spectrum support for ComfyUI's SA-Solver family, stacked cleanly on the current #86 SEEDS implementation.

This revision incorporates the stochastic-state lesson from #86: Spectrum must not replace SA-Solver's data prediction after the model call or attempt to algebraically correct the solver's stochastic state. Instead, stochastic SA PEC uses the same generalized **state-conditioned transformer-residual forecasting** geometry as stochastic SEEDS while retaining its own one-call-per-outer-step solver topology.

## Native topology

For `N = len(sigmas) - 1` in reviewed ComfyUI:

- PEC (`sample_sa_solver(..., use_pece=false)`) performs exactly **N H3 evaluations** and **N native callbacks**.
- Active PECE performs the predicted-state evaluation and, from the second outer interval onward, a corrected-state evaluation at the same sigma but a different latent: **2N - 1 H3 evaluations**, while callbacks remain N.
- `corrector_order=0` suppresses the second PECE evaluation and returns both PECE entry points to the reviewed N-call topology.
- Native noise is drawn after a nonterminal predictor when `tau > 0` and `s_noise > 0`; the next H3 call therefore sees the exact stochastic `x_pred` produced by SA-Solver.
- Adams history remains entirely native and stores the normal ComfyUI data-prediction outputs.

These assumptions are pinned to the reviewed native sampler/helper ASTs, `KSAMPLER.sample`, `KSamplerX0Inpaint`, and `default_noise_sampler`.

## State-conditioned SA forecasting and stochastic protection

SA PEC no longer uses the previous `SASolverOutputTracker` / sampler-space two-anchor extrapolation. That approach has been removed completely.

Outside native stochastic-input steps, Spectrum may forecast H3 in feature space as:

```text
final target hidden
  = exact current-state target input hidden
  + forecasted transformer residual
```

On an actual H3 call Spectrum captures the exact target hidden immediately before the first transformer block and the final target hidden after the last block, retaining only `final_hidden - input_hidden`. On a forecast call it reconstructs H3's exact current target input embedding from the current SA latent, forecasts the transformer residual, adds the exact input term back, and executes the ordinary native H3 final layer.

A real default-SA H3 trace exposed the remaining stochastic failure directly. The run was already past the old one-point-bootstrap bug: steps 0 and 1 were actual, then Spectrum forecast steps 2, 4, 6, 9, 11, 13, 15, and 17. The delayed heavy-noise previews followed those callback-visible forecast evaluations.

Native SA explains the pattern. Noise is injected into `x_pred` after a predictor when `tau > 0`; the **next** outer model call and callback consume that freshly perturbed `x_pred`. Keeping its input embedding exact is necessary but insufficient: the skipped H3 transformer is itself the nonlinear denoising response to that particular random realization. A transformer residual forecast learned from older states cannot be assumed to reproduce that response.

The runtime now resolves the reviewed native SA stochastic interval and forces every H3 evaluation whose input contains a fresh stochastic increment to be actual. For `tau_func=None`, Spectrum uses the same native bounds as ComfyUI: `model_sampling.percent_to_sigma(0.2)` through `percent_to_sigma(0.8)`. For a reviewed native `get_tau_interval_func` closure, the captured `start_sigma`, `end_sigma`, and `eta` values are inspected without executing the callback. Effective `s_noise` also includes the model's native `noise_scale`.

A follow-up real H3 trace showed that the first safety revision over-expanded this constraint. The native stochastic inputs were steps 6 through 13, but the Adams pre-roll widened the forced mask to steps 2 through 13 and the four-call post-forecast debt then forced steps 16 and 17 actual. The result was **18 actual / 1 forecast** out of 19 H3 calls. That loss of acceleration came from Spectrum's fixed scheduling rules, not from model-aware gating.

Forecasted denoisers do enter native `pred_list`, but their mere presence is not a native solver correctness violation: supplying an approximate denoiser is the acceleration mechanism itself. The hard stochastic invariant is narrower. Spectrum must leave native SA noise/state/history operations untouched and must not forecast the H3 transformer evaluation whose **current** `x_pred` contains a fresh stochastic increment.

The revised stochastic PEC policy therefore:
- forces exactly the tau-derived fresh-noise input calls actual, with no Adams-memory pre-roll;
- leaves native `pred_list`, coefficients, predictor/corrector updates, and RNG untouched;
- gives those mandatory exact stochastic calls normal credit as fresh Spectrum history, allowing the adaptive forecast window to widen instead of treating the exact block as dead scheduling time;
- removes fixed post-forecast actual debt for stochastic SA and caps a forecast burst at `min(4, max(predictor_order, corrector_order))`.

For the observed default 19-call geometry with stochastic-input steps 6 through 13, the model-aware-free schedule is now expected to be:

```text
A A F A F A A A A A A A A A F F F F A
```

That is **13 actual / 6 forecast**. The four-call tail burst begins only after eight consecutive exact stochastic-region H3 anchors and after native tau has become inactive. External-patch boundaries, Continuum prefixes, model-aware risk, or fallback conditions may still add actual calls.

Deterministic SA (`s_noise=0` or reviewed `eta=0`) does not receive stochastic exact-block credit and retains the conservative full-Adams-memory refresh until an independent aggressive deterministic cadence is validated.

The native SA noise sampler, tau evaluation, Adams coefficients, `pred_list`, predictor/corrector updates, callbacks, and model-output conversion remain untouched. There is no sampler-space denoised/x0 replacement and no extra transformer NFE.

## Separation from SEEDS

The shared runtime abstraction separates three concerns:

- **state-conditioned residual geometry** — whether a forecast must retain the exact current latent-state input contribution;
- **multistage topology** — whether the sampler has explicit internal stage identity for accounting and stage masks;
- **history ownership** — whether those stages require independent forecast histories.

The current stacked design is:

```text
stochastic SEEDS-2  -> state-conditioned residual + 2-stage topology + shared residual history
stochastic SEEDS-3  -> state-conditioned residual + 3-stage topology + shared residual history
stochastic SA PEC   -> state-conditioned residual + single-stage topology + one residual history
ordinary samplers   -> absolute hidden + single-stage topology
```

SEEDS keeps stage identity because its native outer stage must remain exact, but #86 now intentionally shares actual residual anchors across the interleaved SEEDS call trajectory. SA does not inherit the SEEDS stage mask and instead uses its tau-derived fresh-noise exact-step mask plus a bounded deterministic-tail forecast burst after that exact region. Runtime teardown tests keep SA and SEEDS state isolated across sequential runs.

No SA-specific post-output hook is added to `external_patch_compat.py`; Diff-Aid/external-patch compatibility continues through the existing generic runtime/minimax transaction.

## Scheduling safety

State-conditioned stochastic samplers do not use Spectrum's degree-1 one-point bootstrap.

Stochastic SEEDS inherits #86's shared-history policy: exact outer-stage H3 evaluations continuously refresh the one residual trajectory, so SEEDS-2 no longer requires a redundant same-internal-stage actual after each internal forecast. The ordinary global no-back-to-back forecast guard remains active.

SA is single-stage from Spectrum's model-call perspective. Stochastic SA keeps every fresh-noise input exact, lets those mandatory actual calls grow Spectrum's adaptive window, and permits a bounded burst only after the exact stochastic region has ended. Deterministic SA retains the older full-Adams-memory refresh pending separate validation.

## SEEDS outer-stage protection inherited from #86

The latest default SEEDS-2 media trace isolated the remaining delayed heavy-noise preview artifact to stage-0 forecasts exactly. #87 is rebased on the corrected #86 head and preserves the new sampler-aware stage mask: stochastic SEEDS keeps the native outer stage (stage 0) exact on every interval and forecasts only internal stages. SA-Solver remains a separate single-lane path and does not inherit this SEEDS-only stage mask.

## Support/fallback policy

- `sample_sa_solver`, `use_pece=false`: reviewed Spectrum support.
- `sample_sa_solver`, `use_pece=true`, `corrector_order=0`: reviewed N-call support.
- `sample_sa_solver_pece`, `corrector_order=0`: reviewed N-call support.
- Active PECE correction: untouched native fallback before Spectrum run state is created.
- `tau_func=None`: supported native default.
- Exact closure returned by native `get_tau_interval_func`: supported after provenance/freevar/value validation without executing it.
- Arbitrary tau callable: untouched native fallback; never speculatively invoked.
- Custom callable `noise_sampler`: supported without inspection or extra draws.
- `simple_order_2`: supported; it changes Adams coefficients, not the reviewed call topology.

## Offline replay

True offline smoothing replay remains disabled for SA-Solver because replaying changed denoiser values would change the native Adams history even with a reproducible RNG stream.

With Spectrum's normal `offline_smoothing_replay=true` default, reviewed SA-Solver now runs **one causal Spectrum pass** instead of falling back to untouched native sampling. Stochastic SA therefore still receives acceleration under the default Spectrum node configuration.

## Regression coverage

- Native SA PEC/PECE model-call and callback topology.
- Same-sigma/different-latent PECE corrected-state identity.
- Tau transition and native noise-draw ordering.
- `simple_order_2` topology invariance.
- Exact native tau-closure provenance and eta extraction without executing user callbacks.
- Custom noise-sampler non-interference.
- PEC/inert-PECE native sampler-contract acceptance and active-PECE rejection.
- SA logical model-call and Continuum-prefix accounting.
- Stochastic/deterministic SA state-conditioning classification.
- Exact stochastic-input-step resolution from native tau bounds and effective noise scale.
- Fresh-noise exact-step resolution without Adams-history mask expansion.
- Stochastic-SA exact-region window credit and bounded post-region forecast streak.
- Regression for the observed 19-call default geometry: 13 actual / 6 forecast with steps 6 through 13 exact.
- Deterministic-SA retention of the conservative full-Adams-memory refresh.
- Runtime forced-actual step validation and scheduling.
- Synthetic native proof that SA noise injected by a predictor is consumed by the next callback-visible model call.
- Outer-wrapper entry into one-lane state-conditioned Spectrum.
- Default offline-replay request -> one causal Spectrum pass.
- Active PECE -> pre-runtime untouched native fallback.
- Native MiniMax-H3 integration proving a state-conditioned SA forecast skips transformer blocks while reconstructing from the exact current latent.
- Runtime one-lane SA vs multi-lane SEEDS isolation and SA -> SEEDS -> SA teardown.
- Existing SEEDS, ER-SDE, RefDelta, RES, external-patch, Continuum, masked-H3, model-aware, Ruff and compileall suites.

The next real stochastic-SA validation resolved the remaining ambiguity decisively. The attempted **13 actual / 6 forecast** cadence completed mechanically with no fallbacks but produced a completely corrupted decoded result. The failure is not evidence that SA needs 15 actual calls. It is evidence that the integration model was wrong.

Native SA appends every denoised result to `pred_list` and reuses that list in later corrector and predictor equations. The previous Spectrum integration treated a forecasted denoiser exactly like a measured SA observation. That makes approximation error recursive: once forecasts enter persistent Adams history, later states are solved from a mixture of real and invented observations, and a consecutive tail can become forecast-only. The rejected run exposed exactly that mechanism.

PR #87 now changes the solver integration rather than adding more forced-actual masks:

- persistent Adams history contains **actual H3 denoisers only**;
- a Spectrum forecast is **ephemeral across steps**;
- the current forecast still participates in the native PEC corrector and predictor for its own interval;
- the forecast is discarded before the next step's persistent Adams stencil is formed;
- the next actual H3 evaluation re-anchors both Spectrum and the Adams stencil;
- exact observations keep their real lambda coordinates, so after a skipped step the next corrector uses an irregular-time actual-only stencil instead of pretending the skipped forecast was measured data;
- the native SA coefficient routine, stochastic noise draw, tau schedule, predictor/corrector equations, callback order, sigma schedule, and final denoising semantics remain the reviewed equations.

This removes the blanket fresh-noise exact block. `sa_stochastic_input_steps` remains telemetry, but stochastic-input calls are no longer automatically forced actual. The old 15/4 direction was fundamentally incompatible with the acceleration goal.

Stochastic SA is scheduled with isolated forecasts (`max_consecutive_forecasts=1`). For the default 19-call geometry the model-aware-free target is now **11 actual / 8 forecast**:

`A A F A F A F A F A F A F A F A F A A`

with forecast IDs **2, 4, 6, 8, 10, 12, 14, 16** before hard runtime transitions. In the current DiffAid workflow, if the step-8 forecast candidate is converted to actual at the hard sigma boundary, the zero-debt alternating policy naturally resumes with a forecast at step 9, so the target remains eight forecasts rather than collapsing to 12/7 or 15/4.

The 11/8 real-media run then provided a second, much narrower finding. The NFE target was reached cleanly in both chunks with no fallbacks: the first chunk forecasted steps **2, 4, 6, 9, 11, 13, 15, 17** after DiffAid converted step 8 to actual, and the Continuum chunk followed the same effective cadence. The decoded result was broadly acceptable, but visible delayed-noise artifacts remained at least on actual steps **10, 12, 14, and 16**.

Restoring the current PEC corrector was then tested in real media and **did not remove those delayed-noise artifacts**. The follow-up log positively confirms that the new path was active — `forecast_use=current_corrector+predictor_ephemeral` and `forecast_corrector=ephemeral_current_only` — while the same one-step-late failure remained. That falsifies the missing-current-corrector hypothesis.

The next real-media run then falsified the simple output-space ownership fix as well. The log confirms that `stochastic_ownership=exact_pending_increment` was active and that exact increment compensation executed on the stochastic forecasts at steps **4, 6, 9, 11, 13, and 15**, yet the delayed-noise artifacts remained. The raw `+q` contribution in `denoised = model_input - sigma * model_output` is therefore not sufficient to explain the failure.

The surviving mismatch is inside the **feature forecast's response to stochastic state**. Spectrum reconstructs MiniMax H3's forecast feature as `exact current-state input embedding + forecasted transformer residual`. With native SA, the actual model sees `x_pred = x_base + q` and the transformer can respond to the fresh random increment `q`. A Spectrum forecast rebuilds the exact input embedding of that noisy state but skips the transformer blocks, so it injects the state perturbation without the nonlinear transformer response that should accompany it. Subtracting `q` only after the output cannot remove that hidden-space partial response.

The split-input experiment has been removed completely. Multiple real runs showed that the adapter could announce split ownership while the intended `q` handoff never reached the actual PREDICT_NOISE call path, and CI #507/#508 rejected the focused transport tests as well. Repeating that experiment would only burn more media-validation time.

The current revision uses **solver-space causal dense output** during active stochastic SA intervals. Spectrum still performs its cheap feature forecast so the normal runtime transaction, telemetry, and scheduling semantics remain intact, but that raw hidden-feature forecast is **ignored for SA's corrector/predictor whenever the current model input contains fresh stochastic predictor noise**. SA consumes a denoised estimate built only from exact H3 actual anchors:

- one actual anchor -> latest-exact hold;
- consecutive actual anchors -> latest-exact hold;
- otherwise -> two-anchor lambda-space extrapolation;
- extrapolation is bounded to one prior anchor interval and invalid/reversed/overlong geometry collapses to a hold.

The first full real-media run of this design removed the delayed heavy-noise corruption at 11/8. It exposed a separate Continuum-only artifact in chunk 2: brief whole-frame vertical oscillation and flashing.

The next run tested a Continuum-specific latest-actual hold on every **stochastic** forecast. The requested breadcrumb was present on steps 4, 6, 9, 11, 13, and 15, yet the decoded artifact was unchanged. That cleanly falsifies stochastic secant extrapolation as the cause. The same trace also shows the remaining hole in that experiment: Continuum step 2 and step 17 were still raw Spectrum hidden-feature forecasts because tau was zero there, so those values still entered SA.

Current head closes that hole. When Continuum interop is active, **every forecast coordinate** uses solver-space latest-actual hold, including non-stochastic steps 2 and 17. Spectrum still executes the cheap hidden-feature forecast for its normal transaction/telemetry, but its denoised value is ignored by SA for the whole continuation chunk. The 11/8 schedule and zero-extra-NFE budget are unchanged.

Outside Continuum, bounded lambda-space dense output remains restricted to stochastic forecasts. Native SA still owns the untouched stochastic `x_pred`, exact noise draw, tau, corrector, predictor equations, callback order, and RNG order. Persistent Adams history remains actual-only.

The ordinary model-aware scheduler veto is advisory on stochastic SA. Risk/confidence telemetry, adaptive fit/blend, and generic correction remain active, but NFE reduction is part of the sampler contract rather than something the generic controller may silently destroy. The rejected 13/6 result is retained as negative evidence against **persistent forecast history**, not as justification for a high-NFE exact mask.

The SA implementation remains one commit on the unchanged #86 head `282d9c3cfce5081b6700aa21bf795ac7a97e155d`. The final #87 head is `707bdf348eb4d24973ed1c3c3105355df7e8bdbd`. CI #511 passes on that exact head. No release/version bump is included.

## Real-media validation

The final default stochastic-SA workflow passed the real-media gate at **11 actual / 8 forecast** in both the initial and Continuum chunks with **0 fallbacks**.

Initial chunk:
- forecasts: **2, 4, 6, 9, 11, 13, 15, 17**;
- active stochastic forecasts used bounded solver-space dense output from exact H3 anchors;
- the previously observed delayed heavy-noise corruption is gone.

Continuum chunk:
- `accepted H3 Continuum API v1, actual prefix=2`;
- the same **11/8** cadence completed with **0 fallbacks**;
- all eight forecast coordinates **2, 4, 6, 9, 11, 13, 15, 17** emitted `scope=continuum_all_forecasts mode=latest_actual_hold_continuum`;
- raw Spectrum feature-derived denoised values were ignored by SA at every forecast coordinate;
- the previously observed whole-frame vertical shake/flashing is gone.

This final run confirms the intended invariant: forecasted H3 values are never persistent Adams observations, stochastic SA consumes solver-space causal dense output instead of the raw hidden-feature forecast, and Continuum continuation chunks isolate every forecast coordinate with a latest-exact hold while retaining the target 11/8 NFE budget.

A separate Euler + simple-scheduler Continuum check produced a clean second chunk, so the earlier shake/flashing is not attributed to the reported upstream MiniMax-H3 masking regression.

Active PECE remains intentionally fail-closed/native for configurations with a live corrector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for SA-Solver and SA-Solver PECE sampling.
  - Improved state-conditioned residual forecasting across stochastic samplers.
  - Added safeguards for exact actual-step refreshes and unsupported SA-Solver configurations.
  - Disabled seeded replay and offline smoothing replay where sampler history could become invalid.
  - Added fail-safe fallback to native sampling when compatibility checks fail.

- **Documentation**
  - Documented SA-Solver compatibility, scheduling behavior, constraints, and stochastic SEEDS handling.

- **Tests**
  - Expanded coverage for SA-Solver behavior, forecasting, validation, callbacks, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->