### PR TITLE
Validate RefDelta composition on active PECE base

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           persist-credentials: false
           repository: xmarre/ComfyUI-MiniMax-H3-RefDelta-Solver
-          ref: 359c4fed506ca124171a315297273011aee77159
+          ref: 2d980cc42a8fa8f9c476c96200b6dab377ec526a
           path: RefDeltaSolver
 
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -198,11 +198,43 @@ Forecasting is fail-closed and allowlisted for reviewed sampler contracts.
 | RES multistep | `sample_res_multistep` | Conservative cadence with protected native tail. |
 | RES multistep CFG++ | `sample_res_multistep_cfg_pp` | Same RES safeguards. |
 | SEEDS-2 | `sample_seeds_2` | Stochastic outer stage stays exact; internal stage uses exact-current-state + transformer-residual forecasting with shared interleaved history. |
+| RefDelta SEEDS-2 | `sample_refdelta_seeds_2` | Same Spectrum SEEDS stage policy; RefDelta keeps actual-only outer trajectory evidence and reuses one stochastic gate across the native correlated SEEDS noise segments. |
 | SEEDS-3 | `sample_seeds_3` | Same state-conditioned residual architecture; more conservative because two internal stages occur between exact outer anchors. |
+| RefDelta SEEDS-3 | `sample_refdelta_seeds_3` | Same Spectrum SEEDS-3 stage policy with RefDelta outer-trajectory correction and one frozen gate across all three native stochastic segments. |
 | SA-Solver PEC | `sample_sa_solver` | Actual-only persistent Adams history plus causal solver-space dense output; isolated forecasts re-anchor on the next exact H3 evaluation. |
+| RefDelta SA-Solver PEC | `sample_refdelta_sa_solver` | RefDelta trajectory/stochastic control composed around Spectrum's actual-only isolated PEC adapter; the reviewed backend is explicitly PEC-only. |
 | SA-Solver PECE | `sample_sa_solver` / `sample_sa_solver_pece` | Active correctors use explicit predicted/corrected phases; P0 plus exact corrected endpoints own shared persistent history, while later predicted phases are solver-space forecasts unless a correctness boundary promotes them. |
 
 Unknown or changed sampler contracts fall back to native execution rather than guessing.
+
+### RefDelta sampler-family composition
+
+The RefDelta Stability Sampler can select `er_sde`, `seeds_2`, `seeds_3`, or
+`sa_solver`. Spectrum recognizes the corresponding RefDelta sampler functions through a
+separate versioned backend contract. The existing ER-SDE exact-increment contract remains
+unchanged.
+
+For RefDelta SEEDS, Spectrum still owns the reviewed state-conditioned internal-stage
+forecast topology. RefDelta observes/corrects the outer denoiser trajectory only. Its
+stochastic controller resolves one gate for the outer interval and applies that same gate
+to each native SEEDS noise segment, so Spectrum forecasting does not alter the correlated
+noise construction.
+
+For RefDelta SA-Solver, Spectrum's isolated-history **PEC** adapter remains the solver
+owner: only actual denoisers enter persistent Adams history and forecast denoisers are
+ephemeral current-interval inputs. RefDelta is composed around that adapter rather than
+running a second independent SA history pipeline.
+
+The reviewed RefDelta PR #6 backend is deliberately PEC-only: its
+`sample_refdelta_sa_solver` calls native `sample_sa_solver(..., use_pece=False)`.
+Spectrum therefore never promotes that backend into the active-PECE topology. Native
+`sample_sa_solver` / `sample_sa_solver_pece` active PECE remains supported separately by
+Spectrum's predicted/corrected endpoint architecture described below.
+
+The backend bridge classifies each completed Spectrum logical model call as actual or
+forecast. RefDelta uses only actual outer calls as trajectory anchors. Offline smoothing
+replay is intentionally disabled for RefDelta SEEDS/SA composition because the backend
+evidence contract is defined on the live causal trajectory.
 
 For SEEDS-2/3, every denoiser stage is a real MiniMax H3 model-evaluation opportunity and therefore a Spectrum logical model call. A terminal-zero schedule contains `2N - 1` H3 evaluations for SEEDS-2 and `3N - 2` for SEEDS-3 when the outer sampler has `N` sigma intervals.
 

--- a/comfyui_spectrum_h3/refdelta_interop.py
+++ b/comfyui_spectrum_h3/refdelta_interop.py
@@ -20,6 +20,12 @@ REFDELTA_INTEROP_CONTRACT = (
     "actual-anchor-history",
     "exact-gated-stochastic-increment",
 )
