### PR TITLE
Add full Spectrum acceleration for active SA-Solver PECE

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,10 @@ jobs:
             python_version: "3.12"
             comfy_kitchen_version: "0.2.31"
             comfy_aimdo_version: "0.4.15"
+          - comfy_ref: 8a33128f2f8c5585c57486c07de481241e70a39c
+            python_version: "3.12"
+            comfy_kitchen_version: "0.2.31"
+            comfy_aimdo_version: "0.4.15"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -63,8 +67,13 @@ jobs:
           COMFY_AIMDO_VERSION: ${{ matrix.comfy_aimdo_version || '0.4.13' }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install pytest ruff numpy psutil safetensors einops tqdm pyyaml pillow packaging "comfy-kitchen==${COMFY_KITCHEN_VERSION}" "comfy-aimdo==${COMFY_AIMDO_VERSION}"
+          python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install \
+            pytest ruff numpy scipy torchsde psutil safetensors einops tqdm pyyaml pillow packaging \
+            transformers tokenizers sentencepiece aiohttp yarl alembic SQLAlchemy filelock \
+            "av>=17.0.0" requests simpleeval blake3 kornia spandrel pydantic pydantic-settings \
+            PyOpenGL comfy-angle \
+            "comfy-kitchen==${COMFY_KITCHEN_VERSION}" "comfy-aimdo==${COMFY_AIMDO_VERSION}"
           python -m pip wheel --no-deps --wheel-dir /tmp/spectrum-h3-wheel .
 
       - name: Run forecaster smoke test

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Forecasting is fail-closed and allowlisted for reviewed sampler contracts.
 | SEEDS-2 | `sample_seeds_2` | Stochastic outer stage stays exact; internal stage uses exact-current-state + transformer-residual forecasting with shared interleaved history. |
 | SEEDS-3 | `sample_seeds_3` | Same state-conditioned residual architecture; more conservative because two internal stages occur between exact outer anchors. |
 | SA-Solver PEC | `sample_sa_solver` | Actual-only persistent Adams history plus causal solver-space dense output; isolated forecasts re-anchor on the next exact H3 evaluation. |
-| SA-Solver PECE | `sample_sa_solver` / `sample_sa_solver_pece` | Accepted only when no live corrected-state H3 evaluation is required (`corrector_order=0`); active PECE correctors remain native/fail-closed. |
+| SA-Solver PECE | `sample_sa_solver` / `sample_sa_solver_pece` | Active correctors use explicit predicted/corrected phases; P0 plus exact corrected endpoints own shared persistent history, while later predicted phases are solver-space forecasts unless a correctness boundary promotes them. |
 
 Unknown or changed sampler contracts fall back to native execution rather than guessing.
 
@@ -241,7 +241,14 @@ SEEDS-3 uses the same reviewed state-conditioned residual architecture but remai
 
 ### SA-Solver compatibility details
 
-Spectrum supports the reviewed native Stochastic Adams `sample_sa_solver` PEC topology. Active PECE configurations that require a second corrected-state H3 evaluation remain fail-closed to untouched native execution because they need a separate predictor/corrector stage identity.
+Spectrum supports native Stochastic Adams PEC and active PECE. The original SA-Solver method is formulated in data-prediction space: preceding data-prediction evaluations form the predictor stencil, the predicted endpoint is evaluated, and that endpoint extends the current corrector stencil. Current ComfyUI PECE adds another evaluation after correction. At every corrected outer interval, ComfyUI therefore has two real H3 opportunities at the same sigma and different latent states:
+
+```text
+predicted phase: model(x_pred, sigma_i)   -> callback-visible
+corrected phase: model(x_corr, sigma_i)   -> callback-invisible
+```
+
+With `N = len(sigmas) - 1`, ordinary PEC and PECE with `corrector_order=0` have `N` H3 opportunities and `N` callbacks. Active PECE has `N` predicted opportunities, `N - 1` corrected opportunities, `2N - 1` total H3 opportunities, and still only `N` callbacks.
 
 The central SA invariant is:
 
@@ -253,22 +260,63 @@ next exact H3 call       = re-anchor Spectrum + Adams history
 
 Native SA normally appends every denoised result to its Adams history. Doing that with an approximate Spectrum denoiser makes the forecast error recursive. Spectrum therefore maintains persistent Adams evidence from exact H3 evaluations only. A forecast can participate in the current solver interval, but it is not promoted into persistent solver history.
 
-For stochastic SA, the raw hidden-feature forecast is also not used directly at the SA numerical boundary during the active stochastic interval. Native SA can add a fresh stochastic increment to `x_pred`; although Spectrum can rebuild the exact input embedding of that state, a skipped transformer does not reproduce the transformer's nonlinear response to the new random realization. The final adapter therefore supplies **causal solver-space dense output built only from exact H3 anchors**:
+Active PECE uses an endpoint-owned policy that mirrors native ComfyUI PECE:
 
-- one trustworthy actual anchor -> latest-exact hold;
-- consecutive actual anchors -> latest-exact hold;
-- otherwise -> bounded two-anchor extrapolation in SA lambda space;
-- invalid, reversed, nonfinite, or overlong geometry -> latest-exact hold.
+- predicted and corrected calls retain distinct logical identities; no epsilon is added to sigma and no fake solver coordinate is created;
+- outer step 0 has no corrected evaluation, so P0 is the first exact persistent endpoint;
+- for every later outer step, the exact corrected evaluation C_i replaces P_i as native PECE's persistent Adams endpoint and is also the Spectrum feature-history owner for that coordinate;
+- P_i for i > 0 is never retained in Spectrum persistent feature history, even when a hard boundary promotes that predicted call to exact, because C_i supersedes it at the same outer coordinate;
+- the shared feature history therefore contains exactly P0, C1, C2, ... rather than two different latent states at the same scalar coordinate;
+- every corrected phase remains an actual H3 evaluation and every persistent Adams entry remains an actual H3 observation;
+- a corrected-phase forecast and a both-phases-forecast pair remain prohibited by construction.
 
-The native SA tau schedule, stochastic noise draw, predictor/corrector equations, coefficient routine, callback order, sigma schedule, final denoising semantics, and RNG order remain untouched. Spectrum only substitutes the skipped H3 denoiser value that SA consumes.
+This removes the old predicted-lane refresh debt without pretending that a corrected hidden state is the predicted hidden state. The feature-history ownership follows the solver's endpoint replacement semantics instead: after a forecasted P_i is consumed by the current corrector, exact C_i arrives before the next predictor and becomes the next trustworthy endpoint anchor.
 
-Stochastic SA uses isolated forecasts with `max_consecutive_forecasts=1`. The next exact H3 call re-anchors both Spectrum and the actual-only Adams history. The generic model-aware scheduler veto is advisory on this sampler-specific stochastic path so the controller cannot silently collapse the intended NFE reduction; telemetry, adaptive fit/blend, and generic correction remain active.
+For **every active-PECE predicted forecast**, the raw hidden-feature forecast is transaction-only and is not used as SA's denoised value. The adapter supplies causal solver-space dense output built only from exact persistent PECE endpoints:
 
-H3 Continuum continuation chunks use a stricter variant: **every forecast coordinate** uses a latest-exact solver-space hold, including coordinates outside the active stochastic-tau interval. Spectrum still executes its cheap hidden-feature forecast for transaction accounting and telemetry, but that raw denoised value is ignored by SA for the entire continuation chunk.
+- P1, with only P0 available -> latest-exact hold;
+- with two trustworthy endpoints -> bounded two-anchor secant extrapolation in SA lambda space, including consecutive C endpoints;
+- invalid, reversed, nonfinite, or excessive extrapolation geometry -> latest-exact hold;
+- H3 Continuum -> latest-exact hold on every forecast coordinate.
 
-The validated 19-call production cadence is **11 actual / 8 forecast**. Final real-media validation with DiffAid, Untwist-RoPE and H3 Continuum completed at 11/8 in both the initial and continuation chunks with zero fallbacks. The earlier delayed heavy-noise corruption and the later Continuum-only whole-frame shake/flashing were both absent in the final decoded output.
+The native SA tau schedule, stochastic noise draw, predictor/corrector equations, coefficient routine, callback order, sigma schedule, final denoising semantics, and RNG order remain untouched. A forecasted predicted endpoint may affect only its current corrector; it is never inserted into persistent Adams history.
 
-Deterministic SA keeps the ordinary conservative behavior because the stochastic solver-space adaptation is not needed. Offline smoothing replay is intentionally disabled for SA-Solver: replaying changed denoiser values would change Stochastic Adams history even with a reproducible random stream, so reviewed SA runs use one causal Spectrum pass.
+A declared hard external-patch transition still promotes the affected predicted phase to an exact H3 evaluation before the corrector consumes it. After that exact corrected endpoint lands, the PECE dense-output interpolation anchors restart from the post-transition endpoint so the secant bridge does not extrapolate across a transformer discontinuity. Native Adams history is **not** reset or rewritten.
+
+H3 Continuum's protected prefix remains defined in native outer-step coordinates and still protects both predicted and corrected phases inside each protected outer interval. Outside the prefix, corrected phases are exact and each predicted forecast uses the latest exact corrected endpoint as its solver-space hold. Spectrum still executes its cheap hidden-feature forecast for accounting/model-wrapper continuity, but that raw forecast is ignored by SA.
+
+Because every forecasted predicted phase is followed by an exact corrected H3 call, active PECE no longer needs a separate predicted-phase H3 refresh before forecasting the next outer interval. The final corrected endpoint stays exact while the final predicted phase may forecast unless another correctness boundary requires it to be actual.
+
+### Active-PECE forecast policy
+
+`sa_pece_forecast_policy` exposes the early quality/speed tradeoff instead of hiding one preferred cadence inside the sampler integration. All three policies use the **same** corrected-endpoint ownership, actual-only Adams persistence, solver-space bridge, Continuum handling, and hard-transition rules. They differ only in how many initial PECE outer coordinates are protected from predicted-phase forecasting:
+
+| Policy | Protected predicted phases | Clean 10-outer topology | Intended use |
+|---|---:|---:|---|
+| `max_speed` | P0 only | **10 actual / 9 forecast** | Maximum endpoint-bridge acceleration; trades one additional exact early anchor for speed. |
+| `balanced` **(default)** | P0, P1 | **11 actual / 8 forecast** | Released quality/speed default after matched production testing. |
+| `stable_start` | P0, P1, P2 | **12 actual / 7 forecast** | Stronger early stabilization at the cost of one more H3 evaluation. |
+
+The ordinary `warmup_steps` setting can only make these policies more conservative: a larger user warmup extends the exact prefix beyond the selected policy minimum. It never weakens Continuum or external-patch safety boundaries.
+
+The selector was added after real 10-outer production testing of the `max_speed` endpoint bridge. With the custom `phase_offset_uniform` scheduler, the tested DiffAid + Untwist + runtime-LoRA workflow completed at **12 actual / 7 forecast** for the initial chunk and **13 actual / 6 forecast** for the H3 Continuum chunk, both with **0 fallbacks**. The decoded final video was reported as good, but the earliest callback previews moved substantially between scenes before settling, including a changed first-frame composition after a few early steps.
+
+Final matched production testing with the dedicated RefDelta SA-Solver scheduler showed that both `max_speed` and `balanced` remained structurally clean and produced acceptable decoded output. The `balanced` run was perceptually better in the tested workflow, while the exact `simple_control` scheduler was slightly preferred over the bounded Adams-conditioned scheduler variant. The early coarse/colored-shape previews were also observed with other MiniMax-H3 samplers and are not treated as an SA-PECE correctness failure. `balanced` is therefore the released default; `max_speed` remains the explicit higher-speed option and `stable_start` the more conservative option.
+
+For reference, with no additional hard boundary, Continuum prefix, fallback, force-actual override, or larger user warmup:
+
+- `max_speed`, **10 outer intervals** -> **10 actual / 9 forecast**;
+- `balanced`, **10 outer intervals** -> **11 actual / 8 forecast**;
+- `stable_start`, **10 outer intervals** -> **12 actual / 7 forecast**;
+- `max_speed`, **19 outer intervals** -> **19 actual / 18 forecast**.
+
+These are nominal topology counts, not promises that every production stack will hit them. H3 Continuum's protected prefix and hard external transitions such as DiffAid/Untwist remain authoritative and can promote specific predicted forecasts to actual. Those safety NFEs are intentionally not traded away merely to preserve a headline ratio.
+
+The earlier real-media PECE validation at **16/3** for 10 outer intervals and **29/8** for 19 outer intervals belongs to the previous conservative predicted-lane-refresh implementation. It remains useful evidence for the phase isolation and exact-corrected persistence design, but it is not treated as validation of the endpoint-bridge selector modes.
+
+The validated 19-call ordinary PEC production cadence remains **11 actual / 8 forecast**. Final PEC real-media validation with DiffAid, Untwist-RoPE and H3 Continuum completed at 11/8 in both the initial and continuation chunks with zero fallbacks.
+
+Deterministic PEC keeps the ordinary conservative behavior because the stochastic solver-space adaptation is not needed. Active PECE retains the phase-specific predicted/exact-corrected topology even when tau or `s_noise` disables stochastic injection. Offline smoothing replay is intentionally disabled for SA-Solver: replaying changed denoiser values would change Stochastic Adams history even with a reproducible random stream, so reviewed SA runs use one causal Spectrum pass.
 
 Supported tau configuration is the native default or the exact reviewed closure produced by native `get_tau_interval_func`. Arbitrary tau callables fail closed and are never invoked speculatively during validation. Custom callable `noise_sampler` values are accepted without inspection or pre-drawing. `simple_order_2` changes the Adams coefficient calculation but not the reviewed model-call topology.
 
@@ -287,7 +335,7 @@ ComfyUI-TiledDiffusion's current `KSAMPLER.sample(*args, **kwargs)` passthrough 
 
 Warmup and tail constraints are always actual. Reviewed samplers also limit the causal forecast horizon and require actual refreshes.
 
-For ordinary one-lane samplers, the default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins. State-conditioned stochastic samplers deliberately suppress that bootstrap. Stochastic SEEDS uses its exact outer stages as fresh anchors for the shared residual history; SA-Solver uses its sampler-specific stochastic interval and Adams-memory safeguards described above.
+For ordinary one-lane samplers, the default degree-1 bootstrap can reuse step 0 as a one-point hold for step 1. Step 2 then runs actual before normal two-anchor degree-1 forecasting begins. State-conditioned stochastic SEEDS deliberately suppresses that bootstrap and uses exact outer stages as fresh anchors for its shared residual history. Active PECE uses the separate `sa_pece_forecast_policy` selector. The released default `balanced` keeps P0/P1 exact; `max_speed` permits the solver-owned P1 one-anchor hold for one additional forecast, while `stable_start` also keeps P2 exact.
 
 Typical 20-step Euler/ER-SDE single-pass cadence is approximately:
 

--- a/comfyui_spectrum_h3/config.py
+++ b/comfyui_spectrum_h3/config.py
@@ -32,6 +32,7 @@ class SpectrumH3Config:
     generic_correction_limiter: str = "hard_clip"
     generic_correction_limit: float = 0.40
     generic_correction_attenuation: str = "no_attenuation"
+    sa_pece_forecast_policy: str = "balanced"
 
     def __post_init__(self) -> None:
         trajectory_modes = {
@@ -175,6 +176,14 @@ class SpectrumH3Config:
                 "generic_correction_attenuation must be 'mode_default', "
                 "'no_attenuation', 'general_confidence', 'correction_reliability', "
                 "or 'combined_conservative'"
+            )
+        if not isinstance(self.sa_pece_forecast_policy, str) or self.sa_pece_forecast_policy not in {
+            "balanced",
+            "stable_start",
+            "max_speed",
+        }:
+            raise ValueError(
+                "sa_pece_forecast_policy must be 'balanced', 'stable_start', or 'max_speed'"
             )
         if self.generic_correction_limiter not in {
             "rational",

--- a/comfyui_spectrum_h3/external_patch_compat.py
+++ b/comfyui_spectrum_h3/external_patch_compat.py
@@ -829,9 +829,13 @@ def _log_effective_step(runtime: Any, decision: dict[str, Any]) -> None:
     if not runtime.config.debug:
         return
     sampling.LOG.warning(
-        "Spectrum H3 step run_id=%s step=%s coordinate=%.6f decision=%s reason=%s history=%s window=%.3f",
+        "Spectrum H3 step run_id=%s step=%s outer_step=%s stage=%s phase=%s "
+        "coordinate=%.6f decision=%s reason=%s history=%s window=%.3f",
         decision["run_id"],
         decision["step_id"],
+        decision["policy_step_id"],
+        decision["stage_index"],
+        decision["phase"],
         decision["coordinate"],
         "actual" if decision["actual"] else "forecast",
         decision["reason"],

--- a/comfyui_spectrum_h3/nodes.py
+++ b/comfyui_spectrum_h3/nodes.py
@@ -282,6 +282,21 @@ class SpectrumApplyMiniMaxH3:
                         ),
                     },
                 ),
