### PR TITLE
Clarify multistage sampler step and NFE accounting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.event.workflow_run.head_sha }}
+  group: release-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:
@@ -58,7 +58,7 @@ jobs:
           awk '/^---$/ { exit } { print }' RELEASE_NOTES.md > CURRENT_RELEASE_NOTES.md
           test -s CURRENT_RELEASE_NOTES.md
 
-      - name: Publish GitHub release
+      - name: Publish or refresh GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -67,9 +67,52 @@ jobs:
         shell: bash
         run: |
           if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "Release ${TAG} already exists; leaving it unchanged."
+            current_main="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+            if [[ "${RELEASE_SHA}" != "${current_main}" ]]; then
+              echo "Tested commit ${RELEASE_SHA} is no longer current main (${current_main}); refusing to refresh an existing release from a stale workflow run."
+              exit 0
+            fi
+
+            if ! git fetch --force --no-tags --depth=1 origin "refs/tags/${TAG}:refs/tags/${TAG}"; then
+              echo "Failed to fetch existing release tag ${TAG}; refusing to refresh release notes." >&2
+              exit 1
+            fi
+            if ! existing_target="$(git rev-parse "${TAG}^{commit}")"; then
+              echo "Failed to resolve ${TAG} to a commit; refusing to refresh release notes." >&2
+              exit 1
+            fi
+
+            if [[ "${existing_target}" != "${RELEASE_SHA}" ]]; then
+              changed_file_list="$(mktemp)"
+              if ! git diff --name-only "${existing_target}" "${RELEASE_SHA}" > "${changed_file_list}"; then
+                echo "Failed to compare existing release commit ${existing_target} with tested commit ${RELEASE_SHA}; refusing to refresh release notes." >&2
+                rm -f "${changed_file_list}"
+                exit 1
+              fi
+              mapfile -t changed_files < "${changed_file_list}"
+              rm -f "${changed_file_list}"
+
+              docs_only=true
+              for path in "${changed_files[@]}"; do
+                case "${path}" in
+                  README.md|RELEASE_NOTES.md|.github/workflows/release.yml) ;;
+                  *) docs_only=false ;;
+                esac
+              done
+
+              if [[ "${docs_only}" != "true" ]]; then
+                echo "Release ${TAG} already exists and the tested commit contains non-documentation changes; leaving the published release unchanged."
+                exit 0
+              fi
+            fi
+
+            gh release edit "${TAG}" \
+              --title "Spectrum MiniMax H3 ${TAG}" \
+              --notes-file CURRENT_RELEASE_NOTES.md
+            echo "Refreshed release notes for ${TAG}; existing tag target and assets were preserved."
             exit 0
           fi
+
           gh release create "${TAG}" \
             dist/ComfyUI-Spectrum-MiniMax-H3-v${VERSION}.zip \
             dist/SHA256SUMS \

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Full release details are kept in [RELEASE_NOTES.md](RELEASE_NOTES.md) and the Gi
 - Makes **`balanced` the default PECE forecast policy** after matched production testing; `max_speed` remains the higher-speed option and `stable_start` the more conservative option.
 - Adds Spectrum composition for RefDelta Solver v0.6.0 SEEDS-2/3, SA-Solver PEC, and SA-Solver PECE backends while preserving RefDelta's actual-only evidence ownership.
 - Final production testing with DiffAid, Untwist-RoPE and H3 Continuum produced acceptable decoded media with both balanced and max-speed PECE; balanced was perceptually preferred in the tested workflow.
+- Clarifies that sampler `steps` are outer sigma intervals, while SEEDS-2/3 and active PECE expose additional logical H3 model-call opportunities.
 
 ### v0.2.22 — Native SEEDS-2/3 and SA-Solver support
 
@@ -54,6 +55,38 @@ Full release details are kept in [RELEASE_NOTES.md](RELEASE_NOTES.md) and the Gi
 
 - Fixed native ER-SDE forecast "confetti" corruption with solver-space denoised interpolation while preserving the native stochastic trajectory and RNG stream.
 - Hardened post-run teardown so optional generic-correction research work cannot block a completed generation from reaching decode/save.