+REFDELTA_BACKEND_INTEROP_CONTRACT = (
+    "comfyui-refdelta-spectrum-backend",
+    1,
+    "actual-anchor-history",
+    "native-solver-noise-geometry",
+)
 _REFDELTA_CANONICAL_PACKAGE = "comfyui_refdelta_solver"
 _REFDELTA_ALIAS_METADATA = frozenset(
     {
@@ -100,6 +106,36 @@ def _install_refdelta_namespace_alias_finder() -> None:
 
 
 _install_refdelta_namespace_alias_finder()
+
+
+@dataclass(slots=True)
+class RefDeltaBackendInteropBridge:
+    """Classify RefDelta SEEDS/SA model calls from the completed Spectrum step."""
+
+    runtime: object
+    api_version: ClassVar[int] = 1
+    interop_contract: ClassVar[tuple[str, int, str, str]] = (
+        REFDELTA_BACKEND_INTEROP_CONTRACT
+    )
+
+    def model_result_is_actual(self, step_id: int) -> bool:
+        observed_step = getattr(self.runtime, "last_completed_step_id", None)
+        if observed_step != int(step_id):
+            raise RefDeltaInteropError(
+                "RefDelta backend requested a classification for the wrong Spectrum "
+                f"step (requested={int(step_id)}, observed={observed_step})"
+            )
+        mode = getattr(self.runtime, "last_completed_mode", None)
+        if mode == "actual":
+            return True
+        if mode == "forecast":
+            return False
+        raise RefDeltaInteropError(
+            f"unreviewed Spectrum RefDelta backend step mode {mode!r}"
+        )
+
+    def clear(self) -> None:
+        return None
 
 
 @dataclass(slots=True)
@@ -199,8 +235,10 @@ class RefDeltaInteropBridge:
 
 
 __all__ = [
+    "REFDELTA_BACKEND_INTEROP_CONTRACT",
     "REFDELTA_BRIDGE_KEY",
     "REFDELTA_INTEROP_CONTRACT",
+    "RefDeltaBackendInteropBridge",
     "RefDeltaInteropBridge",
     "RefDeltaInteropError",
 ]

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -23,8 +23,10 @@ from .er_sde_stochastic import (
 )
 from .model_aware import get_model_forecastability_profile
 from .refdelta_interop import (
+    REFDELTA_BACKEND_INTEROP_CONTRACT,
     REFDELTA_BRIDGE_KEY,
     REFDELTA_INTEROP_CONTRACT,
+    RefDeltaBackendInteropBridge,
     RefDeltaInteropBridge,
     RefDeltaInteropError,
 )
@@ -63,10 +65,26 @@ SUPPORTED_SINGLE_CALL_SAMPLERS = frozenset(
     }
 )
 
-SEEDS_SAMPLERS = frozenset({"sample_seeds_2", "sample_seeds_3"})
-SA_SOLVER_SAMPLERS = frozenset({"sample_sa_solver", "sample_sa_solver_pece"})
+NATIVE_SEEDS_SAMPLERS = frozenset({"sample_seeds_2", "sample_seeds_3"})
+REFDELTA_SEEDS_SAMPLERS = frozenset(
+    {"sample_refdelta_seeds_2", "sample_refdelta_seeds_3"}
+)
+SEEDS_SAMPLERS = NATIVE_SEEDS_SAMPLERS | REFDELTA_SEEDS_SAMPLERS
+NATIVE_SA_SOLVER_SAMPLERS = frozenset({"sample_sa_solver", "sample_sa_solver_pece"})
+REFDELTA_SA_SOLVER_SAMPLERS = frozenset({"sample_refdelta_sa_solver"})
+SA_SOLVER_SAMPLERS = NATIVE_SA_SOLVER_SAMPLERS | REFDELTA_SA_SOLVER_SAMPLERS
+REFDELTA_BACKEND_SAMPLERS = REFDELTA_SEEDS_SAMPLERS | REFDELTA_SA_SOLVER_SAMPLERS
 SUPPORTED_SAMPLERS = SUPPORTED_SINGLE_CALL_SAMPLERS | SEEDS_SAMPLERS | SA_SOLVER_SAMPLERS
-SEEDS_STAGE_COUNTS = {"sample_seeds_2": 2, "sample_seeds_3": 3}
+SEEDS_STAGE_COUNTS = {
+    "sample_seeds_2": 2,
+    "sample_seeds_3": 3,
+    "sample_refdelta_seeds_2": 2,
+    "sample_refdelta_seeds_3": 3,
+}
+REFDELTA_SEEDS_BASE_NAMES = {
+    "sample_refdelta_seeds_2": "sample_seeds_2",
+    "sample_refdelta_seeds_3": "sample_seeds_3",
+}
 SEEDS_NATIVE_FUNCTION_DIGESTS = {
     "sample_seeds_2": "e7bcf519718453f77e7ade9b71678c1b593472c8e9b0af142f64f97a9267f383",
     "sample_seeds_3": "8cb90838a30f6ed0d9ba267f0a16275ce8ec5d65a9a5475f1a10cb573d45ce42",
@@ -74,6 +92,12 @@ SEEDS_NATIVE_FUNCTION_DIGESTS = {
 SEEDS_TRACKED_OPTIONS = {
     "sample_seeds_2": frozenset({"eta", "s_noise", "noise_sampler", "r", "solver_type"}),
     "sample_seeds_3": frozenset({"eta", "s_noise", "noise_sampler", "r_1", "r_2"}),
+    "sample_refdelta_seeds_2": frozenset(
+        {"eta", "s_noise", "noise_sampler", "r", "solver_type", "config"}
+    ),
+    "sample_refdelta_seeds_3": frozenset(
+        {"eta", "s_noise", "noise_sampler", "r_1", "r_2", "config"}
+    ),
 }
 
 
@@ -107,6 +131,17 @@ SA_SOLVER_TRACKED_OPTIONS = {
             "predictor_order",
             "corrector_order",
             "simple_order_2",
+        }
+    ),
+    "sample_refdelta_sa_solver": frozenset(
+        {
+            "tau_func",
+            "s_noise",
+            "noise_sampler",
+            "predictor_order",
+            "corrector_order",
+            "simple_order_2",
+            "config",
         }
     ),
 }
@@ -448,6 +483,65 @@ def _sa_solver_stochastic_protection(
     return (), stochastic_input_steps, None
 
 
+def _refdelta_backend_sampler_contract(
+    name: str,
+    function: Any,
+    options: dict[str, Any],
+) -> tuple[bool, str | None]:
+    """Validate the versioned RefDelta SEEDS/SA interop surface."""
+    try:
+        from comfyui_refdelta_solver.config import RefDeltaSamplerConfig
+        from comfyui_refdelta_solver.sampler_backends import (
+            sample_refdelta_sa_solver,
+            sample_refdelta_seeds_2,
+            sample_refdelta_seeds_3,
+        )
+        from comfyui_refdelta_solver.spectrum_interop import (
+            SPECTRUM_BACKEND_INTEROP_CONTRACT,
+        )
+    except (ImportError, AttributeError) as exc:
+        return False, f"RefDelta backend interop API is unavailable: {exc}"
+
+    expected = {
+        "sample_refdelta_seeds_2": sample_refdelta_seeds_2,
+        "sample_refdelta_seeds_3": sample_refdelta_seeds_3,
+        "sample_refdelta_sa_solver": sample_refdelta_sa_solver,
+    }.get(name)
+    if expected is None or function is not expected:
+        return False, "sampler function is not the installed RefDelta backend implementation"
+    if SPECTRUM_BACKEND_INTEROP_CONTRACT != REFDELTA_BACKEND_INTEROP_CONTRACT:
+        return False, "RefDelta/Spectrum backend interop contract version does not match"
+    if (
+        getattr(function, "__spectrum_interop_contract__", None)
+        != REFDELTA_BACKEND_INTEROP_CONTRACT
+    ):
+        return False, "RefDelta backend did not publish the reviewed interop contract"
+
+    config = options.get("config")
+    if type(config) is not RefDeltaSamplerConfig:
+        return False, "RefDelta backend config has unreviewed provenance"
+    try:
+        config.validate()
+    except (TypeError, ValueError) as exc:
+        return False, f"RefDelta backend config is invalid: {exc}"
+    if config.calibration_capture:
+        return False, "RefDelta calibration capture is ER-SDE-only"
+    return True, None
+
+
+def _with_refdelta_backend_bridge(
+    extra_args: dict[str, Any],
+    runtime: SpectrumH3Runtime,
+) -> dict[str, Any]:
+    copied = dict(extra_args or {})
+    model_options = dict(copied.get("model_options") or {})
+    transformer_options = dict(model_options.get("transformer_options") or {})
+    transformer_options[REFDELTA_BRIDGE_KEY] = RefDeltaBackendInteropBridge(runtime)
+    model_options["transformer_options"] = transformer_options
+    copied["model_options"] = model_options
+    return copied
+
+
 def _sa_solver_option_contract(name: str, options: Any) -> str | None:
     """Validate the native SA option surface without executing user callbacks."""
     if name not in SA_SOLVER_SAMPLERS:
@@ -502,10 +596,16 @@ def _sa_solver_sampler_contract(sampler: Any) -> tuple[bool, str | None]:
         return False, f"{name!r} is not a reviewed SA-Solver sampler"
 
     function = getattr(sampler, "sampler_function", None)
-    if function is not getattr(native_sampling, name, None):
-        return False, f"sampler function is not native ComfyUI {name}"
-    if function_ast_digest(function) != SA_SOLVER_NATIVE_FUNCTION_DIGESTS[name]:
-        return False, f"native {name} implementation is not a reviewed revision"
+    if name in REFDELTA_SA_SOLVER_SAMPLERS:
+        options = getattr(sampler, "extra_options", {}) or {}
+        accepted, reason = _refdelta_backend_sampler_contract(name, function, options)
+        if not accepted:
+            return False, reason
+    else:
+        if function is not getattr(native_sampling, name, None):
+            return False, f"sampler function is not native ComfyUI {name}"
+        if function_ast_digest(function) != SA_SOLVER_NATIVE_FUNCTION_DIGESTS[name]:
+            return False, f"native {name} implementation is not a reviewed revision"
     if (
         function_ast_digest(native_sampling.sample_sa_solver)
         != SA_SOLVER_NATIVE_FUNCTION_DIGESTS["sample_sa_solver"]
@@ -594,7 +694,8 @@ def _seeds_option_contract(name: str, options: Any) -> str | None:
     if noise_sampler is not None and not callable(noise_sampler):
         return "SEEDS noise_sampler must be callable or None"
 
-    if name == "sample_seeds_2":
+    base_name = REFDELTA_SEEDS_BASE_NAMES.get(name, name)
+    if base_name == "sample_seeds_2":
         if options.get("solver_type", "phi_1") not in {"phi_1", "phi_2"}:
             return "SEEDS-2 solver_type must be 'phi_1' or 'phi_2'"
         try:
@@ -646,10 +747,20 @@ def _seeds_sampler_contract(sampler: Any) -> tuple[bool, str | None]:
         return False, f"{name!r} is not a reviewed SEEDS sampler"
 
     function = getattr(sampler, "sampler_function", None)
-    if function is not getattr(native_sampling, name, None):
-        return False, f"sampler function is not native ComfyUI {name}"
-    if function_ast_digest(function) != SEEDS_NATIVE_FUNCTION_DIGESTS[name]:
-        return False, f"native {name} implementation is not a reviewed revision"
+    base_name = REFDELTA_SEEDS_BASE_NAMES.get(name, name)
+    if name in REFDELTA_SEEDS_SAMPLERS:
+        options = getattr(sampler, "extra_options", {}) or {}
+        accepted, reason = _refdelta_backend_sampler_contract(name, function, options)
+        if not accepted:
+            return False, reason
+    else:
+        if function is not getattr(native_sampling, name, None):
+            return False, f"sampler function is not native ComfyUI {name}"
+        if function_ast_digest(function) != SEEDS_NATIVE_FUNCTION_DIGESTS[name]:
+            return False, f"native {name} implementation is not a reviewed revision"
+    native_base = getattr(native_sampling, base_name, None)
+    if function_ast_digest(native_base) != SEEDS_NATIVE_FUNCTION_DIGESTS[base_name]:
+        return False, f"native {base_name} implementation is not a reviewed revision"
 
     if type(sampler) is not comfy.samplers.KSAMPLER:
         return False, "SEEDS sampler object is not native ComfyUI KSAMPLER"
@@ -741,6 +852,11 @@ def sampler_supports_seeded_replay(sampler: Any) -> bool:
     if name in SA_SOLVER_SAMPLERS:
         # SA-Solver is a multistep method: replaying altered denoiser values
         # changes its Adams history even when the RNG itself is reproducible.
+        return False
+    if name in REFDELTA_SEEDS_SAMPLERS:
+        # The backend bridge intentionally classifies only the live causal pass.
+        # Do not create an offline replay mode whose provenance cannot be mapped
+        # back to RefDelta's actual-only evidence contract.
         return False
     if name in SEEDS_SAMPLERS:
         options = getattr(sampler, "extra_options", {}) or {}
@@ -1655,28 +1771,58 @@ def _run_solver_aware_sa(
         disable=False,
         **run_options,
     ):
-        # Native `sample_sa_solver` exposes `use_pece` through KSAMPLER
-        # extra_options. Consume that reviewed option here before forwarding the
-        # remaining solver kwargs; otherwise the adapter would pass use_pece
-        # twice when the generic SA entry point is configured for PECE.
+        # Native sample_sa_solver exposes use_pece through KSAMPLER extra_options.
+        # Consume that reviewed option exactly once before forwarding solver kwargs.
         run_options = dict(run_options)
         forwarded_use_pece = run_options.pop("use_pece", use_pece)
         if type(forwarded_use_pece) is not bool or forwarded_use_pece != use_pece:
             raise RuntimeError(
                 "SA isolated-history adapter observed a changed use_pece option"
             )
-        return _sample_sa_solver_forecast_isolated(
-            runtime,
-            model,
-            x,
-            run_sigmas,
-            extra_args=extra_args,
-            callback=callback,
-            disable=disable,
-            use_pece=use_pece,
-            continuum_active=continuum_active,
-            **run_options,
-        )
+
+        refdelta_state = None
+        if name in REFDELTA_SA_SOLVER_SAMPLERS:
+            if use_pece:
+                raise RuntimeError(
+                    "RefDelta SA backend is PEC-only but reached an active PECE adapter"
+                )
+            config = run_options.pop("config", None)
+            if config is None:
+                raise RuntimeError("RefDelta SA adapter lost its validated config")
+            if not config.is_native_equivalence_mode:
+                from comfyui_refdelta_solver.sampler_backends import (
+                    prepare_refdelta_backend_adapters,
+                )
+
+                refdelta_state, model, adapted_noise = (
+                    prepare_refdelta_backend_adapters(
+                        model,
+                        x,
+                        run_sigmas,
+                        extra_args or {},
+                        config,
+                        "sa_solver",
+                        1,
+                        run_options.get("noise_sampler"),
+                    )
+                )
+                run_options["noise_sampler"] = adapted_noise
+        try:
+            return _sample_sa_solver_forecast_isolated(
+                runtime,
+                model,
+                x,
+                run_sigmas,
+                extra_args=extra_args,
+                callback=callback,
+                disable=disable,
+                use_pece=use_pece,
+                continuum_active=continuum_active,
+                **run_options,
+            )
+        finally:
+            if refdelta_state is not None:
+                refdelta_state.finish()
 
     spectrum_sa_function.__name__ = f"{name}_spectrum_isolated_history"
     copied.sampler_function = spectrum_sa_function
@@ -1997,6 +2143,26 @@ def outer_sample_wrapper(
 
     runtime = binding.runtime
     name = sampler_name(sampler)
+    if (
+        (name == REFDELTA_SAMPLER_NAME or name in REFDELTA_BACKEND_SAMPLERS)
+        and "multigpu_clones" in (getattr(guider, "model_options", None) or {})
+    ):
+        LOG.warning(
+            "Spectrum H3 disabled for this RefDelta backend run because multi-GPU "
+            "parallel model calls bypass transactional step finalization; running "
+            "the untouched RefDelta sampler"
+        )
+        return executor(
+            noise,
+            latent_image,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
     expected_model_calls = None
     sa_call_topology = None
     if name in SA_SOLVER_SAMPLERS:
@@ -2148,6 +2314,7 @@ def outer_sample_wrapper(
         not runtime.config.offline_smoothing_replay
         or sampler_supports_seeded_replay(sampler)
         or stochastic_seeds
+        or name in REFDELTA_SEEDS_SAMPLERS
         or name in SA_SOLVER_SAMPLERS
     )
     if runtime.config.model_aware_mode != "off" and profile_eligible:
@@ -2391,6 +2558,21 @@ def outer_sample_wrapper(
             latent_shapes=latent_shapes,
         )
     if not sampler_supports_seeded_replay(sampler):
+        if name in REFDELTA_SEEDS_SAMPLERS:
+            LOG.warning(
+                "Spectrum H3 offline smoothing replay is disabled for RefDelta SEEDS "
+                "because actual-only RefDelta evidence is defined on the live causal pass; "
+                "running one causal state-conditioned Spectrum pass"
+            )
+            return execute_run(
+                noise,
+                latent_image,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                phase="single_pass_replay_fallback",
+            )
         if stochastic_seeds:
             LOG.warning(
                 "Spectrum H3 offline smoothing replay is disabled for stochastic SEEDS "
@@ -2958,7 +3140,24 @@ def sampler_sample_wrapper(
         )
     runtime = binding.runtime
     sampler = executor.class_obj
-    if sampler_name(sampler) in SA_SOLVER_SAMPLERS:
+    name = sampler_name(sampler)
+    if (
+        (name == REFDELTA_SAMPLER_NAME or name in REFDELTA_BACKEND_SAMPLERS)
+        and "multigpu_clones" in ((extra_args or {}).get("model_options") or {})
+    ):
+        return executor(
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
+    if name in REFDELTA_BACKEND_SAMPLERS:
+        extra_args = _with_refdelta_backend_bridge(extra_args, runtime)
+    if name in SA_SOLVER_SAMPLERS:
         return _run_solver_aware_sa(
             executor,
             runtime,
@@ -2971,7 +3170,7 @@ def sampler_sample_wrapper(
             denoise_mask,
             disable_pbar,
         )
-    if sampler_name(sampler) in ER_SDE_SAMPLERS:
+    if name in ER_SDE_SAMPLERS:
         return _run_tracked_er_sde(
             executor,
             runtime,

--- a/tests/test_refdelta_interop.py
+++ b/tests/test_refdelta_interop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -11,10 +11,18 @@ from comfyui_spectrum_h3.er_sde_stochastic import (
     ERSDEStochasticTracker,
 )
 from comfyui_spectrum_h3.refdelta_interop import (
+    REFDELTA_BACKEND_INTEROP_CONTRACT,
     REFDELTA_INTEROP_CONTRACT,
+    RefDeltaBackendInteropBridge,
     RefDeltaInteropBridge,
+    RefDeltaInteropError,
 )
-from comfyui_spectrum_h3.sampling import _refdelta_sampler_contract
+from comfyui_spectrum_h3.sampling import (
+    _refdelta_backend_sampler_contract,
+    _refdelta_sampler_contract,
+    _sa_solver_sampler_contract,
+    _seeds_sampler_contract,
+)
 
 
 def _installed_refdelta():
@@ -152,3 +160,111 @@ def test_bridge_and_tracker_transfer_exact_gated_increment_end_to_end():
 
     torch.testing.assert_close(corrected, torch.tensor([[3.0, 4.0]]), rtol=0, atol=0)
     assert not bridge.model_result_is_actual(1)
+
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    (
+        "sample_refdelta_seeds_2",
+        "sample_refdelta_seeds_3",
+        "sample_refdelta_sa_solver",
+    ),
+)
+def test_installed_refdelta_multi_backend_contract_is_admitted(function_name):
+    try:
+        from comfyui_refdelta_solver.config import RefDeltaSamplerConfig
+        from comfyui_refdelta_solver import sampler_backends
+    except ImportError:
+        pytest.skip("reviewed RefDelta multi-backend package is not on PYTHONPATH")
+
+    function = getattr(sampler_backends, function_name)
+    accepted, reason = _refdelta_backend_sampler_contract(
+        function_name,
+        function,
+        {"config": RefDeltaSamplerConfig()},
+    )
+
+    assert accepted, reason
+    assert (
+        getattr(function, "__spectrum_interop_contract__", None)
+        == REFDELTA_BACKEND_INTEROP_CONTRACT
+    )
+
+
+def test_refdelta_backend_bridge_classifies_only_the_completed_logical_step():
+    runtime = SimpleNamespace(last_completed_step_id=7, last_completed_mode="actual")
+    bridge = RefDeltaBackendInteropBridge(runtime)
+
+    assert bridge.model_result_is_actual(7)
+
+    runtime.last_completed_step_id = 8
+    runtime.last_completed_mode = "forecast"
+    assert not bridge.model_result_is_actual(8)
+
+    with pytest.raises(RefDeltaInteropError, match="wrong Spectrum step"):
+        bridge.model_result_is_actual(7)
+
+
+def test_refdelta_backend_bridge_rejects_unreviewed_runtime_mode():
+    runtime = SimpleNamespace(last_completed_step_id=2, last_completed_mode="replay")
+    bridge = RefDeltaBackendInteropBridge(runtime)
+
+    with pytest.raises(RefDeltaInteropError, match="unreviewed"):
+        bridge.model_result_is_actual(2)
+
+
+
+def test_installed_refdelta_ksamplers_satisfy_reviewed_solver_contracts():
+    try:
+        import comfy.k_diffusion.sampling as native_sampling
+        import comfy.samplers
+        from comfyui_refdelta_solver.config import RefDeltaSamplerConfig
+        from comfyui_refdelta_solver.sampler_backends import (
+            sample_refdelta_sa_solver,
+            sample_refdelta_seeds_2,
+            sample_refdelta_seeds_3,
+        )
+    except ImportError:
+        pytest.skip("reviewed ComfyUI and RefDelta packages are required")
+    if not all(
+        callable(getattr(native_sampling, name, None))
+        for name in ("sample_seeds_2", "sample_seeds_3", "sample_sa_solver")
+    ):
+        pytest.skip("this reviewed ComfyUI lane predates native SEEDS/SA support")
+
+    config = RefDeltaSamplerConfig()
+    seeds_2 = comfy.samplers.KSAMPLER(
+        sample_refdelta_seeds_2,
+        extra_options={
+            "config": config,
+            "eta": 1.0,
+            "s_noise": 1.0,
+            "r": 0.5,
+            "solver_type": "phi_1",
+        },
+    )
+    seeds_3 = comfy.samplers.KSAMPLER(
+        sample_refdelta_seeds_3,
+        extra_options={
+            "config": config,
+            "eta": 1.0,
+            "s_noise": 1.0,
+            "r_1": 1.0 / 3.0,
+            "r_2": 2.0 / 3.0,
+        },
+    )
+    sa = comfy.samplers.KSAMPLER(
+        sample_refdelta_sa_solver,
+        extra_options={
+            "config": config,
+            "s_noise": 1.0,
+            "predictor_order": 3,
+            "corrector_order": 4,
+            "simple_order_2": False,
+        },
+    )
+
+    assert _seeds_sampler_contract(seeds_2) == (True, None)
+    assert _seeds_sampler_contract(seeds_3) == (True, None)
+    assert _sa_solver_sampler_contract(sa) == (True, None)

--- a/tests/test_sa_solver_state_conditioning.py
+++ b/tests/test_sa_solver_state_conditioning.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import ast
-import copy
 import os
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -41,48 +38,16 @@ def _sampler(function_name: str, options: dict | None = None):
 
 
 def _native_sa_functions():
-    comfyui_path = os.environ.get("COMFYUI_PATH")
-    if not comfyui_path:
-        pytest.skip("COMFYUI_PATH is required for synthetic native SA-Solver tests")
-    source_path = Path(comfyui_path) / "comfy/k_diffusion/sampling.py"
-    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    functions = []
-    for name in ("sample_sa_solver", "sample_sa_solver_pece"):
-        function = copy.deepcopy(
-            next(
-                node
-                for node in tree.body
-                if isinstance(node, ast.FunctionDef) and node.name == name
-            )
-        )
-        function.decorator_list = []
-        functions.append(function)
-
-    import comfy.k_diffusion.sa_solver as native_sa_solver
-
-    namespace = {
-        "torch": torch,
-        "trange": lambda count, disable=None: range(count),
-        "default_noise_sampler": lambda x, seed=None: (
-            lambda _sigma, _sigma_next: torch.randn(
-                x.shape,
-                generator=torch.Generator(device=x.device).manual_seed(seed or 0),
-                device=x.device,
-                dtype=x.dtype,
-            )
-        ),
-        "offset_first_sigma_for_snr": lambda sigmas, _sampling: sigmas,
-        "sigma_to_half_log_snr": lambda sigma, model_sampling: -torch.log(sigma),
-        "sa_solver": SimpleNamespace(
-            compute_stochastic_adams_b_coeffs=(
-                native_sa_solver.compute_stochastic_adams_b_coeffs
-            ),
-            get_tau_interval_func=native_sa_solver.get_tau_interval_func,
-        ),
+    if not os.environ.get("COMFYUI_PATH"):
+        pytest.skip("COMFYUI_PATH is required for native SA-Solver tests")
+    try:
+        import comfy.k_diffusion.sampling as native_sampling
+    except ImportError as exc:
+        pytest.skip(f"optional ComfyUI runtime dependency is unavailable: {exc}")
+    return {
+        name: getattr(native_sampling, name)
+        for name in ("sample_sa_solver", "sample_sa_solver_pece")
     }
-    module = ast.fix_missing_locations(ast.Module(body=functions, type_ignores=[]))
-    exec(compile(module, "<native SA-Solver>", "exec"), namespace)  # noqa: S102
-    return namespace
 
 
 class _ModelSampling:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -49,8 +49,11 @@ def _sampler(function_name: str) -> SimpleNamespace:
         "sample_res_multistep_cfg_pp",
         "sample_seeds_2",
         "sample_seeds_3",
+        "sample_refdelta_seeds_2",
+        "sample_refdelta_seeds_3",
         "sample_sa_solver",
         "sample_sa_solver_pece",
+        "sample_refdelta_sa_solver",
     ),
 )
 def test_reviewed_samplers_are_supported(function_name):
@@ -87,6 +90,8 @@ def test_unreviewed_sampler_names_do_not_match_by_prefix(function_name):
         "sample_res_multistep_cfg_pp",
         "sample_seeds_2",
         "sample_seeds_3",
+        "sample_refdelta_seeds_2",
+        "sample_refdelta_seeds_3",
     ),
 )
 def test_supported_h3_samplers_limit_forecast_streaks(function_name):
@@ -110,6 +115,8 @@ def test_res_multistep_policy_refreshes_once_and_protects_tail(function_name):
         "_turbo_sampler",
         "sample_seeds_2",
         "sample_seeds_3",
+        "sample_refdelta_seeds_2",
+        "sample_refdelta_seeds_3",
     ),
 )
 def test_non_res_policy_keeps_one_refresh_and_user_tail(function_name):
@@ -119,7 +126,10 @@ def test_non_res_policy_keeps_one_refresh_and_user_tail(function_name):
     assert min_tail_actual_steps(sampler) == 0
 
 
-@pytest.mark.parametrize("function_name", ("sample_sa_solver", "sample_sa_solver_pece"))
+@pytest.mark.parametrize(
+    "function_name",
+    ("sample_sa_solver", "sample_sa_solver_pece", "sample_refdelta_sa_solver"),
+)
 def test_sa_policy_separates_stochastic_tail_burst_from_deterministic_refresh(function_name):
     sampler = _sampler(function_name)
     sampler.extra_options = {}
@@ -150,6 +160,27 @@ def test_sa_policy_separates_stochastic_tail_burst_from_deterministic_refresh(fu
         assert min_actual_steps_after_forecast(sampler) == 0
 
 
+def test_refdelta_sa_backend_remains_pec_only_on_active_pece_capable_spectrum():
+    sampler = _sampler("sample_refdelta_sa_solver")
+    sampler.extra_options = {"corrector_order": 4}
+
+    assert not sampling_module._sa_solver_is_active_pece(sampler)
+    assert sampling_module._sa_solver_expected_model_calls(
+        sampler,
+        torch.tensor([0.9, 0.7, 0.5, 0.0]),
+    ) == 3
+    topology = sampling_module._sa_solver_call_topology(
+        sampler,
+        torch.tensor([0.9, 0.7, 0.5, 0.0]),
+    )
+    assert topology is not None
+    assert [(entry.outer_step, entry.stage_index, entry.phase) for entry in topology] == [
+        (0, 0, "predicted"),
+        (1, 0, "predicted"),
+        (2, 0, "predicted"),
+    ]
+
+
 def test_unsupported_sampler_has_no_forecast_streak_policy():
     sampler = _sampler("sample_euler_ancestral")
 
@@ -168,6 +199,10 @@ def test_unsupported_sampler_has_no_forecast_streak_policy():
         ("sample_seeds_3", [1.0, 0.6, 0.2, 0.0], 7),
         ("sample_seeds_2", [1.0, 0.6, 0.2], 4),
         ("sample_seeds_3", [1.0, 0.6, 0.2], 6),
+        ("sample_refdelta_seeds_2", [1.0, 0.6, 0.2, 0.0], 5),
+        ("sample_refdelta_seeds_3", [1.0, 0.6, 0.2, 0.0], 7),
+        ("sample_refdelta_seeds_2", [1.0, 0.6, 0.2], 4),
+        ("sample_refdelta_seeds_3", [1.0, 0.6, 0.2], 6),
     ),
 )
 def test_seeds_expected_model_calls_tracks_internal_stages(
@@ -281,6 +316,22 @@ def test_seeds_replay_safety_requires_deterministic_native_configuration(
     assert sampler_supports_seeded_replay(sampler) is replay_safe
 
 
+@pytest.mark.parametrize(
+    ("function_name", "options"),
+    (
+        ("sample_refdelta_seeds_2", {}),
+        ("sample_refdelta_seeds_3", {}),
+        ("sample_refdelta_seeds_2", {"eta": 0.0}),
+        ("sample_refdelta_seeds_3", {"s_noise": 0.0}),
+    ),
+)
+def test_refdelta_seeds_replay_is_intentionally_causal_only(function_name, options):
+    sampler = _sampler(function_name)
+    sampler.extra_options = options
+
+    assert not sampler_supports_seeded_replay(sampler)
+
+
 def test_seeds_2_endpoint_stage_is_rejected_for_spectrum_tracking():
     reason = _seeds_option_contract("sample_seeds_2", {"r": 1.0})
 
@@ -376,6 +427,141 @@ def test_stochastic_seeds_outer_wrapper_enters_state_residual_spectrum(monkeypat
     assert "running the untouched native sampler" not in caplog.text
     assert "feature_geometry=state_conditioned_residual_shared_history" in caplog.text
     assert "stage_histories=shared" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    (
+        "sample_refdelta_er_sde",
+        "sample_refdelta_seeds_2",
+        "sample_refdelta_seeds_3",
+        "sample_refdelta_sa_solver",
+    ),
+)
+def test_refdelta_sampler_multigpu_bypasses_before_runtime_start(
+    monkeypatch,
+    caplog,
+    function_name,
+):
+    runtime = SpectrumH3Runtime(
+        SpectrumH3Config(
+            model_aware_mode="off",
+            offline_smoothing_replay=False,
+        )
+    )
+    guider = SimpleNamespace(
+        model_options={
+            BINDING_KEY: SpectrumH3Binding(runtime),
+            "transformer_options": {},
+            "multigpu_clones": [object()],
+        },
+        model_patcher=object(),
+    )
+    sampler = _sampler(function_name)
+    sampler.extra_options = {}
+    active_runs = []
+
+    def unexpected_preflight(*_args, **_kwargs):
+        raise AssertionError("multi-GPU RefDelta bypass must precede solver preflight")
+
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_er_sde_preflight_reason",
+        unexpected_preflight,
+    )
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_seeds_preflight_reason",
+        unexpected_preflight,
+    )
+    monkeypatch.setattr(
+        sampling_module,
+        "_native_sa_solver_preflight_reason",
+        unexpected_preflight,
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, *args, **kwargs):
+            active_runs.append(runtime.active_run_id)
+            return "native-refdelta-multigpu"
+
+    with caplog.at_level("WARNING"):
+        result = outer_sample_wrapper(
+            Executor(),
+            torch.ones(1),
+            torch.zeros(1),
+            sampler,
+            torch.tensor([1.0, 0.5, 0.0]),
+            seed=17,
+        )
+
+    assert result == "native-refdelta-multigpu"
+    assert active_runs == [None]
+    assert runtime.active_run_id is None
+    assert "multi-GPU parallel model calls bypass transactional step finalization" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    (
+        "sample_refdelta_er_sde",
+        "sample_refdelta_seeds_2",
+        "sample_refdelta_seeds_3",
+        "sample_refdelta_sa_solver",
+    ),
+)
+def test_refdelta_sampler_wrapper_does_not_inject_bridge_for_multigpu(
+    function_name,
+):
+    runtime = SpectrumH3Runtime(SpectrumH3Config(model_aware_mode="off"))
+    runtime.start_run(
+        torch.tensor([1.0, 0.0]),
+        function_name,
+        supported_sampler=True,
+    )
+    sampler = _sampler(function_name)
+    seen = {}
+
+    class Executor:
+        class_obj = sampler
+
+        def __call__(
+            self,
+            model_wrap,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        ):
+            seen["extra_args"] = extra_args
+            return "native-inner-refdelta"
+
+    extra_args = {
+        "model_options": {
+            "multigpu_clones": [object()],
+            "transformer_options": {},
+        }
+    }
+    try:
+        result = sampling_module.sampler_sample_wrapper(
+            Executor(),
+            object(),
+            torch.tensor([1.0, 0.0]),
+            extra_args,
+            None,
+            torch.ones(1),
+        )
+    finally:
+        runtime.end_run(runtime.active_run_id)
+
+    assert result == "native-inner-refdelta"
+    transformer_options = seen["extra_args"]["model_options"]["transformer_options"]
+    assert sampling_module.REFDELTA_BRIDGE_KEY not in transformer_options
 
 
 def test_stochastic_seeds_offline_request_runs_one_causal_spectrum_pass(monkeypatch, caplog):


### PR DESCRIPTION
Temporary validation PR for rebasing #91 onto #92.

This branch is one commit directly on `feature/active-sa-solver-pece-spectrum`.

Key composition boundary:
- #92 remains authoritative for native active PECE predicted/corrected endpoint topology.
- RefDelta SEEDS uses the existing backend classification bridge.
- RefDelta `sample_refdelta_sa_solver` remains PEC-only because reviewed RefDelta PR #6 hard-codes `use_pece=False`.
- The final RefDelta PR #6 head `2d980cc42a8fa8f9c476c96200b6dab377ec526a` is pinned in CI.
- Adds an explicit regression test proving the RefDelta SA identity remains a three-predicted-call PEC topology rather than entering active PECE.

This PR is validation-only; after CI passes, #91 will be rewritten to this tree and based directly on #92.