+                # Appended last so existing saved workflow widget arrays retain
+                # the positional meaning of every older Spectrum input.
+                "sa_pece_forecast_policy": (
+                    ["max_speed", "balanced", "stable_start"],
+                    {
+                        "default": "balanced",
+                        "tooltip": (
+                            "Active SA-Solver PECE only. balanced is the released default after matched production testing; "
+                            "it keeps P0/P1 exact (clean 10-step topology: 11 actual / 8 forecast). max_speed protects only P0 "
+                            "(10/9) and trades one more actual evaluation for speed, while stable_start keeps P0/P1/P2 exact "
+                            "(12/7). Continuum, hard patch transitions, fallbacks, force-actual conditions, and a larger "
+                            "warmup_steps value always remain authoritative."
+                        ),
+                    },
+                ),
             },
         }
 
@@ -318,6 +333,7 @@ class SpectrumApplyMiniMaxH3:
         generic_correction_limiter="hard_clip",
         generic_correction_limit=0.40,
         generic_correction_attenuation="no_attenuation",
+        sa_pece_forecast_policy="balanced",
     ):
         if not enabled:
             return (model,)
@@ -370,6 +386,7 @@ class SpectrumApplyMiniMaxH3:
             generic_correction_attenuation=str(generic_correction_attenuation),
             generic_correction_limiter=str(generic_correction_limiter),
             generic_correction_limit=float(generic_correction_limit),
+            sa_pece_forecast_policy=str(sa_pece_forecast_policy),
             debug=bool(debug),
         ).validate()
         patched = model.clone()

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -52,6 +52,15 @@ class OfflineReplayAbort(RuntimeError):
     """Internal signal used to return the valid first-pass result after replay failure."""
 
 
+@dataclass(frozen=True, slots=True)
+class SolverCallDescriptor:
+    """Identity of one model evaluation inside an outer solver interval."""
+
+    outer_step: int
+    stage_index: int
+    phase: str
+
+
 @dataclass(slots=True)
 class RuntimeStats:
     run_id: int = 0
@@ -63,6 +72,8 @@ class RuntimeStats:
     forecast_model_calls: int = 0
     forecast_fallbacks: int = 0
     bypassed_steps: int = 0
+    phase_actual_steps: dict[str, int] = field(default_factory=dict)
+    phase_forecast_steps: dict[str, int] = field(default_factory=dict)
     causal_video_blend_weight: float = 0.0
     causal_audio_blend_weight: float = 0.0
     history_archive_seconds: float = 0.0
@@ -203,11 +214,14 @@ class _CallState:
 @dataclass(slots=True)
 class _StepState:
     step_id: int
+    policy_step_id: int
     coordinate: float
     adaptive_recompute: bool
     mode: str
     reason: str
     stage_index: int = 0
+    phase: str = "model"
+    retain_history: bool = True
     state_residual_mode: bool = False
     bootstrap_forecast: bool = False
     calls: list[_CallState] = field(default_factory=list)
@@ -230,9 +244,14 @@ class _RunState:
     total_steps: int
     policy_steps: int
     stage_count: int
+    logical_call_topology: tuple[SolverCallDescriptor, ...] | None
     state_conditioned_residual: bool
     separate_stage_histories: bool
     forecastable_stage_indices: tuple[int, ...] | None
+    history_stage_indices: frozenset[int]
+    history_step_ids: frozenset[int] | None
+    tail_actual_stage_indices: frozenset[int] | None
+    allow_state_conditioned_bootstrap: bool
     forced_actual_step_ids: frozenset[int]
     forced_actual_steps_advance_window: bool
     model_aware_can_force_actual: bool
@@ -243,6 +262,7 @@ class _RunState:
     min_actual_steps_after_forecast: int
     min_tail_actual_steps: int
     min_actual_prefix_steps: int
+    min_sampler_actual_prefix_steps: int
     next_step_id: int = 0
 
 
@@ -263,6 +283,7 @@ class RuntimeRollbackSnapshot:
     experiment_disable_reason: str | None
     last_completed_mode: str | None
     last_completed_step_id: int | None
+    last_completed_reason: str | None
     model_aware_state: dict[str, float | int]
     stats: RuntimeStats
 
@@ -333,6 +354,14 @@ class SpectrumH3Runtime:
         return 0 if self._step is None else self._step.stage_index
 
     @property
+    def active_solver_phase(self) -> str | None:
+        return None if self._step is None else self._step.phase
+
+    @property
+    def active_policy_step_id(self) -> int | None:
+        return None if self._step is None else self._step.policy_step_id
+
+    @property
     def active_state_conditioned_residual(self) -> bool:
         return bool(self._step is not None and self._step.state_residual_mode)
 
@@ -352,6 +381,7 @@ class SpectrumH3Runtime:
             self._run is not None
             and self._run.state_conditioned_residual
             and self._run.stage_count > 1
+            and self._run.logical_call_topology is None
         )
 
     @property
@@ -373,6 +403,10 @@ class SpectrumH3Runtime:
     @property
     def last_completed_step_id(self) -> int | None:
         return self._last_completed_step_id
+
+    @property
+    def last_completed_reason(self) -> str | None:
+        return self._last_completed_reason
 
     @property
     def experiment_disabled_reason(self) -> str | None:
@@ -700,12 +734,18 @@ class SpectrumH3Runtime:
         min_actual_steps_after_forecast: int = 0,
         min_tail_actual_steps: int = 0,
         min_actual_prefix_steps: int = 0,
+        min_sampler_actual_prefix_steps: int = 0,
         expected_model_calls: int | None = None,
         stage_count: int = 1,
+        logical_call_topology: tuple[SolverCallDescriptor, ...] | None = None,
         state_conditioned_residual: bool = False,
         stochastic_multistage: bool | None = None,
         separate_stage_histories: bool | None = None,
         forecastable_stage_indices: tuple[int, ...] | None = None,
+        history_stage_indices: tuple[int, ...] | None = None,
+        history_step_ids: tuple[int, ...] | None = None,
+        tail_actual_stage_indices: tuple[int, ...] | None = None,
+        allow_state_conditioned_bootstrap: bool = False,
         forced_actual_step_ids: tuple[int, ...] | None = None,
         forced_actual_steps_advance_window: bool = False,
         model_aware_can_force_actual: bool = True,
@@ -722,13 +762,41 @@ class SpectrumH3Runtime:
             ("min_actual_steps_after_forecast", min_actual_steps_after_forecast),
             ("min_tail_actual_steps", min_tail_actual_steps),
             ("min_actual_prefix_steps", min_actual_prefix_steps),
+            ("min_sampler_actual_prefix_steps", min_sampler_actual_prefix_steps),
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{name} must be an integer >= 0")
         if isinstance(stage_count, bool) or not isinstance(stage_count, int) or stage_count < 1:
             raise ValueError("stage_count must be an integer >= 1")
+        if logical_call_topology is not None:
+            normalized_call_topology = tuple(logical_call_topology)
+            if any(
+                not isinstance(descriptor, SolverCallDescriptor)
+                for descriptor in normalized_call_topology
+            ):
+                raise ValueError(
+                    "logical_call_topology entries must be SolverCallDescriptor values"
+                )
+            if any(
+                descriptor.outer_step < 0
+                or descriptor.stage_index < 0
+                or descriptor.stage_index >= stage_count
+                or not descriptor.phase
+                for descriptor in normalized_call_topology
+            ):
+                raise ValueError(
+                    "logical_call_topology contains an invalid outer step, stage, or phase"
+                )
+        else:
+            normalized_call_topology = None
         if type(state_conditioned_residual) is not bool:
             raise ValueError("state_conditioned_residual must be boolean")
+        if type(allow_state_conditioned_bootstrap) is not bool:
+            raise ValueError("allow_state_conditioned_bootstrap must be boolean")
+        if allow_state_conditioned_bootstrap and not state_conditioned_residual:
+            raise ValueError(
+                "allow_state_conditioned_bootstrap requires state_conditioned_residual"
+            )
         if type(forced_actual_steps_advance_window) is not bool:
             raise ValueError("forced_actual_steps_advance_window must be boolean")
         if type(model_aware_can_force_actual) is not bool:
@@ -748,10 +816,11 @@ class SpectrumH3Runtime:
             else bool(separate_stage_histories)
         )
         if resolved_stage_histories and (
-            not state_conditioned_residual or stage_count < 2
+            stage_count < 2
+            or (not state_conditioned_residual and normalized_call_topology is None)
         ):
             raise ValueError(
-                "separate_stage_histories requires multistage state-conditioned residual mode"
+                "separate_stage_histories requires an explicit multistage topology"
             )
         if forecastable_stage_indices is not None:
             normalized_forecastable_stages = tuple(forecastable_stage_indices)
@@ -770,6 +839,48 @@ class SpectrumH3Runtime:
                 )
         else:
             normalized_forecastable_stages = None
+        if history_stage_indices is not None:
+            normalized_history_stages = tuple(history_stage_indices)
+            if len(set(normalized_history_stages)) != len(normalized_history_stages):
+                raise ValueError("history_stage_indices must not contain duplicates")
+            if any(
+                isinstance(index, bool)
+                or not isinstance(index, int)
+                or index < 0
+                or index >= stage_count
+                for index in normalized_history_stages
+            ):
+                raise ValueError(
+                    "history_stage_indices entries must be integer stage indices "
+                    "within [0, stage_count)"
+                )
+        else:
+            normalized_history_stages = tuple(range(stage_count))
+        if tail_actual_stage_indices is not None:
+            normalized_tail_actual_stages = tuple(tail_actual_stage_indices)
+            if len(set(normalized_tail_actual_stages)) != len(
+                normalized_tail_actual_stages
+            ):
+                raise ValueError("tail_actual_stage_indices must not contain duplicates")
+            if any(
+                isinstance(index, bool)
+                or not isinstance(index, int)
+                or index < 0
+                or index >= stage_count
+                for index in normalized_tail_actual_stages
+            ):
+                raise ValueError(
+                    "tail_actual_stage_indices entries must be integer stage indices "
+                    "within [0, stage_count)"
+                )
+        else:
+            normalized_tail_actual_stages = None
+        if normalized_forecastable_stages is not None and not set(
+            normalized_forecastable_stages
+        ).issubset(normalized_history_stages):
+            raise ValueError(
+                "every forecastable stage must retain a Spectrum history"
+            )
         if forced_actual_step_ids is not None:
             normalized_forced_actual_steps = tuple(forced_actual_step_ids)
             if len(set(normalized_forced_actual_steps)) != len(normalized_forced_actual_steps):
@@ -799,6 +910,37 @@ class SpectrumH3Runtime:
             total_steps = expected_model_calls
         else:
             total_steps = schedule_steps
+        if normalized_call_topology is not None:
+            if len(normalized_call_topology) != total_steps:
+                raise ValueError(
+                    "logical_call_topology length must equal the total model-call count"
+                )
+            if any(
+                descriptor.outer_step >= schedule_steps
+                for descriptor in normalized_call_topology
+            ):
+                raise ValueError(
+                    "logical_call_topology outer steps must be within the sigma schedule"
+                )
+        if history_step_ids is not None:
+            normalized_history_step_ids = tuple(history_step_ids)
+            if len(set(normalized_history_step_ids)) != len(
+                normalized_history_step_ids
+            ):
+                raise ValueError("history_step_ids must not contain duplicates")
+            if any(
+                isinstance(index, bool)
+                or not isinstance(index, int)
+                or index < 0
+                or index >= total_steps
+                for index in normalized_history_step_ids
+            ):
+                raise ValueError(
+                    "history_step_ids entries must be integer step indices within "
+                    "[0, total_steps)"
+                )
+        else:
+            normalized_history_step_ids = None
         if any(index >= total_steps for index in normalized_forced_actual_steps):
             raise ValueError(
                 "forced_actual_step_ids entries must be smaller than total model-call count"
@@ -819,9 +961,22 @@ class SpectrumH3Runtime:
             total_steps=total_steps,
             policy_steps=schedule_steps,
             stage_count=stage_count,
+            logical_call_topology=normalized_call_topology,
             state_conditioned_residual=bool(state_conditioned_residual),
             separate_stage_histories=resolved_stage_histories,
             forecastable_stage_indices=normalized_forecastable_stages,
+            history_stage_indices=frozenset(normalized_history_stages),
+            history_step_ids=(
+                None
+                if normalized_history_step_ids is None
+                else frozenset(normalized_history_step_ids)
+            ),
+            tail_actual_stage_indices=(
+                None
+                if normalized_tail_actual_stages is None
+                else frozenset(normalized_tail_actual_stages)
+            ),
+            allow_state_conditioned_bootstrap=allow_state_conditioned_bootstrap,
             forced_actual_step_ids=frozenset(normalized_forced_actual_steps),
             forced_actual_steps_advance_window=forced_actual_steps_advance_window,
             model_aware_can_force_actual=model_aware_can_force_actual,
@@ -834,7 +989,15 @@ class SpectrumH3Runtime:
             min_actual_prefix_steps=min(
                 min_actual_prefix_steps,
                 schedule_steps
-                if state_conditioned_residual and stage_count > 1
+                if normalized_call_topology is not None
+                or (state_conditioned_residual and stage_count > 1)
+                else total_steps,
+            ),
+            min_sampler_actual_prefix_steps=min(
+                min_sampler_actual_prefix_steps,
+                schedule_steps
+                if normalized_call_topology is not None
+                or (state_conditioned_residual and stage_count > 1)
                 else total_steps,
             ),
         )
@@ -878,6 +1041,7 @@ class SpectrumH3Runtime:
         self._experiment_disable_reason = None
         self._last_completed_mode = None
         self._last_completed_step_id = None
+        self._last_completed_reason = None
         self._rollback_requested = False
         self._forced_actual_reason = None
         self._forced_actual_is_replay = False
@@ -1073,18 +1237,43 @@ class SpectrumH3Runtime:
         if step_id >= self._run.total_steps:
             raise RuntimeError("predict_noise call count exceeded the supplied sigma schedule")
         coordinate = self.coordinate_for_timestep(timestep)
-        use_multistage_topology = (
-            self._run.state_conditioned_residual and self._run.stage_count > 1
+        descriptor = (
+            self._run.logical_call_topology[step_id]
+            if self._run.logical_call_topology is not None
+            else None
+        )
+        use_multistage_topology = bool(
+            descriptor is not None
+            or (self._run.state_conditioned_residual and self._run.stage_count > 1)
         )
         stage_index = (
-            step_id % self._run.stage_count if use_multistage_topology else 0
+            descriptor.stage_index
+            if descriptor is not None
+            else step_id % self._run.stage_count
+            if use_multistage_topology
+            else 0
         )
+        policy_step_id = (
+            descriptor.outer_step
+            if descriptor is not None
+            else step_id // self._run.stage_count
+            if use_multistage_topology
+            else step_id
+        )
+        phase = descriptor.phase if descriptor is not None else "model"
         if self._run.separate_stage_histories:
             self.forecaster = self._stage_forecasters[stage_index]
             self.model_aware = self._stage_model_aware[stage_index]
         else:
             self.forecaster = self._primary_forecaster
             self.model_aware = self._primary_model_aware
+        retain_history = (
+            stage_index in self._run.history_stage_indices
+            and (
+                self._run.history_step_ids is None
+                or step_id in self._run.history_step_ids
+            )
+        )
 
         if self._offline_phase == "replay":
             archive = self._offline_archive
@@ -1098,33 +1287,40 @@ class SpectrumH3Runtime:
                 )
             self._step = _StepState(
                 step_id=step_id,
+                policy_step_id=policy_step_id,
                 coordinate=coordinate,
                 adaptive_recompute=False,
                 mode="replay",
                 reason="offline smoothing replay",
                 stage_index=stage_index,
-                state_residual_mode=self._run.state_conditioned_residual,
+                phase=phase,
+                retain_history=retain_history,
+                state_residual_mode=(
+                    self._run.state_conditioned_residual
+                    and stage_index in self._run.history_stage_indices
+                ),
             )
             self._run.next_step_id += 1
             return {
                 "run_id": self._run.run_id,
                 "step_id": step_id,
+                "policy_step_id": policy_step_id,
+                "stage_index": stage_index,
+                "phase": phase,
                 "coordinate": coordinate,
                 "actual": False,
                 "reason": "offline smoothing replay",
             }
 
-        use_multistage_topology = (
-            self._run.state_conditioned_residual and self._run.stage_count > 1
-        )
-        policy_step_id = (
-            step_id // self._run.stage_count if use_multistage_topology else step_id
-        )
         policy_total_steps = (
             self._run.policy_steps if use_multistage_topology else self._run.total_steps
         )
         effective_tail = max(self.config.tail_actual_steps, self._run.min_tail_actual_steps)
         tail_start = max(0, policy_total_steps - effective_tail)
+        tail_stage_protected = (
+            self._run.tail_actual_stage_indices is None
+            or stage_index in self._run.tail_actual_stage_indices
+        )
         advances_window = False
         bootstrap_forecast = False
         rollback_replay = False
@@ -1144,9 +1340,11 @@ class SpectrumH3Runtime:
             consumes_feedback_refresh = True
         elif policy_step_id < self._run.min_actual_prefix_steps:
             actual, reason = True, "H3 Continuum actual prefix"
+        elif policy_step_id < self._run.min_sampler_actual_prefix_steps:
+            actual, reason = True, "sampler policy actual prefix"
         elif policy_step_id < self.config.warmup_steps:
             actual, reason = True, "warmup"
-        elif policy_step_id >= tail_start:
+        elif policy_step_id >= tail_start and tail_stage_protected:
             actual, reason = True, "final actual tail"
         elif step_id in self._run.forced_actual_step_ids:
             actual, reason = True, "sampler-required exact step"