+
+## Step counts vs. H3 model-call opportunities
+
+The ComfyUI **steps** value is the number of outer sigma intervals. It is **not**
+necessarily the number of logical MiniMax-H3 model-call opportunities. Multi-stage
+solvers and active SA-Solver PECE can expose multiple H3 calls inside one outer interval.
+
+For the usual terminal-zero schedule, with `N = len(sigmas) - 1` outer steps:
+
+| Sampler topology | H3 model-call opportunities | 10 outer steps | 19 outer steps |
+| --- | ---: | ---: | ---: |
+| Ordinary one-call samplers (for example Euler, RES multistep, ER-SDE) | `N` | 10 | 19 |
+| SA-Solver PEC / inactive PECE (`use_pece = false` or `corrector_order = 0`) | `N` | 10 | 19 |
+| SEEDS-2 | `2N - 1` | 19 | 37 |
+| SEEDS-3 | `3N - 2` | 28 | 55 |
+| Active SA-Solver PECE (`use_pece = true`, `corrector_order > 0`) | `2N - 1` | 19 | 37 |
+
+The final SEEDS interval terminates directly at sigma zero, so it does not expose its
+internal stage calls; that is why the usual counts are `2N - 1` and `3N - 2` rather than
+`2N` and `3N`. The active-PECE `2N - 1` formula additionally assumes
+`corrector_order > 0`; with `corrector_order = 0`, PECE reduces to `N` logical H3
+model-call opportunities.
+
+Spectrum's `actual / forecast` accounting is over these **logical H3 model-call
+opportunities**, not over the UI step count. For example, a clean 10-outer-step
+SA-Solver PECE run has 19 logical H3 calls: `balanced` is nominally **11 actual / 8
+forecast**, while `max_speed` is **10 / 9**. Continuum prefixes, hard external-patch
+transitions, warmup, fallbacks, and other force-actual conditions can change that split,
+but they do not change the underlying outer-step count.
+
+This matters when comparing speed across samplers: a 10-step SEEDS-2 or PECE run is not
+an NFE-equivalent comparison with a 10-step Euler/RES/ER-SDE run.
 
 ## Installation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,32 @@
 
 v0.2.23 completes the SA-Solver PECE and RefDelta multi-backend integration and makes **`balanced` the default active-PECE forecast policy** after matched MiniMax-H3 production testing.
 
+## Important: outer steps are not H3 model-call counts
+
+The ComfyUI scheduler's **steps** value counts outer sigma intervals. Some of the newly
+supported solvers expose additional logical H3 model-call opportunities inside those
+intervals, so raw step counts are not NFE-equivalent across sampler families.
+
+For the usual terminal-zero schedule, with `N = len(sigmas) - 1`:
+
+| Sampler topology | Native H3 model-call opportunities | 10 outer steps | 19 outer steps |
+| --- | ---: | ---: | ---: |
+| Euler / RES multistep / ER-SDE | `N` | 10 | 19 |
+| SA-Solver PEC / inactive PECE (`use_pece = false` or `corrector_order = 0`) | `N` | 10 | 19 |
+| SEEDS-2 | `2N - 1` | 19 | 37 |
+| SEEDS-3 | `3N - 2` | 28 | 55 |
+| Active SA-Solver PECE (`use_pece = true`, `corrector_order > 0`) | `2N - 1` | 19 | 37 |
+
+SEEDS omits its internal stage calls on the final sigma-to-zero interval. Active PECE
+with `corrector_order > 0` executes `P0`, then predicted/corrected pairs
+`P1/C1, P2/C2, ...`, giving `N` predicted opportunities plus `N - 1` corrected
+opportunities. With `corrector_order = 0`, PECE collapses to `N`.
+
+Spectrum's actual/forecast ratios are therefore counted over logical H3 model-call opportunities.
+A clean 10-outer-step PECE run contains **19** logical H3 calls: `balanced` is nominally
+**11 actual / 8 forecast** and `max_speed` **10 / 9**. Production safety boundaries may
+promote forecasts to actual, changing the split without changing the 10 outer steps.
+
 ## Active SA-Solver PECE
 
 Spectrum now models native ComfyUI PECE as explicit predicted/corrected evaluations:


### PR DESCRIPTION
## Summary

Clarify the distinction between **outer scheduler steps** and actual MiniMax-H3 model-evaluation opportunities for the newly supported sampler families.

The README and v0.2.23 release notes now state the normal terminal-zero counts explicitly:

| Sampler | H3 model-call opportunities for N outer steps |
| --- | ---: |
| Euler / RES multistep / ER-SDE | N |
| SA-Solver PEC | N |
| SEEDS-2 | 2N - 1 |
| SEEDS-3 | 3N - 2 |
| active SA-Solver PECE | 2N - 1 |

This also explains that a 10-outer-step PECE run has 19 logical H3 opportunities, so a nominal balanced 11 actual / 8 forecast split is over those 19 calls, not 19 scheduler steps.

The release workflow is hardened to allow **release-note-only refreshes** after an already-published version when every change since the release target is limited to README.md, RELEASE_NOTES.md, or the release workflow itself. It preserves the existing tag target and release assets and still refuses to mutate an existing release after any code/package change.

No sampler/runtime behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that sampler step counts represent outer sigma intervals, not individual H3 model evaluations.
  * Added evaluation-count tables for supported sampler topologies, including examples for 10 and 19 outer steps.
  * Documented how Spectrum’s actual/forecast ratios are calculated from logical H3 evaluation opportunities.
* **Release Process**
  * Improved handling of documentation-only release updates while preventing refreshes when source changes cannot be safely verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Release-refresh race safety

The release-note refresh path serializes main-branch release jobs in one repository-level main release group and, before editing an existing release, verifies that the tested SHA is still the current `main` head. That prevents an older completed workflow from overwriting notes produced by a newer documentation commit. Existing tag targets and assets remain unchanged.