@@ -1161,6 +1359,13 @@ class SpectrumH3Runtime:
             and self._stage_required_actual_refreshes.get(stage_index, 0) > 0
         ):
             actual, reason = True, "post-forecast stage-lane refresh"
+        elif (
+            self._run.allow_state_conditioned_bootstrap
+            and policy_step_id == 1
+            and self.forecaster.history_length == 1
+        ):
+            actual, reason = False, "solver-owned one-point bootstrap forecast"
+            bootstrap_forecast = True
         elif (
             self.config.bootstrap_first_forecast
             and not self._run.state_conditioned_residual
@@ -1250,12 +1455,18 @@ class SpectrumH3Runtime:
 
         self._step = _StepState(
             step_id=step_id,
+            policy_step_id=policy_step_id,
             coordinate=coordinate,
             adaptive_recompute=advances_window,
             mode="actual" if actual else "forecast",
             reason=reason,
             stage_index=stage_index,
-            state_residual_mode=self._run.state_conditioned_residual,
+            phase=phase,
+            retain_history=retain_history,
+            state_residual_mode=(
+                self._run.state_conditioned_residual
+                and (not actual or retain_history)
+            ),
             bootstrap_forecast=bootstrap_forecast,
             rollback_replay=rollback_replay,
             consumes_feedback_refresh=consumes_feedback_refresh,
@@ -1266,6 +1477,9 @@ class SpectrumH3Runtime:
         return {
             "run_id": self._run.run_id,
             "step_id": step_id,
+            "policy_step_id": policy_step_id,
+            "stage_index": stage_index,
+            "phase": phase,
             "coordinate": coordinate,
             "actual": actual,
             "reason": reason,
@@ -1387,6 +1601,13 @@ class SpectrumH3Runtime:
             raise RuntimeError(
                 f"actual H3 feature shape {tuple(feature.shape)} does not match {call.expected_shape}"
             )
+        if not step.retain_history:
+            # Exact-only solver phases (currently active PECE corrected-state
+            # evaluations) need transaction/accounting identity, not a duplicate
+            # archived final-block tensor. Their solver value is consumed directly
+            # by the sampler and never becomes Spectrum forecast evidence.
+            call.observed_actual = True
+            return
         started = time.perf_counter()
         feature_bytes = feature.numel() * feature.element_size()
         self.log_offline_transition(
@@ -2359,6 +2580,7 @@ class SpectrumH3Runtime:
                 self.stats.offline_replay_smoothed_steps += 1
             self._last_completed_mode = "replay"
             self._last_completed_step_id = step.step_id
+            self._last_completed_reason = step.reason
             self._step = None
             return
 
@@ -2377,13 +2599,16 @@ class SpectrumH3Runtime:
                     self._run.min_actual_steps_after_forecast,
                 )
             self.stats.forecast_steps += 1
+            self.stats.phase_forecast_steps[step.phase] = (
+                self.stats.phase_forecast_steps.get(step.phase, 0) + 1
+            )
             self.stats.forecast_model_calls += len(step.calls)
             if step.model_aware_decision is not None:
                 self.stats.model_aware_forecasts += 1
         else:
             if any(call.used_forecast for call in step.calls):
                 raise RuntimeError("actual solver step retained a forecasted subcall")
-            combined = self._aggregate_actual(step)
+            combined = self._aggregate_actual(step) if step.retain_history else None
             residual_result = self._aggregate_residual(step)
             if combined is not None and not self._disabled:
                 exact_head_weights: dict[str, torch.Tensor] = {}
@@ -2530,22 +2755,24 @@ class SpectrumH3Runtime:
             if step.consumes_feedback_refresh:
                 self._required_feedback_actuals = max(0, self._required_feedback_actuals - 1)
             self.stats.actual_steps += 1
+            self.stats.phase_actual_steps[step.phase] = (
+                self.stats.phase_actual_steps.get(step.phase, 0) + 1
+            )
             if step.model_aware_forced_actual:
                 self.stats.adaptive_extra_nfes += 1
-            self.stats.actual_transformer_calls += len(step.actual_records)
+            observed_actual_calls = sum(
+                int(call.observed_actual) for call in step.calls
+            )
+            self.stats.actual_transformer_calls += observed_actual_calls
             if step.consumes_feedback_refresh:
                 self.stats.feedback_refreshes += 1
             if step.rollback_replay:
-                self.stats.replayed_transformer_calls += len(step.actual_records)
+                self.stats.replayed_transformer_calls += observed_actual_calls
             if (
                 step.adaptive_recompute
                 and not step.fallback
                 and not self._disabled
-                and (
-                    step.step_id // self._run.stage_count
-                    if self._run.state_conditioned_residual and self._run.stage_count > 1
-                    else step.step_id
-                ) >= self.config.warmup_steps
+                and step.policy_step_id >= self.config.warmup_steps
             ):
                 window_ceiling = max(float(self.config.window_size), float(self.config.max_history))
                 self._current_window = min(
@@ -2567,6 +2794,7 @@ class SpectrumH3Runtime:
         self.stats.current_window = self._current_window
         self._last_completed_mode = step.mode
         self._last_completed_step_id = step.step_id
+        self._last_completed_reason = step.reason
         self._step = None
         self.log_offline_transition(
             "finalize_step_end",
@@ -2603,8 +2831,13 @@ class SpectrumH3Runtime:
             experiment_disable_reason=self._experiment_disable_reason,
             last_completed_mode=self._last_completed_mode,
             last_completed_step_id=self._last_completed_step_id,
+            last_completed_reason=self._last_completed_reason,
             model_aware_state=self.model_aware.snapshot(),
-            stats=replace(self.stats),
+            stats=replace(
+                self.stats,
+                phase_actual_steps=dict(self.stats.phase_actual_steps),
+                phase_forecast_steps=dict(self.stats.phase_forecast_steps),
+            ),
         )
 
     def restore_rollback_snapshot(self, snapshot: RuntimeRollbackSnapshot) -> None:
@@ -2619,7 +2852,11 @@ class SpectrumH3Runtime:
         discarded_actual_calls = max(
             0, current.actual_transformer_calls - snapshot.stats.actual_transformer_calls
         )
-        restored = replace(snapshot.stats)
+        restored = replace(
+            snapshot.stats,
+            phase_actual_steps=dict(snapshot.stats.phase_actual_steps),
+            phase_forecast_steps=dict(snapshot.stats.phase_forecast_steps),
+        )
         restored.forecast_model_calls += speculative_calls
         restored.actual_transformer_calls += discarded_actual_calls
         restored.speculative_forecast_calls += speculative_calls
@@ -2727,6 +2964,7 @@ class SpectrumH3Runtime:
         self._experiment_disable_reason = snapshot.experiment_disable_reason
         self._last_completed_mode = snapshot.last_completed_mode
         self._last_completed_step_id = snapshot.last_completed_step_id
+        self._last_completed_reason = snapshot.last_completed_reason
         self.model_aware.restore(snapshot.model_aware_state)
         restored.model_aware_correction_seconds = (
             restored.model_aware_causal_correction_seconds
@@ -2764,6 +3002,8 @@ class SpectrumH3Runtime:
         if self._run is None or not self._run.state_conditioned_residual:
             return "absolute_hidden"
         if self._run.stage_count > 1:
+            if self._run.history_step_ids is not None:
+                return "state_conditioned_residual_endpoint_history"
             return (
                 "state_conditioned_residual_stage_lanes"
                 if self._run.separate_stage_histories
@@ -2875,18 +3115,32 @@ class SpectrumH3Runtime:
                     )
                 )
         subspace_summary = " ".join(subspace_parts)
+        phase_names = sorted(
+            set(self.stats.phase_actual_steps) | set(self.stats.phase_forecast_steps)
+        )
+        phase_summary = ",".join(
+            f"{phase}:a{self.stats.phase_actual_steps.get(phase, 0)}"
+            f"/f{self.stats.phase_forecast_steps.get(phase, 0)}"
+            for phase in phase_names
+        )
         return (
             f"run_id={self.stats.run_id} sampler={self.stats.sampler_name} "
             f"steps={self.stats.total_steps} "
+            f"outer_steps={self._run.policy_steps if self._run is not None else self.stats.total_steps} "
+            f"h3_logical_calls={self.stats.total_steps} "
             f"stage_count={self._run.stage_count if self._run is not None else 1} "
             f"state_conditioned_residual={self._run.state_conditioned_residual if self._run is not None else False} "
-            f"stage_histories={'separate' if self._run is not None and self._run.separate_stage_histories else 'shared'} "
+            f"stage_histories={('shared_endpoint' if self._run is not None and self._run.history_step_ids is not None else 'separate' if self._run is not None and self._run.separate_stage_histories else 'shared')} "
             f"feature_geometry={self._feature_geometry_name()} "
             f"forecastable_stages={self._run.forecastable_stage_indices if self._run is not None else None} "
+            f"history_stages={tuple(sorted(self._run.history_stage_indices)) if self._run is not None else None} "
+            f"continuum_prefix_steps={self._run.min_actual_prefix_steps if self._run is not None else 0} "
+            f"sampler_prefix_steps={self._run.min_sampler_actual_prefix_steps if self._run is not None else 0} "
             f"forced_actual_steps={len(self._run.forced_actual_step_ids) if self._run is not None else 0} "
             f"stage_refresh_pending={sum(self._stage_required_actual_refreshes.values())} "
             f"actual_steps={self.stats.actual_steps} "
             f"forecast_steps={self.stats.forecast_steps} "
+            f"phase_counts={phase_summary or '-'} "
             f"actual_transformer_calls={self.stats.actual_transformer_calls} "
             f"forecast_calls={self.stats.forecast_model_calls} "
             f"fallbacks={self.stats.forecast_fallbacks} "

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -29,7 +29,12 @@ from .refdelta_interop import (
     RefDeltaInteropError,
 )
 from .rollback import run_selective_rollback_euler
-from .runtime import ForecastRetryActual, OfflineReplayAbort, SpectrumH3Runtime
+from .runtime import (
+    ForecastRetryActual,
+    OfflineReplayAbort,
+    SolverCallDescriptor,
+    SpectrumH3Runtime,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -37,6 +42,8 @@ BINDING_KEY = "spectrum_h3_binding"
 RUNTIME_KEY = "spectrum_h3_runtime"
 RUN_ID_KEY = "spectrum_h3_run_id"
 STEP_ID_KEY = "spectrum_h3_step_id"
+OUTER_STEP_ID_KEY = "spectrum_h3_outer_step_id"
+SOLVER_PHASE_KEY = "spectrum_h3_solver_phase"
 COORDINATE_KEY = "spectrum_h3_coordinate"
 ACTUAL_KEY = "spectrum_h3_actual"
 REASON_KEY = "spectrum_h3_reason"
@@ -80,6 +87,12 @@ SA_SOLVER_HELPER_DIGESTS = {
     "compute_stochastic_adams_b_coeffs": "f2480f0fc36f70f48909779e9604fa9dcb4e2a475b0040fd83c6e9e01f65e6e2",
     "get_tau_interval_func": "f301a5d271a219a7f8b709e264327477945ddb7b2cadd40d700392c987afb3bb",
 }
+SA_PECE_POLICY_MIN_ACTUAL_PREFIX = {
+    "max_speed": 1,
+    "balanced": 2,
+    "stable_start": 3,
+}
+
 SA_SOLVER_TRACKED_OPTIONS = {
     "sample_sa_solver": frozenset(
         {
@@ -214,6 +227,17 @@ def _seeds_stage_schedule_reason(sigmas: Any) -> str | None:
     return None
 
 
+def _sa_pece_policy_min_actual_prefix(runtime: SpectrumH3Runtime) -> int:
+    """Return the PECE outer-step prefix protected by the selected user policy."""
+    try:
+        return SA_PECE_POLICY_MIN_ACTUAL_PREFIX[runtime.config.sa_pece_forecast_policy]
+    except KeyError as exc:
+        raise RuntimeError(
+            "Spectrum H3 active PECE received an unreviewed forecast policy: "
+            f"{runtime.config.sa_pece_forecast_policy!r}"
+        ) from exc
+
+
 def _sa_solver_expected_model_calls(sampler: Any, sigmas: Any) -> int | None:
     """Count native SA-Solver denoiser calls, including active PECE evaluations."""
     name = sampler_name(sampler)
@@ -232,6 +256,44 @@ def _sa_solver_expected_model_calls(sampler: Any, sigmas: Any) -> int | None:
     if not use_pece or corrector_order == 0 or outer_steps == 0:
         return outer_steps
     return 2 * outer_steps - 1
+
+
+def _sa_solver_call_topology(
+    sampler: Any,
+    sigmas: Any,
+) -> tuple[SolverCallDescriptor, ...] | None:
+    """Describe every native SA model call without inventing phase time offsets."""
+    expected = _sa_solver_expected_model_calls(sampler, sigmas)
+    if expected is None:
+        return None
+    name = sampler_name(sampler)
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return None
+    corrector_order = options.get("corrector_order", 4)
+    use_pece = name == "sample_sa_solver_pece" or options.get("use_pece", False) is True
+    active_pece = bool(use_pece and corrector_order > 0)
+    outer_steps = max(0, int(sigmas.numel()) - 1)
+    topology: list[SolverCallDescriptor] = []
+    for outer_step in range(outer_steps):
+        topology.append(
+            SolverCallDescriptor(
+                outer_step=outer_step,
+                stage_index=0,
+                phase="predicted",
+            )
+        )
+        if active_pece and outer_step > 0:
+            topology.append(
+                SolverCallDescriptor(
+                    outer_step=outer_step,
+                    stage_index=1,
+                    phase="corrected",
+                )
+            )
+    if len(topology) != expected:
+        return None
+    return tuple(topology)
 
 
 def _sa_solver_prefix_model_calls(
@@ -320,6 +382,19 @@ def _sa_solver_is_stochastic(sampler: Any) -> bool:
     if values is None:
         return True
     return values["eta"] > 0.0
+
+
+def _sa_solver_is_active_pece(sampler: Any) -> bool:
+    """Return whether native SA performs the corrected-state PECE evaluation."""
+    name = sampler_name(sampler)
+    if name not in SA_SOLVER_SAMPLERS:
+        return False
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        return False
+    use_pece = name == "sample_sa_solver_pece" or options.get("use_pece", False) is True
+    corrector_order = options.get("corrector_order", 4)
+    return bool(use_pece and type(corrector_order) is int and corrector_order > 0)
 
 
 def _sa_solver_stochastic_protection(
@@ -418,18 +493,10 @@ def _sa_solver_option_contract(name: str, options: Any) -> str | None:
     if type(options.get("simple_order_2", False)) is not bool:
         return "SA-Solver simple_order_2 must be boolean"
 
-    use_pece = name == "sample_sa_solver_pece"
     if name == "sample_sa_solver":
         configured_use_pece = options.get("use_pece", False)
         if type(configured_use_pece) is not bool:
             return "SA-Solver use_pece must be boolean"
-        use_pece = configured_use_pece
-    if use_pece and options.get("corrector_order", 4) > 0:
-        return (
-            "SA-Solver PECE with an active corrector has duplicate-sigma "
-            "predicted/corrected states and is not reviewed for Spectrum forecasting"
-        )
-
     noise_sampler = options.get("noise_sampler")
     if noise_sampler is not None and not callable(noise_sampler):
         return "SA-Solver noise_sampler must be callable or None"
@@ -762,15 +829,20 @@ def _sa_predict_causal_denoised(
     target_lambda: torch.Tensor,
     target_step: int,
     continuum_active: bool = False,
+    allow_consecutive_extrapolation: bool = False,
 ) -> tuple[torch.Tensor, str, tuple[int, ...], torch.Tensor]:
     """Predict SA's denoised variable directly from exact actual anchors.
 
     Fresh SA predictor noise changes the model input in a direction that cannot be
-    reconstructed exactly when the H3 transformer is skipped. During an active
-    stochastic interval, do not feed the hidden-feature forecast into SA's Adams
-    equations. Instead extrapolate the solver-space denoised trajectory from exact
-    H3 anchors only. The extrapolation is causal and bounded to one previous
-    anchor interval; any untrusted geometry degenerates to a latest-actual hold.
+    reconstructed exactly when the H3 transformer is skipped. Solver-space dense
+    output therefore uses exact H3 anchors only. The extrapolation is causal and
+    bounded to one previous anchor interval; any untrusted geometry degenerates to
+    a latest-actual hold.
+
+    Ordinary stochastic PEC keeps the conservative rule that consecutive exact
+    anchors imply a hold. Active PECE may opt into consecutive-anchor secant
+    extrapolation because every forecasted predicted phase is immediately followed
+    by an exact corrected endpoint before the next predictor.
     """
     if not (
         len(actual_preds) == len(actual_lambdas) == len(actual_steps)
@@ -819,10 +891,10 @@ def _sa_predict_causal_denoised(
     ):
         raise RuntimeError("stochastic SA dense-output actual anchors are incompatible")
 
-    # Consecutive exact anchors usually mean warmup, a hard transition, or an
-    # externally forced refresh. There is no crossed forecast interval to justify
-    # a secant extrapolation yet, so hold the newest exact denoised value.
-    if latest_step - previous_step == 1:
+    # Ordinary stochastic PEC treats consecutive exact anchors as a conservative
+    # hold boundary. Active PECE can instead use the exact corrected endpoints as
+    # a one-step secant because each endpoint is native persistent Adams evidence.
+    if latest_step - previous_step == 1 and not allow_consecutive_extrapolation:
         return (
             latest_value.clone(memory_format=torch.contiguous_format),
             "latest_actual_hold_consecutive_anchors",
@@ -855,6 +927,400 @@ def _sa_predict_causal_denoised(
         (previous_step, latest_step),
         weight,
     )
+
+
+def _sample_sa_solver_pece_forecast_isolated(
+    runtime: SpectrumH3Runtime,
+    model: Any,
+    x: torch.Tensor,
+    sigmas: torch.Tensor,
+    *,
+    extra_args: dict[str, Any] | None = None,
+    callback: Any = None,
+    disable: bool = False,
+    tau_func: Any = None,
+    s_noise: float = 1.0,
+    noise_sampler: Any = None,
+    predictor_order: int = 3,
+    corrector_order: int = 4,
+    simple_order_2: bool = False,
+    continuum_active: bool = False,
+) -> torch.Tensor:
+    """Run active PECE with forecastable predicted phases and exact corrected phases.
+
+    ComfyUI evaluates the predicted state first, uses that endpoint in the current
+    corrector, then evaluates the corrected state at the same sigma. The corrected
+    evaluation replaces the predicted endpoint before the next predictor. Spectrum
+    preserves that ownership explicitly:
+
+    * a predicted-phase forecast is ephemeral and can affect only the current
+      corrector state;
+    * the corrected phase is always an actual H3 evaluation;
+    * only the corrected actual becomes the persistent endpoint for that outer
+      sigma (the initial predicted actual is retained when no corrector exists).
+
+    Spectrum feature history mirrors native PECE endpoint ownership: the initial
+    predicted actual is the first anchor, then each exact corrected evaluation
+    replaces the same-coordinate predicted phase as the persistent feature anchor.
+    Predicted phases after outer zero never enter persistent feature history, even
+    if a hard boundary forces them exact.
+
+    Every predicted-phase forecast is solver-owned. The raw hidden-feature
+    forecast completes the cheap Spectrum transaction but is never consumed by
+    SA. Instead the corrector receives a causal solver-space estimate built only
+    from exact persistent PECE endpoints. Continuum keeps its stricter latest-exact
+    hold policy for every forecast coordinate.
+    """
+    if corrector_order <= 0:
+        raise ValueError("active PECE requires corrector_order > 0")
+    if len(sigmas) <= 1:
+        return x
+
+    import comfy.k_diffusion.sa_solver as native_sa_solver
+    import comfy.k_diffusion.sampling as native_sampling
+    from tqdm.auto import trange
+
+    extra_args = {} if extra_args is None else extra_args
+    seed = extra_args.get("seed", None)
+    noise_sampler = (
+        native_sampling.default_noise_sampler(x, seed=seed)
+        if noise_sampler is None
+        else noise_sampler
+    )
+    s_in = x.new_ones([x.shape[0]])
+
+    model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
+    s_noise = s_noise * getattr(model_sampling, "noise_scale", 1.0)
+    sigmas = native_sampling.offset_first_sigma_for_snr(sigmas, model_sampling)
+    lambdas = native_sampling.sigma_to_half_log_snr(
+        sigmas,
+        model_sampling=model_sampling,
+    )
+
+    if tau_func is None:
+        start_sigma = model_sampling.percent_to_sigma(0.2)
+        end_sigma = model_sampling.percent_to_sigma(0.8)
+        tau_func = native_sa_solver.get_tau_interval_func(
+            start_sigma,
+            end_sigma,
+            eta=1.0,
+        )
+
+    max_used_order = max(predictor_order, corrector_order)
+    x_pred = x
+    h = 0.0
+    tau_t = 0.0
+    noise = 0.0
+
+    # One exact endpoint per completed outer coordinate. For outer step zero it
+    # is the predicted evaluation; for every active corrector step it is the
+    # corrected-state evaluation that native PECE assigns to pred_list[-1].
+    persistent_preds: list[torch.Tensor] = []
+    persistent_lambdas: list[torch.Tensor] = []
+    persistent_outer_steps: list[int] = []
+
+    # Dense-output anchors mirror the exact persistent PECE endpoint stream.
+    # They are kept separate from the native Adams lists only so a declared
+    # transformer discontinuity can reset interpolation geometry without changing
+    # native Adams persistence/order.
+    dense_endpoint_preds: list[torch.Tensor] = []
+    dense_endpoint_lambdas: list[torch.Tensor] = []
+    dense_endpoint_outer_steps: list[int] = []
+
+    lower_order_to_end = sigmas[-1].item() == 0
+
+    def append_bounded(
+        values: list[torch.Tensor],
+        coordinates: list[torch.Tensor],
+        outer_steps: list[int],
+        value: torch.Tensor,
+        coordinate: torch.Tensor,
+        outer_step: int,
+    ) -> None:
+        values.append(value)
+        coordinates.append(coordinate)
+        outer_steps.append(outer_step)
+        if len(values) > max_used_order:
+            del values[:-max_used_order]
+            del coordinates[:-max_used_order]
+            del outer_steps[:-max_used_order]
+
+    for i in trange(len(sigmas) - 1, disable=disable):
+        raw_predicted = model(
+            x_pred,
+            sigmas[i] * s_in,
+            **extra_args,
+        )
+        predicted_mode = runtime.last_completed_mode
+        predicted_step_id = 0 if i == 0 else 2 * i - 1
+        if runtime.last_completed_step_id not in {None, predicted_step_id}:
+            raise RuntimeError(
+                "Spectrum PECE predicted-state call arrived at the wrong logical "
+                f"coordinate (outer={i}, expected={predicted_step_id}, "
+                f"observed={runtime.last_completed_step_id})"
+            )
+        if predicted_mode not in {"actual", "forecast"}:
+            raise RuntimeError(
+                "Spectrum PECE adapter could not classify the predicted-state "
+                f"evaluation at outer step {i}"
+            )
+        predicted_actual = predicted_mode == "actual"
+        predicted_reason = getattr(runtime, "last_completed_reason", None)
+        predicted = raw_predicted
+        solver_value_source = "actual_h3" if predicted_actual else "feature_forecast"
+        if not predicted_actual:
+            predicted, dense_mode, anchor_steps, dense_alpha = (
+                _sa_predict_causal_denoised(
+                    dense_endpoint_preds,
+                    dense_endpoint_lambdas,
+                    dense_endpoint_outer_steps,
+                    target_lambda=lambdas[i],
+                    target_step=i,
+                    continuum_active=continuum_active,
+                    allow_consecutive_extrapolation=True,
+                )
+            )
+            solver_value_source = dense_mode
+            if runtime.config.debug:
+                alpha_value = float(dense_alpha.detach().to(device="cpu").item())
+                LOG.warning(
+                    "Spectrum H3 SA PECE dense output sa_outer=%s sa_phase=predicted "
+                    "scope=%s mode=%s anchor_outer_steps=%s alpha=%.8f "
+                    "raw_feature_forecast=ignored "
+                    "history_lane=persistent_endpoint_actual_only",
+                    i,
+                    (
+                        "continuum_all_forecasts"
+                        if continuum_active
+                        else "pece_all_forecasts"
+                    ),
+                    dense_mode,
+                    anchor_steps,
+                    alpha_value,
+                )
+
+        if callback is not None:
+            callback(
+                {
+                    "x": x_pred,
+                    "i": i,
+                    "sigma": sigmas[i],
+                    "sigma_hat": sigmas[i],
+                    "denoised": predicted,
+                }
+            )
+
+        # The current predicted endpoint is valid input to this corrector even
+        # when it is forecast. It is deliberately absent from persistent_preds
+        # until native PECE resolves the endpoint through the corrected phase.
+        corrector_preds = [*persistent_preds, predicted]
+        corrector_lambdas = [*persistent_lambdas, lambdas[i]]
+        if len(corrector_preds) > max_used_order:
+            corrector_preds = corrector_preds[-max_used_order:]
+            corrector_lambdas = corrector_lambdas[-max_used_order:]
+
+        predictor_order_used = min(predictor_order, len(corrector_preds))
+        corrector_order_used = 0 if i == 0 else min(
+            corrector_order,
+            len(corrector_preds),
+        )
+        if lower_order_to_end:
+            predictor_order_used = min(
+                predictor_order_used,
+                len(sigmas) - 2 - i,
+            )
+            corrector_order_used = min(
+                corrector_order_used,
+                len(sigmas) - 1 - i,
+            )
+
+        if corrector_order_used == 0:
+            x = x_pred
+            if not predicted_actual:
+                raise RuntimeError(
+                    "active PECE cannot begin without an actual initial endpoint"
+                )
+            append_bounded(
+                persistent_preds,
+                persistent_lambdas,
+                persistent_outer_steps,
+                predicted,
+                lambdas[i],
+                i,
+            )
+            append_bounded(
+                dense_endpoint_preds,
+                dense_endpoint_lambdas,
+                dense_endpoint_outer_steps,
+                predicted,
+                lambdas[i],
+                i,
+            )
+            endpoint = predicted
+            predicted_persistent = True
+        else:
+            curr_lambdas = torch.stack(
+                corrector_lambdas[-corrector_order_used:]
+            )
+            b_coeffs = native_sa_solver.compute_stochastic_adams_b_coeffs(
+                sigmas[i],
+                curr_lambdas,
+                lambdas[i - 1],
+                lambdas[i],
+                tau_t,
+                simple_order_2,
+                is_corrector_step=True,
+            )
+            pred_mat = torch.stack(
+                corrector_preds[-corrector_order_used:],
+                dim=1,
+            )
+            corr_res = torch.tensordot(
+                pred_mat,
+                b_coeffs,
+                dims=([1], [0]),
+            )
+            x = (
+                sigmas[i]
+                / sigmas[i - 1]
+                * (-(tau_t**2) * h).exp()
+                * x
+                + corr_res
+            )
+            if tau_t > 0 and s_noise > 0:
+                x = x + noise
+
+            corrected = model(
+                x,
+                sigmas[i] * s_in,
+                **extra_args,
+            )
+            corrected_mode = runtime.last_completed_mode
+            corrected_step_id = 2 * i
+            if runtime.last_completed_step_id not in {None, corrected_step_id}:
+                raise RuntimeError(
+                    "Spectrum PECE corrected-state call arrived at the wrong logical "
+                    f"coordinate (outer={i}, expected={corrected_step_id}, "
+                    f"observed={runtime.last_completed_step_id})"
+                )
+            if corrected_mode != "actual":
+                raise RuntimeError(
+                    "Spectrum PECE corrected-state phase violated its exact reanchor policy "
+                    f"at outer step {i} (mode={corrected_mode!r})"
+                )
+            append_bounded(
+                persistent_preds,
+                persistent_lambdas,
+                persistent_outer_steps,
+                corrected,
+                lambdas[i],
+                i,
+            )
+            if predicted_reason == "external patch hard sigma transition":
+                dense_endpoint_preds.clear()
+                dense_endpoint_lambdas.clear()
+                dense_endpoint_outer_steps.clear()
+                if runtime.config.debug:
+                    LOG.warning(
+                        "Spectrum H3 SA PECE dense history reset sa_outer=%s "
+                        "reason=external_patch_hard_transition "
+                        "native_adams_history=preserved",
+                        i,
+                    )
+            append_bounded(
+                dense_endpoint_preds,
+                dense_endpoint_lambdas,
+                dense_endpoint_outer_steps,
+                corrected,
+                lambdas[i],
+                i,
+            )
+            endpoint = corrected
+            predicted_persistent = False
+            if runtime.config.debug:
+                LOG.warning(
+                    "Spectrum H3 SA PECE opportunity logical_step=%s "
+                    "sa_outer=%s sa_phase=corrected sigma=%.9g "
+                    "actual_model_evaluation=1 forecast=0 "
+                    "reason=pece_exact_reanchor adams_persistent=1 "
+                    "solver_value_source=actual_h3 continuum=%s",
+                    corrected_step_id,
+                    i,
+                    float(sigmas[i].detach().to(device="cpu").item()),
+                    int(continuum_active),
+                )
+
+        if runtime.config.debug:
+            LOG.warning(
+                "Spectrum H3 SA PECE opportunity logical_step=%s "
+                "sa_outer=%s sa_phase=predicted sigma=%.9g "
+                "actual_model_evaluation=%s forecast=%s reason=%s "
+                "adams_persistent=%s solver_value_source=%s continuum=%s",
+                predicted_step_id,
+                i,
+                float(sigmas[i].detach().to(device="cpu").item()),
+                int(predicted_actual),
+                int(not predicted_actual),
+                "predicted_actual_h3" if predicted_actual else "predicted_forecast_ephemeral",
+                int(predicted_persistent),
+                solver_value_source,
+                int(continuum_active),
+            )
+
+        if sigmas[i + 1] == 0:
+            x_pred = endpoint
+            continue
+
+        if not persistent_preds:
+            raise RuntimeError("active PECE has no exact endpoint for its predictor")
+        predictor_order_used = min(predictor_order_used, len(persistent_preds))
+        tau_t = tau_func(sigmas[i + 1])
+        curr_lambdas = torch.stack(
+            persistent_lambdas[-predictor_order_used:]
+        )
+        b_coeffs = native_sa_solver.compute_stochastic_adams_b_coeffs(
+            sigmas[i + 1],
+            curr_lambdas,
+            lambdas[i],
+            lambdas[i + 1],
+            tau_t,
+            simple_order_2,
+            is_corrector_step=False,
+        )
+        pred_mat = torch.stack(
+            persistent_preds[-predictor_order_used:],
+            dim=1,
+        )
+        pred_res = torch.tensordot(
+            pred_mat,
+            b_coeffs,
+            dims=([1], [0]),
+        )
+        h = lambdas[i + 1] - lambdas[i]
+        x_pred = (
+            sigmas[i + 1]
+            / sigmas[i]
+            * (-(tau_t**2) * h).exp()
+            * x
+            + pred_res
+        )
+        if tau_t > 0 and s_noise > 0:
+            noise = (
+                noise_sampler(sigmas[i], sigmas[i + 1])
+                * sigmas[i + 1]
+                * (-2 * tau_t**2 * h).expm1().neg().sqrt()
+                * s_noise
+            )
+            x_pred = x_pred + noise
+
+    expected_last_step = 2 * (len(sigmas) - 1) - 2
+    if runtime.last_completed_step_id not in {None, expected_last_step}:
+        raise RuntimeError(
+            "Spectrum PECE completed with an unexpected logical model-call count "
+            f"(expected_last={expected_last_step}, "
+            f"observed={runtime.last_completed_step_id})"
+        )
+    return x_pred
 
 
 def _sample_sa_solver_forecast_isolated(
@@ -905,7 +1371,22 @@ def _sample_sa_solver_forecast_isolated(
     equations, and RNG draws remain unchanged.
     """
     if use_pece and corrector_order > 0:
-        raise RuntimeError("active SA-Solver PECE is not supported by the isolated-history adapter")
+        return _sample_sa_solver_pece_forecast_isolated(
+            runtime,
+            model,
+            x,
+            sigmas,
+            extra_args=extra_args,
+            callback=callback,
+            disable=disable,
+            tau_func=tau_func,
+            s_noise=s_noise,
+            noise_sampler=noise_sampler,
+            predictor_order=predictor_order,
+            corrector_order=corrector_order,
+            simple_order_2=simple_order_2,
+            continuum_active=continuum_active,
+        )
     if len(sigmas) <= 1:
         return x
 
@@ -1180,10 +1661,7 @@ def _run_solver_aware_sa(
     continuum_active = _continuum_actual_prefix(
         (extra_args or {}).get("model_options")
     ) > 0
-    if use_pece and int(options.get("corrector_order", 4)) > 0:
-        raise RuntimeError(
-            "active SA-Solver PECE reached the isolated-history adapter after preflight"
-        )
+    active_pece = bool(use_pece and int(options.get("corrector_order", 4)) > 0)
 
     def spectrum_sa_function(
         model,
@@ -1194,6 +1672,16 @@ def _run_solver_aware_sa(
         disable=False,
         **run_options,
     ):
+        # Native `sample_sa_solver` exposes `use_pece` through KSAMPLER
+        # extra_options. Consume that reviewed option here before forwarding the
+        # remaining solver kwargs; otherwise the adapter would pass use_pece
+        # twice when the generic SA entry point is configured for PECE.
+        run_options = dict(run_options)
+        forwarded_use_pece = run_options.pop("use_pece", use_pece)
+        if type(forwarded_use_pece) is not bool or forwarded_use_pece != use_pece:
+            raise RuntimeError(
+                "SA isolated-history adapter observed a changed use_pece option"
+            )
         return _sample_sa_solver_forecast_isolated(
             runtime,
             model,
@@ -1219,12 +1707,24 @@ def _run_solver_aware_sa(
     if runtime.config.debug:
         LOG.warning(
             "Spectrum H3 SA adapter mode=isolated_adams_history "
-            "persistent=actual_only forecast_use=current_corrector+predictor_ephemeral "
-            "forecast_corrector=ephemeral_current_only "
+            "topology=%s persistent=actual_only "
+            "predicted_forecast=current_corrector_ephemeral "
+            "corrected_phase=%s "
             "stochastic_forecast=solver_space_causal_dense_output "
+            "pece_forecast_policy=%s pece_policy_prefix=%s "
             "continuum_dense_mode=%s continuum_dense_scope=%s",
+            "predicted+corrected" if active_pece else "predicted",
+            "exact_reanchor" if active_pece else "none",
+            runtime.config.sa_pece_forecast_policy if active_pece else "-",
+            _sa_pece_policy_min_actual_prefix(runtime) if active_pece else 0,
             "latest_actual_hold" if continuum_active else "lambda_bounded_extrapolation",
-            "all_forecasts" if continuum_active else "stochastic_only",
+            (
+                "all_forecasts"
+                if continuum_active
+                else "all_predicted_forecasts"
+                if active_pece
+                else "stochastic_only"
+            ),
         )
     return copied.sample(
         model_wrap,
@@ -1390,6 +1890,11 @@ def max_consecutive_forecasts(sampler: Any) -> int | None:
 def min_actual_steps_after_forecast(sampler: Any) -> int:
     name = sampler_name(sampler)
     if name in SA_SOLVER_SAMPLERS:
+        if _sa_solver_is_active_pece(sampler):
+            # Every forecastable predicted phase is followed by an exact
+            # corrected-state H3 reanchor in the same outer interval. The
+            # predicted feature lane still enforces its own one-anchor refresh.
+            return 0
         if _sa_solver_is_stochastic(sampler):
             return 0
         options = getattr(sampler, "extra_options", {}) or {}
@@ -1461,6 +1966,8 @@ def copy_model_options_with_step(
     transformer_options[RUNTIME_KEY] = runtime
     transformer_options[RUN_ID_KEY] = int(decision["run_id"])
     transformer_options[STEP_ID_KEY] = int(decision["step_id"])
+    transformer_options[OUTER_STEP_ID_KEY] = int(decision["policy_step_id"])
+    transformer_options[SOLVER_PHASE_KEY] = str(decision["phase"])
     transformer_options[COORDINATE_KEY] = float(decision["coordinate"])
     transformer_options[ACTUAL_KEY] = bool(decision["actual"])
     transformer_options[REASON_KEY] = str(decision["reason"])
@@ -1517,13 +2024,19 @@ def outer_sample_wrapper(
     runtime = binding.runtime
     name = sampler_name(sampler)
     expected_model_calls = None
+    sa_call_topology = None
     if name in SA_SOLVER_SAMPLERS:
         preflight_reason = _native_sa_solver_preflight_reason(
             sampler,
             getattr(guider, "model_options", None),
         )
         expected_model_calls = _sa_solver_expected_model_calls(sampler, sigmas)
-        if preflight_reason is not None or expected_model_calls is None:
+        sa_call_topology = _sa_solver_call_topology(sampler, sigmas)
+        if (
+            preflight_reason is not None
+            or expected_model_calls is None
+            or sa_call_topology is None
+        ):
             reason = preflight_reason or "SA-Solver model-call topology is unavailable"
             LOG.warning(
                 "Spectrum H3 disabled for this SA-Solver run; running the untouched "
@@ -1608,7 +2121,8 @@ def outer_sample_wrapper(
     continuum_log_emitted = False
     stochastic_seeds = name in SEEDS_SAMPLERS and _seeds_is_stochastic(sampler)
     stochastic_sa = name in SA_SOLVER_SAMPLERS and _sa_solver_is_stochastic(sampler)
-    state_conditioned_residual = stochastic_seeds or stochastic_sa
+    active_pece = name in SA_SOLVER_SAMPLERS and _sa_solver_is_active_pece(sampler)
+    state_conditioned_residual = stochastic_seeds or stochastic_sa or active_pece
     sa_forced_actual_steps: tuple[int, ...] = ()
     sa_stochastic_input_steps: tuple[int, ...] = ()
     if name in SA_SOLVER_SAMPLERS:
@@ -1718,6 +2232,22 @@ def outer_sample_wrapper(
             if expanded_prefix is None:
                 raise RuntimeError("SEEDS prefix model-call topology became unavailable")
             phase_prefix = expanded_prefix
+        pece_policy_prefix = (
+            _sa_pece_policy_min_actual_prefix(runtime) if active_pece else 0
+        )
+        pece_history_step_ids = (
+            tuple(
+                logical_step
+                for logical_step, descriptor in enumerate(sa_call_topology or ())
+                if descriptor.phase == "corrected"
+                or (
+                    descriptor.outer_step == 0
+                    and descriptor.phase == "predicted"
+                )
+            )
+            if active_pece
+            else None
+        )
         run_id = runtime.start_run(
             run_sigmas,
             name,
@@ -1726,22 +2256,36 @@ def outer_sample_wrapper(
             min_actual_steps_after_forecast=min_actual_steps_after_forecast(sampler),
             min_tail_actual_steps=min_tail_actual_steps(sampler),
             min_actual_prefix_steps=phase_prefix,
+            min_sampler_actual_prefix_steps=pece_policy_prefix,
             expected_model_calls=expected_model_calls,
-            stage_count=SEEDS_STAGE_COUNTS.get(name, 1),
+            stage_count=(
+                2 if active_pece else SEEDS_STAGE_COUNTS.get(name, 1)
+            ),
+            logical_call_topology=sa_call_topology,
             state_conditioned_residual=state_conditioned_residual,
-            separate_stage_histories=False if stochastic_seeds else None,
+            separate_stage_histories=(
+                False if active_pece or stochastic_seeds else None
+            ),
             forecastable_stage_indices=(
-                tuple(range(1, SEEDS_STAGE_COUNTS[name]))
+                (0,)
+                if active_pece
+                else tuple(range(1, SEEDS_STAGE_COUNTS[name]))
                 if stochastic_seeds
                 else None
             ),
+            history_stage_indices=(0, 1) if active_pece else None,
+            history_step_ids=pece_history_step_ids,
+            tail_actual_stage_indices=(1,) if active_pece else None,
+            allow_state_conditioned_bootstrap=active_pece,
             forced_actual_step_ids=(
                 sa_forced_actual_steps if name in SA_SOLVER_SAMPLERS else None
             ),
             forced_actual_steps_advance_window=bool(
                 name in SA_SOLVER_SAMPLERS and stochastic_sa
             ),
-            model_aware_can_force_actual=not (stochastic_seeds or stochastic_sa),
+            model_aware_can_force_actual=not (
+                stochastic_seeds or stochastic_sa or active_pece
+            ),
         )
         if phase_prefix > 0 and runtime.supported_sampler and not continuum_log_emitted:
             LOG.warning(
@@ -1767,11 +2311,13 @@ def outer_sample_wrapper(
         if runtime.config.debug:
             LOG.warning(
                 "Spectrum H3 run start phase=%s run_id=%s sampler=%s steps=%s supported=%s "
-                "seeds_stochastic=%s sa_stochastic=%s stage_count=%s feature_geometry=%s "
+                "seeds_stochastic=%s sa_stochastic=%s sa_active_pece=%s "
+                "stage_count=%s feature_geometry=%s "
                 "stage_histories=%s sa_stochastic_input_steps=%s "
                 "sa_forced_actual_steps=%s sa_post_forecast_refresh=%s "
                 "sa_max_forecast_streak=%s sa_exact_window_credit=%s "
-                "sa_adams_history=%s "
+                "sa_pece_forecast_policy=%s sa_pece_policy_prefix=%s "
+                "sa_adams_history=%s sa_feature_history=%s "
                 "model_aware_force_actual=%s",
                 phase,
                 run_id,
@@ -1780,26 +2326,40 @@ def outer_sample_wrapper(
                 runtime.supported_sampler,
                 stochastic_seeds,
                 stochastic_sa,
-                SEEDS_STAGE_COUNTS.get(name, 1),
+                active_pece,
+                2 if active_pece else SEEDS_STAGE_COUNTS.get(name, 1),
                 (
-                    "state_conditioned_residual_shared_history"
+                    "state_conditioned_residual_endpoint_history"
+                    if active_pece
+                    else "state_conditioned_residual_shared_history"
                     if stochastic_seeds
                     else "state_conditioned_residual"
                     if state_conditioned_residual
                     else "absolute_hidden"
                 ),
-                "shared" if stochastic_seeds else "single",
+                "shared_endpoint"
+                if active_pece
+                else "shared"
+                if stochastic_seeds
+                else "single",
                 sa_stochastic_input_steps,
                 sa_forced_actual_steps,
                 min_actual_steps_after_forecast(sampler) if name in SA_SOLVER_SAMPLERS else 0,
                 max_consecutive_forecasts(sampler) if name in SA_SOLVER_SAMPLERS else 0,
                 bool(name in SA_SOLVER_SAMPLERS and stochastic_sa),
+                runtime.config.sa_pece_forecast_policy if active_pece else "-",
+                pece_policy_prefix if active_pece else 0,
                 (
                     "actual_only_persistent+ephemeral_forecast"
                     if name in SA_SOLVER_SAMPLERS
                     else "-"
                 ),
-                not (stochastic_seeds or stochastic_sa),
+                (
+                    "initial_predicted+corrected_actual_endpoints"
+                    if active_pece
+                    else "-"
+                ),
+                not (stochastic_seeds or stochastic_sa or active_pece),
             )
         started = time.perf_counter()
         try:
@@ -2052,9 +2612,13 @@ def predict_noise_wrapper(executor, x, timestep, model_options=None, seed=None):
     decision = runtime.begin_step(timestep)
     if runtime.config.debug:
         LOG.warning(
-            "Spectrum H3 step run_id=%s step=%s coordinate=%.6f decision=%s reason=%s history=%s window=%.3f",
+            "Spectrum H3 step run_id=%s step=%s outer_step=%s stage=%s phase=%s "
+            "coordinate=%.6f decision=%s reason=%s history=%s window=%.3f",
             decision["run_id"],
             decision["step_id"],
+            decision["policy_step_id"],
+            decision["stage_index"],
+            decision["phase"],
             decision["coordinate"],
             "actual" if decision["actual"] else "forecast",
             decision["reason"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,7 @@ def test_preliminary_scheduler_defaults():
     assert config.generic_correction_attenuation == "no_attenuation"
     assert config.generic_correction_limiter == "hard_clip"
     assert config.generic_correction_limit == 0.40
+    assert config.sa_pece_forecast_policy == "balanced"
     assert required["degree"][1]["default"] == 1
     assert required["warmup_steps"][1]["default"] == 1
     assert required["tail_actual_steps"][1]["default"] == 1
@@ -115,11 +116,24 @@ def test_preliminary_scheduler_defaults():
     assert apply_parameters["generic_correction_limiter"].default == "hard_clip"
     assert optional["generic_correction_limit"][1]["default"] == 0.40
     assert apply_parameters["generic_correction_limit"].default == 0.40
+    assert optional["sa_pece_forecast_policy"][0] == [
+        "max_speed",
+        "balanced",
+        "stable_start",
+    ]
+    assert optional["sa_pece_forecast_policy"][1]["default"] == "balanced"
+    assert apply_parameters["sa_pece_forecast_policy"].default == "balanced"
     for name in ("anchor_residual_feedback", "selective_rollback_correction"):
         assert getattr(config, name) is False
         assert optional[name][0] == "BOOLEAN"
         assert optional[name][1]["default"] is False
         assert apply_parameters[name].default is False
+
+
+@pytest.mark.parametrize("value", ["", "fast", "MAX_SPEED", None])
+def test_sa_pece_forecast_policy_rejects_unknown_values(value):
+    with pytest.raises(ValueError, match="sa_pece_forecast_policy"):
+        SpectrumH3Config(sa_pece_forecast_policy=value).validate()
 
 
 @pytest.mark.parametrize("value", ["", "rls", "REGIONAL", None])
@@ -351,6 +365,7 @@ def test_apply_normalizes_reported_warmup_conflict(monkeypatch, caplog):
     assert captured["config"].generic_correction_attenuation == "no_attenuation"
     assert captured["config"].generic_correction_limiter == "hard_clip"
     assert captured["config"].generic_correction_limit == 0.40
+    assert captured["config"].sa_pece_forecast_policy == "balanced"
     assert "Disabling bootstrap_first_forecast" in caplog.text
 
 
@@ -362,3 +377,4 @@ def test_saved_workflow_default_adds_no_public_rls_lambda_control():
         "generic_correction_limit"
     )
     assert "generic_correction_rls_lambda" not in optional
+    assert keys[-1] == "sa_pece_forecast_policy"

--- a/tests/test_external_patch_compat.py
+++ b/tests/test_external_patch_compat.py
@@ -441,6 +441,24 @@ def test_already_actual_transition_does_not_duplicate_model_evaluation():
     assert run.forced_actuals == 0
 
 
+def test_pece_same_sigma_corrected_phase_cannot_bypass_hard_transition():
+    fake = _FakeRuntime(parsed(contract(sigma_start=0.55, sigma_end=1.0)))
+    _observe(fake, 0, 0.70, "actual")
+    _commit(fake)
+
+    # The predicted phase crosses the hard boundary and is promoted to exact.
+    assert _observe(fake, 1, 0.50, "forecast") == "actual"
+    _commit(fake)
+
+    # Native PECE's corrected phase is a distinct evaluation at the same sigma.
+    # It is already exact by policy, and the equal coordinate cannot create or
+    # evade a second transition.
+    assert _observe(fake, 2, 0.50, "actual") == "actual"
+    run = compat._compat_state(fake).run
+    assert run.transitions == 1
+    assert run.forced_actuals == 1
+
+
 def test_two_contracts_crossing_same_step_force_only_one_actual():
     contracts = parsed(
         contract(instance_id="diffaid-h3-1", sigma_start=0.55, sigma_end=1.0),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5,7 +5,11 @@ import torch
 
 from comfyui_spectrum_h3.config import SpectrumH3Config
 from comfyui_spectrum_h3.model_aware import ModelForecastabilityProfile, ProfileLookup
-from comfyui_spectrum_h3.runtime import ForecastRetryActual, SpectrumH3Runtime
+from comfyui_spectrum_h3.runtime import (
+    ForecastRetryActual,
+    SolverCallDescriptor,
+    SpectrumH3Runtime,
+)
 
 TOPOLOGY = (
     ("video", (1, 24, 2, 4, 4)),
@@ -123,6 +127,282 @@ def _complete_step(runtime, timestep, *, labels=LABEL):
     runtime.finalize_step(decision["run_id"], decision["step_id"])
     return decision
 
+
+
+def test_explicit_pece_topology_separates_same_sigma_phases_and_outer_policy():
+    runtime = _runtime(warmup_steps=0, tail_actual_steps=1)
+    sigmas = torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0])
+    topology = (
+        SolverCallDescriptor(0, 0, "predicted"),
+        SolverCallDescriptor(1, 0, "predicted"),
+        SolverCallDescriptor(1, 1, "corrected"),
+        SolverCallDescriptor(2, 0, "predicted"),
+        SolverCallDescriptor(2, 1, "corrected"),
+        SolverCallDescriptor(3, 0, "predicted"),
+        SolverCallDescriptor(3, 1, "corrected"),
+    )
+    run_id = runtime.start_run(
+        sigmas,
+        "sample_sa_solver_pece",
+        supported_sampler=True,
+        expected_model_calls=len(topology),
+        stage_count=2,
+        logical_call_topology=topology,
+        state_conditioned_residual=True,
+        separate_stage_histories=False,
+        forecastable_stage_indices=(0,),
+        history_stage_indices=(0, 1),
+        history_step_ids=(0, 2, 4, 6),
+        tail_actual_stage_indices=(1,),
+        allow_state_conditioned_bootstrap=True,
+        min_actual_prefix_steps=2,
+        min_actual_steps_after_forecast=0,
+        max_consecutive_forecasts=1,
+        model_aware_can_force_actual=False,
+    )
+
+    decisions = [
+        _complete_step(runtime, sigma)
+        for sigma in (1.0, 0.75, 0.75, 0.5, 0.5, 0.25, 0.25)
+    ]
+
+    assert [decision["phase"] for decision in decisions] == [
+        "predicted",
+        "predicted",
+        "corrected",
+        "predicted",
+        "corrected",
+        "predicted",
+        "corrected",
+    ]
+    assert [decision["policy_step_id"] for decision in decisions] == [
+        0,
+        1,
+        1,
+        2,
+        2,
+        3,
+        3,
+    ]
+    assert [decision["actual"] for decision in decisions] == [
+        True,
+        True,
+        True,
+        False,
+        True,
+        False,
+        True,
+    ]
+    assert runtime.stats.phase_actual_steps == {"predicted": 2, "corrected": 3}
+    assert runtime.stats.phase_forecast_steps == {"predicted": 2}
+    assert runtime.forecaster.history_length == 4
+    assert runtime.forecaster.latest_anchor_ids(4) == (0, 2, 4, 6)
+    assert runtime._stage_forecasters == {}
+    runtime.end_run(run_id)
+
+
+def test_active_pece_corrected_phase_owns_shared_endpoint_history():
+    runtime = _runtime(force_actual=True, warmup_steps=0, tail_actual_steps=0)
+    sigmas = torch.tensor([1.0, 0.5, 0.0])
+    topology = (
+        SolverCallDescriptor(0, 0, "predicted"),
+        SolverCallDescriptor(1, 0, "predicted"),
+        SolverCallDescriptor(1, 1, "corrected"),
+    )
+    run_id = runtime.start_run(
+        sigmas,
+        "sample_sa_solver_pece",
+        supported_sampler=True,
+        expected_model_calls=3,
+        stage_count=2,
+        logical_call_topology=topology,
+        state_conditioned_residual=True,
+        separate_stage_histories=False,
+        forecastable_stage_indices=(0,),
+        history_stage_indices=(0, 1),
+        history_step_ids=(0, 2),
+        tail_actual_stage_indices=(1,),
+        allow_state_conditioned_bootstrap=True,
+    )
+
+    _complete_step(runtime, 1.0)
+    _complete_step(runtime, 0.5)
+    assert runtime.forecaster.history_length == 1
+    assert runtime.forecaster.latest_anchor_ids(1) == (0,)
+
+    decision = runtime.begin_step(torch.tensor([0.5]))
+    assert decision["phase"] == "corrected"
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=TOPOLOGY,
+        labels=LABEL,
+        expected_shape=(1, 3, 4),
+    )
+    assert actual
+    runtime.observe_actual(
+        decision["run_id"],
+        decision["step_id"],
+        call_id,
+        torch.full((1, 3, 4), 123.0),
+    )
+    assert runtime._step is not None
+    assert runtime._step.calls[0].observed_actual
+    assert len(runtime._step.actual_records) == 1
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    assert runtime.stats.actual_transformer_calls == 3
+    assert runtime.forecaster.history_length == 2
+    assert runtime.forecaster.latest_anchor_ids(2) == (0, 2)
+    assert runtime._stage_forecasters == {}
+    runtime.end_run(run_id)
+
+
+def test_active_pece_default_19_interval_cadence_counts_true_h3_opportunities():
+    runtime = _runtime(warmup_steps=1, tail_actual_steps=1)
+    sigmas = torch.cat((torch.linspace(1.0, 0.1, 19), torch.zeros(1)))
+    topology = [SolverCallDescriptor(0, 0, "predicted")]
+    for outer_step in range(1, 19):
+        topology.extend(
+            (
+                SolverCallDescriptor(outer_step, 0, "predicted"),
+                SolverCallDescriptor(outer_step, 1, "corrected"),
+            )
+        )
+    topology = tuple(topology)
+    history_step_ids = tuple(
+        step_id
+        for step_id, descriptor in enumerate(topology)
+        if step_id == 0 or descriptor.phase == "corrected"
+    )
+
+    run_id = runtime.start_run(
+        sigmas,
+        "sample_sa_solver_pece",
+        supported_sampler=True,
+        expected_model_calls=len(topology),
+        stage_count=2,
+        logical_call_topology=topology,
+        state_conditioned_residual=True,
+        separate_stage_histories=False,
+        forecastable_stage_indices=(0,),
+        history_stage_indices=(0, 1),
+        history_step_ids=history_step_ids,
+        tail_actual_stage_indices=(1,),
+        allow_state_conditioned_bootstrap=True,
+        min_actual_steps_after_forecast=0,
+        max_consecutive_forecasts=1,
+        model_aware_can_force_actual=False,
+    )
+
+    decisions = [
+        _complete_step(runtime, float(sigmas[descriptor.outer_step]))
+        for descriptor in topology
+    ]
+    predicted = [
+        decision for decision in decisions if decision["phase"] == "predicted"
+    ]
+    corrected = [
+        decision for decision in decisions if decision["phase"] == "corrected"
+    ]
+
+    assert len(decisions) == 37
+    assert len(predicted) == 19
+    assert len(corrected) == 18
+    assert sum(decision["actual"] for decision in predicted) == 1
+    assert sum(not decision["actual"] for decision in predicted) == 18
+    assert all(decision["actual"] for decision in corrected)
+    assert runtime.stats.actual_steps == 19
+    assert runtime.stats.forecast_steps == 18
+    assert runtime.stats.actual_steps + runtime.stats.forecast_steps == 37
+    assert runtime.stats.actual_transformer_calls == 19
+    assert runtime.stats.phase_actual_steps == {"predicted": 1, "corrected": 18}
+    assert runtime.stats.phase_forecast_steps == {"predicted": 18}
+    assert runtime.forecaster.latest_anchor_ids(4) == history_step_ids[-4:]
+    summary = runtime.debug_summary()
+    assert "outer_steps=19" in summary
+    assert "h3_logical_calls=37" in summary
+    assert "phase_counts=corrected:a18/f0,predicted:a1/f18" in summary
+    runtime.end_run(run_id)
+
+
+@pytest.mark.parametrize(
+    ("policy_prefix", "predicted_actuals", "total_actuals", "forecasts"),
+    (
+        (1, 1, 10, 9),
+        (2, 2, 11, 8),
+        (3, 3, 12, 7),
+    ),
+)
+def test_active_pece_10_interval_policy_prefix_controls_speed_stability_tradeoff(
+    policy_prefix,
+    predicted_actuals,
+    total_actuals,
+    forecasts,
+):
+    runtime = _runtime(warmup_steps=1, tail_actual_steps=1)
+    sigmas = torch.cat((torch.linspace(1.0, 0.1, 10), torch.zeros(1)))
+    topology = [SolverCallDescriptor(0, 0, "predicted")]
+    for outer_step in range(1, 10):
+        topology.extend(
+            (
+                SolverCallDescriptor(outer_step, 0, "predicted"),
+                SolverCallDescriptor(outer_step, 1, "corrected"),
+            )
+        )
+    topology = tuple(topology)
+    history_step_ids = tuple(
+        step_id
+        for step_id, descriptor in enumerate(topology)
+        if step_id == 0 or descriptor.phase == "corrected"
+    )
+
+    run_id = runtime.start_run(
+        sigmas,
+        "sample_sa_solver_pece",
+        supported_sampler=True,
+        expected_model_calls=len(topology),
+        stage_count=2,
+        logical_call_topology=topology,
+        state_conditioned_residual=True,
+        separate_stage_histories=False,
+        forecastable_stage_indices=(0,),
+        history_stage_indices=(0, 1),
+        history_step_ids=history_step_ids,
+        tail_actual_stage_indices=(1,),
+        allow_state_conditioned_bootstrap=True,
+        min_actual_steps_after_forecast=0,
+        min_sampler_actual_prefix_steps=policy_prefix,
+        max_consecutive_forecasts=1,
+        model_aware_can_force_actual=False,
+    )
+
+    decisions = [
+        _complete_step(runtime, float(sigmas[descriptor.outer_step]))
+        for descriptor in topology
+    ]
+    predicted = [d for d in decisions if d["phase"] == "predicted"]
+    corrected = [d for d in decisions if d["phase"] == "corrected"]
+
+    assert len(decisions) == 19
+    assert [d["actual"] for d in predicted] == (
+        [True] * predicted_actuals + [False] * (10 - predicted_actuals)
+    )
+    assert all(d["actual"] for d in corrected)
+    assert runtime.stats.actual_steps == total_actuals
+    assert runtime.stats.forecast_steps == forecasts
+    assert runtime.stats.actual_transformer_calls == total_actuals
+    assert runtime.stats.phase_actual_steps == {
+        "predicted": predicted_actuals,
+        "corrected": 9,
+    }
+    assert runtime.stats.phase_forecast_steps == {
+        "predicted": 10 - predicted_actuals,
+    }
+    assert runtime.forecaster.latest_anchor_ids(4) == history_step_ids[-4:]
+    summary = runtime.debug_summary()
+    assert f"sampler_prefix_steps={policy_prefix}" in summary
+    runtime.end_run(run_id)
 
 def test_model_aware_off_never_enters_controller_and_keeps_legacy_forecast_path(
     monkeypatch,
@@ -442,7 +722,7 @@ def test_separate_stage_histories_validation():
             separate_stage_histories=1,
         )
 
-    with pytest.raises(ValueError, match="requires multistage"):
+    with pytest.raises(ValueError, match="requires an explicit multistage topology"):
         runtime.start_run(
             sigmas,
             "sample_sa_solver",
@@ -731,6 +1011,80 @@ def test_sa_and_seeds_state_conditioned_runs_do_not_leak_stage_histories():
     assert runtime.stochastic_multistage is False
     runtime.end_run(sa_again)
 
+
+
+@pytest.mark.parametrize(
+    ("middle_sampler", "middle_stage_count", "middle_calls"),
+    (
+        ("sample_sa_solver", 1, 3),
+        ("sample_seeds_2", 2, 6),
+        ("sample_seeds_3", 3, 9),
+    ),
+)
+def test_active_pece_runtime_isolation_across_pec_and_seeds(
+    middle_sampler,
+    middle_stage_count,
+    middle_calls,
+):
+    runtime = _runtime(
+        model_aware_mode="off",
+        force_actual=True,
+        warmup_steps=0,
+        tail_actual_steps=0,
+    )
+    sigmas = torch.tensor([1.0, 0.6, 0.3, 0.0])
+    pece_topology = (
+        SolverCallDescriptor(0, 0, "predicted"),
+        SolverCallDescriptor(1, 0, "predicted"),
+        SolverCallDescriptor(1, 1, "corrected"),
+        SolverCallDescriptor(2, 0, "predicted"),
+        SolverCallDescriptor(2, 1, "corrected"),
+    )
+    pece_history_step_ids = (0, 2, 4)
+
+    def run_pece():
+        run_id = runtime.start_run(
+            sigmas,
+            "sample_sa_solver_pece",
+            supported_sampler=True,
+            expected_model_calls=len(pece_topology),
+            stage_count=2,
+            logical_call_topology=pece_topology,
+            state_conditioned_residual=True,
+            separate_stage_histories=False,
+            forecastable_stage_indices=(0,),
+            history_stage_indices=(0, 1),
+            history_step_ids=pece_history_step_ids,
+            tail_actual_stage_indices=(1,),
+            allow_state_conditioned_bootstrap=True,
+        )
+        assert runtime.prediction_history_length == 0
+        assert runtime.stochastic_multistage is False
+        for timestep in (1.0, 0.6, 0.6, 0.3, 0.3):
+            _complete_step(runtime, timestep)
+        assert runtime.forecaster.history_length == 3
+        assert runtime.forecaster.latest_anchor_ids(3) == pece_history_step_ids
+        assert runtime._stage_forecasters == {}
+        runtime.end_run(run_id)
+
+    run_pece()
+    middle_run = runtime.start_run(
+        sigmas,
+        middle_sampler,
+        supported_sampler=True,
+        expected_model_calls=middle_calls,
+        stage_count=middle_stage_count,
+        state_conditioned_residual=True,
+        separate_stage_histories=middle_stage_count > 1,
+    )
+    assert runtime.prediction_history_length == 0
+    assert runtime._run is not None
+    assert runtime._run.logical_call_topology is None
+    assert runtime.stochastic_multistage is (middle_stage_count > 1)
+    for call_id in range(middle_calls):
+        _complete_step(runtime, float(sigmas[min(call_id // middle_stage_count, 2)]))
+    runtime.end_run(middle_run)
+    run_pece()
 
 def test_legacy_stochastic_multistage_keyword_maps_to_generic_state_conditioning():
     runtime = _runtime(force_actual=True)

--- a/tests/test_sa_solver_state_conditioning.py
+++ b/tests/test_sa_solver_state_conditioning.py
@@ -16,11 +16,14 @@ from comfyui_spectrum_h3.sampling import (
     BINDING_KEY,
     SpectrumH3Binding,
     _sa_solver_expected_model_calls,
+    _sa_solver_call_topology,
+    _sa_solver_is_active_pece,
     _sa_solver_is_stochastic,
     _sa_solver_option_contract,
     _sa_solver_prefix_model_calls,
     _sa_solver_sampler_contract,
     _sa_solver_tau_values,
+    _run_solver_aware_sa,
     outer_sample_wrapper,
     sampler_supports_seeded_replay,
 )
@@ -55,28 +58,7 @@ def _native_sa_functions():
         function.decorator_list = []
         functions.append(function)
 
-    def coefficients(
-        _sigma_next,
-        curr_lambdas,
-        _lambda_s,
-        _lambda_t,
-        _tau_t,
-        _simple_order_2=False,
-        is_corrector_step=False,
-    ):
-        scale = 0.15 if is_corrector_step else 0.2
-        return torch.full_like(curr_lambdas, scale / curr_lambdas.numel())
-
-    def interval_factory(start_sigma, end_sigma, eta=1.0):
-        def tau_func(sigma):
-            value = (
-                float(sigma.detach().cpu().item())
-                if torch.is_tensor(sigma)
-                else float(sigma)
-            )
-            return float(eta) if float(start_sigma) >= value >= float(end_sigma) else 0.0
-
-        return tau_func
+    import comfy.k_diffusion.sa_solver as native_sa_solver
 
     namespace = {
         "torch": torch,
@@ -92,8 +74,10 @@ def _native_sa_functions():
         "offset_first_sigma_for_snr": lambda sigmas, _sampling: sigmas,
         "sigma_to_half_log_snr": lambda sigma, model_sampling: -torch.log(sigma),
         "sa_solver": SimpleNamespace(
-            compute_stochastic_adams_b_coeffs=coefficients,
-            get_tau_interval_func=interval_factory,
+            compute_stochastic_adams_b_coeffs=(
+                native_sa_solver.compute_stochastic_adams_b_coeffs
+            ),
+            get_tau_interval_func=native_sa_solver.get_tau_interval_func,
         ),
     }
     module = ast.fix_missing_locations(ast.Module(body=functions, type_ignores=[]))
@@ -121,10 +105,12 @@ def _run_native(
     function_name="sample_sa_solver",
     sigmas=(0.9, 0.7, 0.5, 0.3, 0.0),
     use_pece=False,
+    predictor_order=3,
     corrector_order=4,
     simple_order_2=False,
     tau_func="piecewise",
     s_noise=0.7,
+    noise_scale=1.0,
 ):
     native = _native_sa_functions()[function_name]
     generator = torch.Generator(device="cpu").manual_seed(8675309)
@@ -155,8 +141,12 @@ def _run_native(
     else:
         raise AssertionError(f"unknown tau fixture {tau_func!r}")
 
+    model_sampling = _ModelSampling()
+    model_sampling.noise_scale = noise_scale
+    patcher = SimpleNamespace(get_model_object=lambda _name: model_sampling)
+
     class Model:
-        inner_model = SimpleNamespace(model_patcher=_Patcher())
+        inner_model = SimpleNamespace(model_patcher=patcher)
 
         def __call__(self, x, sigma, **_extra_args):
             coordinate = float(sigma.detach().cpu().item())
@@ -169,7 +159,9 @@ def _run_native(
         callback=lambda state: callbacks.append(
             {
                 "x": state["x"].detach().clone(),
+                "i": state["i"],
                 "sigma": float(state["sigma"]),
+                "sigma_hat": float(state["sigma_hat"]),
                 "denoised": state["denoised"].detach().clone(),
             }
         ),
@@ -177,7 +169,7 @@ def _run_native(
         tau_func=configured_tau,
         s_noise=s_noise,
         noise_sampler=noise_sampler,
-        predictor_order=3,
+        predictor_order=predictor_order,
         corrector_order=corrector_order,
         simple_order_2=simple_order_2,
     )
@@ -196,6 +188,7 @@ def _run_native(
         noise_draws=noise_draws,
         noise_args=noise_args,
         tau_args=tau_args,
+        rng_state=generator.get_state().clone(),
     )
 
 
@@ -207,7 +200,13 @@ def _run_isolated(
     s_noise=0.7,
     predictor_order=3,
     corrector_order=4,
+    simple_order_2=False,
     continuum_active=False,
+    use_pece=False,
+    forecast_offset=0.0,
+    noise_scale=1.0,
+    debug=False,
+    reasons=None,
 ):
     generator = torch.Generator(device="cpu").manual_seed(8675309)
     noise_draws = []
@@ -215,8 +214,14 @@ def _run_isolated(
     callbacks = []
     model_events = []
     tau_args = []
-    runtime = SimpleNamespace(last_completed_mode=None)
+    runtime = SimpleNamespace(
+        last_completed_mode=None,
+        last_completed_step_id=None,
+        last_completed_reason=None,
+        config=SimpleNamespace(debug=bool(debug)),
+    )
     mode_iter = iter(modes)
+    reason_iter = iter(reasons) if reasons is not None else None
 
     def noise_sampler(sigma, sigma_next):
         noise_args.append((float(sigma), float(sigma_next)))
@@ -239,14 +244,23 @@ def _run_isolated(
     else:
         raise AssertionError(f"unknown tau fixture {tau_func!r}")
 
+    model_sampling = _ModelSampling()
+    model_sampling.noise_scale = noise_scale
+    patcher = SimpleNamespace(get_model_object=lambda _name: model_sampling)
+
     class Model:
-        inner_model = SimpleNamespace(model_patcher=_Patcher())
+        inner_model = SimpleNamespace(model_patcher=patcher)
 
         def __call__(self, x, sigma, **_extra_args):
             coordinate = float(sigma.detach().cpu().item())
             model_events.append((x.detach().clone(), coordinate))
             runtime.last_completed_mode = next(mode_iter)
-            return torch.full_like(x, 0.25 + 0.5 * coordinate)
+            runtime.last_completed_step_id = len(model_events) - 1
+            runtime.last_completed_reason = (
+                next(reason_iter) if reason_iter is not None else None
+            )
+            offset = forecast_offset if runtime.last_completed_mode == "forecast" else 0.0
+            return torch.full_like(x, 0.25 + 0.5 * coordinate + offset)
 
     sigma_tensor = torch.tensor(sigmas, dtype=torch.float32)
     result = sampling_module._sample_sa_solver_forecast_isolated(
@@ -258,7 +272,9 @@ def _run_isolated(
         callback=lambda state: callbacks.append(
             {
                 "x": state["x"].detach().clone(),
+                "i": state["i"],
                 "sigma": float(state["sigma"]),
+                "sigma_hat": float(state["sigma_hat"]),
                 "denoised": state["denoised"].detach().clone(),
             }
         ),
@@ -268,7 +284,8 @@ def _run_isolated(
         noise_sampler=noise_sampler,
         predictor_order=predictor_order,
         corrector_order=corrector_order,
-        simple_order_2=False,
+        use_pece=use_pece,
+        simple_order_2=simple_order_2,
         continuum_active=continuum_active,
     )
     return SimpleNamespace(
@@ -279,6 +296,7 @@ def _run_isolated(
         noise_args=noise_args,
         tau_args=tau_args,
         runtime=runtime,
+        rng_state=generator.get_state().clone(),
     )
 
 
@@ -356,6 +374,29 @@ def test_sa_dense_output_holds_after_consecutive_actual_refreshes():
     assert float(alpha) == pytest.approx(0.0)
 
 
+
+def test_sa_dense_output_allows_consecutive_pece_endpoint_extrapolation():
+    previous = torch.tensor([[1.0, 3.0]], dtype=torch.float32)
+    latest = torch.tensor([[2.0, 4.0]], dtype=torch.float32)
+    predicted, mode, anchors, alpha = sampling_module._sa_predict_causal_denoised(
+        [previous, latest],
+        [torch.tensor(0.2), torch.tensor(0.3)],
+        [7, 8],
+        target_lambda=torch.tensor(0.4),
+        target_step=9,
+        allow_consecutive_extrapolation=True,
+    )
+
+    torch.testing.assert_close(
+        predicted,
+        torch.tensor([[3.0, 5.0]], dtype=torch.float32),
+        rtol=0,
+        atol=1e-6,
+    )
+    assert mode == "lambda_bounded_extrapolation"
+    assert anchors == (7, 8)
+    assert float(alpha) == pytest.approx(1.0)
+
 def test_sa_dense_output_uses_bounded_lambda_extrapolation_from_actuals():
     previous = torch.tensor([[1.0, 3.0]], dtype=torch.float32)
     latest = torch.tensor([[2.0, 5.0]], dtype=torch.float32)
@@ -404,9 +445,27 @@ def test_isolated_sa_adapter_is_exact_native_parity_when_every_call_is_actual():
     assert torch.allclose(isolated.result, native.result, atol=0.0, rtol=0.0)
     assert isolated.noise_args == pytest.approx(native.noise_args)
     assert isolated.tau_args == pytest.approx(native.tau_args)
+    assert len(isolated.noise_draws) == len(native.noise_draws)
+    for candidate, expected in zip(
+        isolated.noise_draws,
+        native.noise_draws,
+        strict=True,
+    ):
+        torch.testing.assert_close(candidate, expected, rtol=0, atol=0)
+    torch.testing.assert_close(isolated.rng_state, native.rng_state, rtol=0, atol=0)
+    assert len(isolated.model_events) == len(native.model_events)
+    for candidate, expected in zip(
+        isolated.model_events,
+        native.model_events,
+        strict=True,
+    ):
+        assert candidate[1] == pytest.approx(expected[1])
+        torch.testing.assert_close(candidate[0], expected[0], rtol=0, atol=0)
     assert len(isolated.callbacks) == len(native.callbacks)
     for candidate, expected in zip(isolated.callbacks, native.callbacks, strict=True):
+        assert candidate["i"] == expected["i"]
         assert candidate["sigma"] == pytest.approx(expected["sigma"])
+        assert candidate["sigma_hat"] == pytest.approx(expected["sigma_hat"])
         assert torch.allclose(candidate["x"], expected["x"], atol=0.0, rtol=0.0)
         assert torch.allclose(
             candidate["denoised"],
@@ -414,6 +473,337 @@ def test_isolated_sa_adapter_is_exact_native_parity_when_every_call_is_actual():
             atol=0.0,
             rtol=0.0,
         )
+
+
+def test_active_pece_adapter_is_exact_native_parity_when_every_phase_is_actual():
+    pytest.importorskip("scipy")
+    native = _run_native(use_pece=True)
+    isolated = _run_isolated(["actual"] * 7, use_pece=True)
+
+    torch.testing.assert_close(isolated.result, native.result, rtol=0, atol=0)
+    assert isolated.noise_args == pytest.approx(native.noise_args)
+    assert isolated.tau_args == pytest.approx(native.tau_args)
+    assert len(isolated.noise_draws) == len(native.noise_draws)
+    for candidate, expected in zip(
+        isolated.noise_draws,
+        native.noise_draws,
+        strict=True,
+    ):
+        torch.testing.assert_close(candidate, expected, rtol=0, atol=0)
+    torch.testing.assert_close(isolated.rng_state, native.rng_state, rtol=0, atol=0)
+    assert len(isolated.model_events) == len(native.model_events) == 7
+    for candidate, expected in zip(
+        isolated.model_events,
+        native.model_events,
+        strict=True,
+    ):
+        assert candidate[1] == pytest.approx(expected[1])
+        torch.testing.assert_close(candidate[0], expected[0], rtol=0, atol=0)
+    assert len(isolated.callbacks) == len(native.callbacks) == 4
+    for candidate, expected in zip(isolated.callbacks, native.callbacks, strict=True):
+        assert candidate["i"] == expected["i"]
+        assert candidate["sigma"] == pytest.approx(expected["sigma"])
+        assert candidate["sigma_hat"] == pytest.approx(expected["sigma_hat"])
+        torch.testing.assert_close(candidate["x"], expected["x"], rtol=0, atol=0)
+        torch.testing.assert_close(
+            candidate["denoised"],
+            expected["denoised"],
+            rtol=0,
+            atol=0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("predictor_order", "corrector_order", "tau_func", "s_noise", "simple_order_2"),
+    (
+        (1, 1, "piecewise", 0.7, False),
+        (1, 4, "zero", 0.7, False),
+        (2, 1, "piecewise", 0.7, False),
+        (2, 2, "piecewise", 0.7, True),
+        (3, 2, "piecewise", 0.0, False),
+        (3, 3, "zero", 0.7, False),
+        (3, 4, "piecewise", 0.0, False),
+        (3, 4, None, 0.7, False),
+    ),
+)
+def test_active_pece_all_actual_parity_across_order_and_stochasticity(
+    predictor_order,
+    corrector_order,
+    tau_func,
+    s_noise,
+    simple_order_2,
+):
+    pytest.importorskip("scipy")
+    native = _run_native(
+        use_pece=True,
+        predictor_order=predictor_order,
+        corrector_order=corrector_order,
+        tau_func=tau_func,
+        s_noise=s_noise,
+        simple_order_2=simple_order_2,
+    )
+    isolated = _run_isolated(
+        ["actual"] * 7,
+        use_pece=True,
+        predictor_order=predictor_order,
+        corrector_order=corrector_order,
+        tau_func=tau_func,
+        s_noise=s_noise,
+        simple_order_2=simple_order_2,
+    )
+
+    torch.testing.assert_close(isolated.result, native.result, rtol=0, atol=0)
+    assert isolated.noise_args == pytest.approx(native.noise_args)
+    assert isolated.tau_args == pytest.approx(native.tau_args)
+
+
+
+def test_active_pece_continuum_predicted_forecast_uses_corrected_endpoint_hold():
+    pytest.importorskip("scipy")
+    run = _run_isolated(
+        ["actual", "actual", "actual", "forecast", "actual", "actual", "actual"],
+        use_pece=True,
+        tau_func="zero",
+        s_noise=0.0,
+        continuum_active=True,
+        forecast_offset=50.0,
+    )
+
+    # P2's raw feature forecast would be 50.5. Continuum instead holds C1,
+    # the exact persistent PECE endpoint at outer step 1. In this fixture C1's
+    # exact denoiser is 0.25 + 0.5*0.7 = 0.6.
+    torch.testing.assert_close(
+        run.callbacks[2]["denoised"],
+        torch.full((1, 2), 0.6),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_active_pece_debug_telemetry_exposes_phase_value_and_persistence(caplog):
+    pytest.importorskip("scipy")
+    with caplog.at_level("WARNING"):
+        _run_isolated(
+            ["actual", "actual", "actual", "forecast", "actual", "actual", "actual"],
+            use_pece=True,
+            tau_func="zero",
+            s_noise=0.0,
+            forecast_offset=25.0,
+            debug=True,
+        )
+
+    text = caplog.text
+    assert "logical_step=3 sa_outer=2 sa_phase=predicted" in text
+    assert "actual_model_evaluation=0 forecast=1" in text
+    assert "reason=predicted_forecast_ephemeral" in text
+    assert "adams_persistent=0 solver_value_source=lambda_bounded_extrapolation" in text
+    assert "scope=pece_all_forecasts mode=lambda_bounded_extrapolation" in text
+    assert "raw_feature_forecast=ignored" in text
+    assert "history_lane=persistent_endpoint_actual_only" in text
+    assert "logical_step=4 sa_outer=2 sa_phase=corrected" in text
+    assert "reason=pece_exact_reanchor adams_persistent=1" in text
+    assert "solver_value_source=actual_h3" in text
+
+def test_active_pece_all_actual_parity_preserves_model_noise_scale():
+    pytest.importorskip("scipy")
+    native = _run_native(use_pece=True, noise_scale=1.75)
+    isolated = _run_isolated(
+        ["actual"] * 7,
+        use_pece=True,
+        noise_scale=1.75,
+    )
+
+    torch.testing.assert_close(isolated.result, native.result, rtol=0, atol=0)
+    assert isolated.noise_args == pytest.approx(native.noise_args)
+    assert isolated.tau_args == pytest.approx(native.tau_args)
+
+
+def test_active_pece_all_actual_parity_without_terminal_zero():
+    pytest.importorskip("scipy")
+    sigmas = (0.9, 0.7, 0.5, 0.3, 0.1)
+    native = _run_native(use_pece=True, sigmas=sigmas)
+    isolated = _run_isolated(
+        ["actual"] * 7,
+        use_pece=True,
+        sigmas=sigmas,
+    )
+
+    torch.testing.assert_close(isolated.result, native.result, rtol=0, atol=0)
+    assert isolated.noise_args == pytest.approx(native.noise_args)
+    assert isolated.tau_args == pytest.approx(native.tau_args)
+
+
+
+def test_active_pece_predicted_forecast_is_current_corrector_only(monkeypatch):
+    """The solver-owned predicted estimate may enter C and cannot persist past C."""
+    pytest.importorskip("scipy")
+    import comfy.k_diffusion.sa_solver as native_sa_solver
+
+    original_coefficients = native_sa_solver.compute_stochastic_adams_b_coeffs
+    original_tensordot = torch.tensordot
+    pending_kind = None
+    integrations = []
+    bridge_sentinel = 37.5
+
+    def fake_dense_output(
+        actual_preds,
+        actual_lambdas,
+        actual_steps,
+        *,
+        target_lambda,
+        target_step,
+        continuum_active=False,
+        allow_consecutive_extrapolation=False,
+    ):
+        assert actual_preds
+        assert allow_consecutive_extrapolation
+        return (
+            torch.full_like(actual_preds[-1], bridge_sentinel),
+            "test_endpoint_bridge",
+            (actual_steps[-1],),
+            target_lambda.new_zeros(()),
+        )
+
+    def capture_coefficients(*args, **kwargs):
+        nonlocal pending_kind
+        pending_kind = "corrector" if kwargs.get("is_corrector_step") else "predictor"
+        return original_coefficients(*args, **kwargs)
+
+    def capture_tensordot(input_tensor, other, *args, **kwargs):
+        nonlocal pending_kind
+        integrations.append((pending_kind, input_tensor.detach().clone()))
+        pending_kind = None
+        return original_tensordot(input_tensor, other, *args, **kwargs)
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_sa_predict_causal_denoised",
+        fake_dense_output,
+    )
+    monkeypatch.setattr(
+        native_sa_solver,
+        "compute_stochastic_adams_b_coeffs",
+        capture_coefficients,
+    )
+    monkeypatch.setattr(torch, "tensordot", capture_tensordot)
+
+    # P2 is the only forecast. Its raw hidden forecast would produce 50.5, but
+    # active PECE must ignore that solver value and use the endpoint bridge.
+    _run_isolated(
+        ["actual", "actual", "actual", "forecast", "actual", "actual", "actual"],
+        use_pece=True,
+        tau_func="zero",
+        s_noise=0.0,
+        forecast_offset=50.0,
+    )
+
+    bridge_integrations = [
+        (kind, matrix)
+        for kind, matrix in integrations
+        if bool(torch.isclose(matrix, torch.tensor(bridge_sentinel)).any().item())
+    ]
+    assert len(bridge_integrations) == 1
+    assert bridge_integrations[0][0] == "corrector"
+
+    raw_feature_sentinel = 50.5
+    assert not any(
+        bool(torch.isclose(matrix, torch.tensor(raw_feature_sentinel)).any().item())
+        for _, matrix in integrations
+    )
+
+
+def test_active_pece_supports_forecasted_predicted_phase_every_outer_step_after_p0():
+    pytest.importorskip("scipy")
+    run = _run_isolated(
+        ["actual", "forecast", "actual", "forecast", "actual", "forecast", "actual"],
+        use_pece=True,
+        tau_func="zero",
+        s_noise=0.0,
+        forecast_offset=100.0,
+    )
+
+    assert len(run.model_events) == 7
+    assert len(run.callbacks) == 4
+    # Raw feature forecasts are ~100.x in this fixture. Solver-visible callback
+    # denoisers must come only from exact persistent PECE endpoint anchors.
+    for callback in run.callbacks[1:]:
+        assert float(callback["denoised"].abs().max()) < 10.0
+
+
+
+def test_active_pece_hard_transition_restarts_dense_endpoint_interpolation():
+    pytest.importorskip("scipy")
+    run = _run_isolated(
+        ["actual", "forecast", "actual", "actual", "actual", "forecast", "actual"],
+        use_pece=True,
+        tau_func="zero",
+        s_noise=0.0,
+        forecast_offset=100.0,
+        reasons=[
+            None,
+            None,
+            None,
+            "external patch hard sigma transition",
+            None,
+            None,
+            None,
+        ],
+    )
+
+    # P2 is exact because it crosses the hard transformer boundary. Once C2
+    # becomes the exact endpoint, the dense secant history is restarted there.
+    # P3 must therefore hold C2 rather than extrapolate across pre-transition C1.
+    torch.testing.assert_close(
+        run.callbacks[3]["denoised"],
+        torch.full((1, 2), 0.5),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_active_pece_rejects_a_forecasted_corrected_phase():
+    pytest.importorskip("scipy")
+    with pytest.raises(RuntimeError, match="exact reanchor policy"):
+        _run_isolated(
+            ["actual", "actual", "forecast"],
+            sigmas=(0.9, 0.7, 0.0),
+            use_pece=True,
+            tau_func="zero",
+            s_noise=0.0,
+        )
+
+
+def test_active_pece_rejects_forecasting_both_phases():
+    pytest.importorskip("scipy")
+    with pytest.raises(RuntimeError, match="exact reanchor policy"):
+        _run_isolated(
+            ["actual", "actual", "actual", "forecast", "forecast"],
+            sigmas=(0.9, 0.7, 0.5, 0.0),
+            use_pece=True,
+            tau_func="zero",
+            s_noise=0.0,
+        )
+
+
+def test_active_pece_forecast_preserves_native_tau_and_noise_call_order():
+    pytest.importorskip("scipy")
+    native = _run_native(use_pece=True)
+    accelerated = _run_isolated(
+        ["actual", "actual", "actual", "forecast", "actual", "actual", "actual"],
+        use_pece=True,
+        forecast_offset=25.0,
+    )
+
+    assert accelerated.tau_args == pytest.approx(native.tau_args)
+    assert accelerated.noise_args == pytest.approx(native.noise_args)
+    assert len(accelerated.noise_draws) == len(native.noise_draws)
+    for candidate, expected in zip(
+        accelerated.noise_draws,
+        native.noise_draws,
+        strict=True,
+    ):
+        torch.testing.assert_close(candidate, expected, rtol=0, atol=0)
+    torch.testing.assert_close(accelerated.rng_state, native.rng_state, rtol=0, atol=0)
 
 
 def test_isolated_sa_adapter_uses_forecast_in_current_corrector_but_not_next_history(monkeypatch):
@@ -456,7 +846,10 @@ def test_isolated_sa_adapter_uses_forecast_in_current_corrector_but_not_next_his
         "compute_stochastic_adams_b_coeffs",
         capture,
     )
-    sigmas = torch.tensor([0.9, 0.7, 0.5, 0.3, 0.0], dtype=torch.float32)
+    # Keep the following exact endpoint non-terminal so native PEC executes
+    # its current corrector there; a terminal zero intentionally suppresses the
+    # PEC corrector.
+    sigmas = torch.tensor([0.9, 0.7, 0.5, 0.3, 0.1], dtype=torch.float32)
     lambdas = native_sampling.sigma_to_half_log_snr(
         sigmas,
         model_sampling=_ModelSampling(),
@@ -695,6 +1088,30 @@ def test_sa_model_call_accounting_tracks_pec_and_pece(
     assert _sa_solver_expected_model_calls(sampler, torch.tensor(sigmas)) == expected
 
 
+def test_active_pece_call_topology_has_explicit_same_coordinate_phase_identity():
+    sampler = _sampler(
+        "sample_sa_solver_pece",
+        {"corrector_order": 4},
+    )
+    topology = _sa_solver_call_topology(
+        sampler,
+        torch.tensor([0.9, 0.7, 0.5, 0.0]),
+    )
+
+    assert topology is not None
+    assert [
+        (entry.outer_step, entry.stage_index, entry.phase)
+        for entry in topology
+    ] == [
+        (0, 0, "predicted"),
+        (1, 0, "predicted"),
+        (1, 1, "corrected"),
+        (2, 0, "predicted"),
+        (2, 1, "corrected"),
+    ]
+    assert _sa_solver_is_active_pece(sampler)
+
+
 def test_sa_continuum_prefix_is_outer_step_identity_for_reviewed_pec():
     sampler = _sampler("sample_sa_solver")
 
@@ -711,8 +1128,6 @@ def test_sa_continuum_prefix_is_outer_step_identity_for_reviewed_pec():
 @pytest.mark.parametrize(
     ("function_name", "options", "message"),
     (
-        ("sample_sa_solver", {"use_pece": True}, "duplicate-sigma"),
-        ("sample_sa_solver_pece", {}, "duplicate-sigma"),
         ("sample_sa_solver", {"predictor_order": True}, "predictor_order"),
         ("sample_sa_solver", {"corrector_order": -1}, "corrector_order"),
         ("sample_sa_solver", {"s_noise": float("nan")}, "s_noise"),
@@ -727,7 +1142,7 @@ def test_sa_unsupported_options_fail_closed(function_name, options, message):
     assert message in reason
 
 
-def test_native_sa_sampler_contract_accepts_pec_and_inert_pece_options():
+def test_native_sa_sampler_contract_accepts_pec_and_pece_options():
     if not os.environ.get("COMFYUI_PATH"):
         pytest.skip("COMFYUI_PATH is required for native SA sampler provenance")
     pytest.importorskip("torchsde")
@@ -753,9 +1168,14 @@ def test_native_sa_sampler_contract_accepts_pec_and_inert_pece_options():
         "sa_solver_pece",
         {"tau_func": tau_func, "corrector_order": 0},
     )
+    active_pece = comfy.samplers.ksampler(
+        "sa_solver_pece",
+        {"tau_func": tau_func, "corrector_order": 4},
+    )
 
     assert _sa_solver_sampler_contract(pec) == (True, None)
     assert _sa_solver_sampler_contract(inert_pece) == (True, None)
+    assert _sa_solver_sampler_contract(active_pece) == (True, None)
 
 
 @pytest.mark.parametrize(
@@ -765,7 +1185,7 @@ def test_native_sa_sampler_contract_accepts_pec_and_inert_pece_options():
         ("sa_solver_pece", {"corrector_order": 4}),
     ),
 )
-def test_native_sa_sampler_contract_rejects_active_pece(sampler_name, options):
+def test_native_sa_sampler_contract_accepts_active_pece(sampler_name, options):
     if not os.environ.get("COMFYUI_PATH"):
         pytest.skip("COMFYUI_PATH is required for native SA sampler provenance")
     pytest.importorskip("torchsde")
@@ -778,9 +1198,123 @@ def test_native_sa_sampler_contract_rejects_active_pece(sampler_name, options):
         comfy.samplers.ksampler(sampler_name, options)
     )
 
-    assert not accepted
-    assert reason is not None
-    assert "duplicate-sigma" in reason
+    assert accepted
+    assert reason is None
+
+
+def test_generic_sa_pece_option_is_consumed_before_adapter_forwarding(monkeypatch):
+    calls = []
+
+    class FakeSampler:
+        def __init__(self):
+            def sample_sa_solver():
+                return None
+
+            sample_sa_solver.__name__ = "sample_sa_solver"
+            self.sampler_function = sample_sa_solver
+            self.extra_options = {
+                "use_pece": True,
+                "corrector_order": 4,
+                "predictor_order": 3,
+                "simple_order_2": False,
+                "s_noise": 0.0,
+            }
+            self.inpaint_options = {}
+
+        def sample(
+            self,
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        ):
+            return self.sampler_function(
+                model_wrap,
+                noise,
+                sigmas,
+                extra_args=extra_args,
+                callback=callback,
+                disable=disable_pbar,
+                **self.extra_options,
+            )
+
+    sampler = FakeSampler()
+
+    class Executor:
+        class_obj = sampler
+        wrappers = (object(),)
+
+        def __call__(self, *args, **kwargs):
+            raise AssertionError("native fallback must not be used")
+
+    def isolated(
+        runtime,
+        model,
+        x,
+        sigmas,
+        *,
+        use_pece,
+        corrector_order,
+        predictor_order,
+        simple_order_2,
+        s_noise,
+        **kwargs,
+    ):
+        calls.append(
+            {
+                "use_pece": use_pece,
+                "corrector_order": corrector_order,
+                "predictor_order": predictor_order,
+                "simple_order_2": simple_order_2,
+                "s_noise": s_noise,
+                "kwargs": kwargs,
+            }
+        )
+        return x
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_sample_sa_solver_forecast_isolated",
+        isolated,
+    )
+
+    runtime = SimpleNamespace(
+        disable_forecasting_for_run=lambda _reason: None,
+        config=SimpleNamespace(debug=False),
+    )
+    result = _run_solver_aware_sa(
+        Executor(),
+        runtime,
+        object(),
+        torch.tensor([1.0, 0.0]),
+        {},
+        None,
+        torch.ones(1),
+        None,
+        None,
+        True,
+    )
+
+    torch.testing.assert_close(result, torch.ones(1))
+    assert calls == [
+        {
+            "use_pece": True,
+            "corrector_order": 4,
+            "predictor_order": 3,
+            "simple_order_2": False,
+            "s_noise": 0.0,
+            "kwargs": {
+                "extra_args": {},
+                "callback": None,
+                "disable": True,
+                "continuum_active": False,
+            },
+        }
+    ]
 
 
 def test_sa_solver_replay_is_intentionally_causal_only():
@@ -904,52 +1438,99 @@ def test_sa_offline_request_runs_one_causal_spectrum_pass(monkeypatch, caplog):
     assert "running one causal Spectrum pass" in caplog.text
 
 
-def test_active_pece_falls_back_before_runtime_state(monkeypatch, caplog):
+
+@pytest.mark.parametrize(
+    ("policy", "expected_prefix"),
+    (
+        ("balanced", 2),
+        ("stable_start", 3),
+        ("max_speed", 1),
+    ),
+)
+def test_active_pece_outer_wrapper_enters_phase_aware_runtime(
+    monkeypatch,
+    policy,
+    expected_prefix,
+):
     runtime = SpectrumH3Runtime(
-        SpectrumH3Config(model_aware_mode="off", offline_smoothing_replay=False)
+        SpectrumH3Config(
+            model_aware_mode="off",
+            offline_smoothing_replay=False,
+            sa_pece_forecast_policy=policy,
+        )
     )
     guider = SimpleNamespace(
         model_options={
             BINDING_KEY: SpectrumH3Binding(runtime),
             "transformer_options": {},
         },
-        model_patcher=object(),
+        model_patcher=_Patcher(),
     )
     sampler = _sampler(
         "sample_sa_solver",
-        {"use_pece": True, "corrector_order": 4},
+        {"use_pece": True, "corrector_order": 4, "s_noise": 0.0},
     )
     calls = []
 
     monkeypatch.setattr(
         sampling_module,
         "_native_sa_solver_preflight_reason",
-        lambda _sampler, _model_options: (
-            "SA-Solver PECE with an active corrector has duplicate-sigma "
-            "predicted/corrected states and is not reviewed for Spectrum forecasting"
-        ),
+        lambda _sampler, _model_options: None,
     )
 
     class Executor:
         class_obj = guider
 
         def __call__(self, *args, **kwargs):
-            calls.append((runtime.active_run_id, args, kwargs))
-            return "native-pece"
+            run = runtime._run
+            assert run is not None
+            calls.append(
+                {
+                    "run_id": runtime.active_run_id,
+                    "total_steps": runtime.stats.total_steps,
+                    "stage_count": run.stage_count,
+                    "separate_stage_histories": run.separate_stage_histories,
+                    "forecastable": run.forecastable_stage_indices,
+                    "history_stages": run.history_stage_indices,
+                    "history_steps": run.history_step_ids,
+                    "tail_stages": run.tail_actual_stage_indices,
+                    "bootstrap": run.allow_state_conditioned_bootstrap,
+                    "sampler_prefix": run.min_sampler_actual_prefix_steps,
+                    "topology": run.logical_call_topology,
+                    "model_aware_force_actual": run.model_aware_can_force_actual,
+                }
+            )
+            return "phase-aware-pece"
 
-    with caplog.at_level("WARNING"):
-        result = outer_sample_wrapper(
-            Executor(),
-            torch.ones(1),
-            torch.zeros(1),
-            sampler,
-            torch.tensor([1.0, 0.7, 0.4, 0.0]),
-            seed=17,
-        )
+    result = outer_sample_wrapper(
+        Executor(),
+        torch.ones(1),
+        torch.zeros(1),
+        sampler,
+        torch.tensor([1.0, 0.7, 0.4, 0.0]),
+        seed=17,
+    )
 
-    assert result == "native-pece"
+    assert result == "phase-aware-pece"
     assert len(calls) == 1
-    assert calls[0][0] is None
+    call = calls[0]
+    assert call["run_id"] == 1
+    assert call["total_steps"] == 5
+    assert call["stage_count"] == 2
+    assert call["separate_stage_histories"] is False
+    assert call["forecastable"] == (0,)
+    assert call["history_stages"] == frozenset({0, 1})
+    assert call["history_steps"] == frozenset({0, 2, 4})
+    assert call["tail_stages"] == frozenset({1})
+    assert call["bootstrap"] is True
+    assert call["sampler_prefix"] == expected_prefix
+    assert [entry.phase for entry in call["topology"]] == [
+        "predicted",
+        "predicted",
+        "corrected",
+        "predicted",
+        "corrected",
+    ]
+    assert call["model_aware_force_actual"] is False
     assert runtime.active_run_id is None
-    assert "running the untouched native sampler" in caplog.text
-    assert "duplicate-sigma" in caplog.text
+

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -130,7 +130,9 @@ def test_sa_policy_separates_stochastic_tail_burst_from_deterministic_refresh(fu
 
     sampler.extra_options = {"s_noise": 0.0}
     assert max_consecutive_forecasts(sampler) == 1
-    assert min_actual_steps_after_forecast(sampler) == 4
+    assert min_actual_steps_after_forecast(sampler) == (
+        0 if function_name == "sample_sa_solver_pece" else 4
+    )
 
     sampler.extra_options = {
         "s_noise": 0.0,
@@ -138,6 +140,14 @@ def test_sa_policy_separates_stochastic_tail_burst_from_deterministic_refresh(fu
         "corrector_order": 0,
     }
     assert min_actual_steps_after_forecast(sampler) == 2
+
+    if function_name == "sample_sa_solver":
+        sampler.extra_options = {
+            "s_noise": 0.0,
+            "use_pece": True,
+            "corrector_order": 4,
+        }
+        assert min_actual_steps_after_forecast(sampler) == 0
 
 
 def test_unsupported_sampler_has_no_forecast_streak_policy():


### PR DESCRIPTION
## Summary

Add full Spectrum acceleration for active native ComfyUI SA-Solver PECE:

- `sa_solver_pece` with `corrector_order > 0`;
- `sa_solver` with `use_pece=True` and `corrector_order > 0`.

Active PECE is represented as the native predicted/corrected topology rather than a generic two-stage approximation. Predicted and corrected H3 evaluations at the same sigma remain distinct latent states, corrected endpoints remain exact, and persistent solver/Spectrum history contains actual endpoint observations only.

## Final ownership model

For `N` outer intervals, native active PECE executes:

```text
P0
P1 C1
P2 C2
...
P(N-1) C(N-1)
```

Spectrum persistent feature/Adams ownership is:

```text
P0, C1, C2, C3, ...
```

A forecasted `P_i` is ephemeral to the current corrector and is never promoted into persistent Adams evidence. Every `C_i` is an actual H3 evaluation and replaces the ephemeral predicted endpoint before the next predictor.

For a forecasted predicted phase, Spectrum's cheap hidden forecast is retained for runtime/accounting continuity but is not passed to SA as its denoised value. SA consumes causal solver-space dense output derived only from exact persistent endpoints:

- one endpoint: latest-exact hold;
- two endpoints: bounded two-anchor lambda-space extrapolation;
- invalid/nonfinite/reversed/excessive geometry: latest-exact hold;
- H3 Continuum: latest-exact hold for every forecast coordinate.

Native sigma placement, tau, stochastic variance, noise draws/RNG order, predictor/corrector equations, PECE endpoint replacement, callbacks, and terminal semantics remain authoritative.

## Active-PECE forecast policy

The user-facing `sa_pece_forecast_policy` selector is append-only in the node's optional widgets so existing saved workflow positions retain their meaning.

| Policy | Protected predicted phases | Clean 10-outer topology | Role |
|---|---:|---:|---|
| `max_speed` | P0 | 10 actual / 9 forecast | Higher-speed option |
| `balanced` **default** | P0, P1 | 11 actual / 8 forecast | Released quality/speed default |
| `stable_start` | P0, P1, P2 | 12 actual / 7 forecast | More conservative start |

A larger user `warmup_steps`, H3 Continuum prefixes, hard external-patch transitions, fallbacks, force-actual conditions, and final correctness boundaries always take precedence over these nominal counts.

The release default is now **`balanced`**. Matched production testing found both `max_speed` and `balanced` structurally clean and capable of acceptable decoded output, while `balanced` was perceptually better in the tested MiniMax-H3 workflow. The early coarse/colored-shape previews seen during the first few denoising steps also occur with other MiniMax-H3 samplers and are not treated as an SA-PECE correctness failure.

## Production media evidence

The final 10-outer production stack included runtime LoRA/DoRA hooks, DiffAid, Untwist-RoPE, Spectrum full/model-aware mode, RefDelta SA-Solver PECE, and H3 Continuum.

The maximum-speed run produced the expected conservative production accounting after hard boundaries:

- initial chunk: **12 actual / 7 forecast**;
- Continuum chunk: **13 actual / 6 forecast**;
- corrected phases: **9 actual / 0 forecast**;
- zero fallbacks, bypasses, rollbacks, speculative calls, discarded actual calls, or external-patch contract failures.

The matched balanced run was perceptually preferable. Both remained within the same reviewed endpoint-ownership architecture.

The dedicated RefDelta SA scheduler comparison also finished its media gate: exact `simple_control` was slightly preferred over `simple_adams_bounded`, while both produced acceptable output. That result does not change Spectrum's PECE ownership; Spectrum remains the sole owner of forecast cadence.

## Safety and compatibility

- H3 Continuum protects both phases inside its requested outer-step prefix.
- DiffAid/Untwist hard transitions promote a predicted forecast to actual before the corrector consumes it.
- Dense interpolation anchors reset after hard transitions while native Adams history is preserved.
- Active PECE uses one shared endpoint history, avoiding duplicate same-coordinate feature anchors.
- Ordinary SA-Solver PEC, SEEDS-2/3, ER-SDE, replay/rollback, and non-SA samplers remain isolated from the PECE policy selector.
- All-actual PECE remains parity-tested against native ComfyUI for call order/output, callbacks, predictor/corrector orders, `simple_order_2`, tau variants, stochastic and deterministic paths, model noise scale, RNG/noise ordering, and terminal/nonterminal schedules.

## Final implementation / CI

Implementation head:

```text
01224bd4f640c60a9da9e0cca677453f48ab33ed
```

Parent/base:

```text
c7942d1308d4bdec2fc078f34c3afb3cfce534fd
```

Final Actions run:

https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/actions/runs/33337115081

All **eight** reviewed ComfyUI/Python matrix lanes pass, including Ruff, compileall, native H3/SA fixtures, and the current reviewed ComfyUI authority `8a33128f2f8c5585c57486c07de481241e70a39c`.

## Stacked RefDelta composition

PR #91 remains the one-commit downstream composition layer. Its current head is:

```text
562b25809f89e101e290203e0f015c5f72132552
```

directly parented by this PR's head. PR #91 adds Spectrum interoperability for RefDelta SEEDS-2/3, SA-Solver PEC, and SA-Solver PECE, and will carry the final Spectrum v0.2.23 release preparation after this PR lands.

## Final merge status

Completed on 2026-08-30.

- merged head: `01224bd4f640c60a9da9e0cca677453f48ab33ed`;
- final eight-lane PR CI: https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/actions/runs/33337115081 — green;
- post-merge `main` CI: https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3/actions/runs/33337247780 — green;
- the stacked RefDelta composition/release layer landed immediately afterward through PR #91;
- the combined result is released as Spectrum v0.2.23.
