### PR TITLE
Remove obsolete RES three-step tail floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ Forecasting is fail-closed and allowlisted for reviewed sampler contracts.
 | Native ER-SDE | `sample_er_sde` | Same conservative cadence plus stochastic-state tracking and solver-space dense output. |
 | RefDelta ER-SDE | `sample_refdelta_er_sde` | Requires RefDelta Solver v0.2.0+; preserves actual-only evidence and transfers the exact adaptive stochastic increment. |
 | MiniMax H3 Turbo | `_turbo_sampler` | Reviewed deterministic single-call contract. |
-| RES multistep | `sample_res_multistep` | Conservative cadence with protected native tail. |
-| RES multistep CFG++ | `sample_res_multistep_cfg_pp` | Same RES safeguards. |
+| RES multistep | `sample_res_multistep` | One exact refresh after each forecast; final-tail protection follows `tail_actual_steps`. |
+| RES multistep CFG++ | `sample_res_multistep_cfg_pp` | Same one-refresh rule; no sampler-specific final-tail floor. |
 | SEEDS-2 | `sample_seeds_2` | Stochastic outer stage stays exact; internal stage uses exact-current-state + transformer-residual forecasting with shared interleaved history. |
 | RefDelta SEEDS-2 | `sample_refdelta_seeds_2` | Same Spectrum SEEDS stage policy; RefDelta keeps actual-only outer trajectory evidence and reuses one stochastic gate across the native correlated SEEDS noise segments. |
 | SEEDS-3 | `sample_seeds_3` | Same state-conditioned residual architecture; more conservative because two internal stages occur between exact outer anchors. |
@@ -251,6 +251,9 @@ Forecasting is fail-closed and allowlisted for reviewed sampler contracts.
 | RefDelta SA-Solver PEC | `sample_refdelta_sa_solver` | RefDelta trajectory/stochastic control composed around Spectrum's actual-only isolated PEC adapter. |
 | SA-Solver PECE | `sample_sa_solver` / `sample_sa_solver_pece` | Active correctors use explicit predicted/corrected phases; P0 plus exact corrected endpoints own shared persistent history, while later predicted phases are solver-space forecasts unless a correctness boundary promotes them. |
 | RefDelta SA-Solver PECE | `sample_refdelta_sa_solver_pece` | Same Spectrum active-PECE endpoint topology and user-selected PECE forecast policy; RefDelta keeps P0/C_i actual endpoint evidence and uses the corrected endpoint to own trajectory/stochastic state. |
+
+
+RES keeps the one-exact-evaluation post-forecast refresh because native RES carries `old_denoised` into the following second-order update. That recurrence safeguard is independent of the final tail. RES no longer raises `tail_actual_steps` internally: the configured final tail remains authoritative, while Continuum prefixes, warmup, external-patch transitions, fallbacks, and other force-actual conditions continue to apply independently.
 
 Unknown or changed sampler contracts fall back to native execution rather than guessing.
 

--- a/comfyui_spectrum_h3/nodes.py
+++ b/comfyui_spectrum_h3/nodes.py
@@ -85,7 +85,7 @@ class SpectrumApplyMiniMaxH3:
                         "max": 64,
                         "step": 1,
                         "tooltip": (
-                            "Requested final native tail. RES enforces its three-step solver tail. "
+                            "Requested final native tail. RES does not add a hidden tail floor; its separate one-actual post-forecast refresh remains enforced. "
                             "ER-SDE offline replay promotes only a penultimate step that the normal schedule would forecast, preserving a future exact terminal anchor without a blanket two-step tail."
                         ),
                     },

--- a/comfyui_spectrum_h3/sampling.py
+++ b/comfyui_spectrum_h3/sampling.py
@@ -165,13 +165,6 @@ SA_SOLVER_TRACKED_OPTIONS = {
     ),
 }
 
-RES_MULTISTEP_SAMPLERS = frozenset(
-    {
-        "sample_res_multistep",
-        "sample_res_multistep_cfg_pp",
-    }
-)
-
 ER_SDE_SAMPLERS = frozenset({"sample_er_sde", "sample_refdelta_er_sde"})
 REFDELTA_SAMPLER_NAME = "sample_refdelta_er_sde"
 ER_SDE_NATIVE_SCALER_MODULE = "comfy_extras.nodes_custom_sampler"
@@ -2077,10 +2070,6 @@ def min_actual_steps_after_forecast(sampler: Any) -> int:
     return 1 if name in SUPPORTED_SAMPLERS else 0
 
 
-def min_tail_actual_steps(sampler: Any) -> int:
-    return 3 if sampler_name(sampler) in RES_MULTISTEP_SAMPLERS else 0
-
-
 def _binding_from_model_options(
     model_options: dict[str, Any] | None,
 ) -> SpectrumH3Binding | None:
@@ -2445,7 +2434,6 @@ def outer_sample_wrapper(
             supported_sampler=sampler_is_supported(sampler),
             max_consecutive_forecasts=max_consecutive_forecasts(sampler),
             min_actual_steps_after_forecast=min_actual_steps_after_forecast(sampler),
-            min_tail_actual_steps=min_tail_actual_steps(sampler),
             min_actual_prefix_steps=phase_prefix,
             min_sampler_actual_prefix_steps=pece_policy_prefix,
             expected_model_calls=expected_model_calls,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1709,7 +1709,7 @@ def test_res_multistep_refreshes_once_without_growing_the_window():
     assert runtime.stats.current_window == pytest.approx(4.0)
 
 
-def test_twenty_step_res_schedule_refreshes_once_and_enforces_three_step_tail():
+def test_twenty_step_res_schedule_refreshes_once_without_sampler_tail_floor():
     runtime = SpectrumH3Runtime(SpectrumH3Config(tail_actual_steps=0))
     runtime.start_run(
         torch.linspace(1.0, 0.0, 21),
@@ -1717,7 +1717,6 @@ def test_twenty_step_res_schedule_refreshes_once_and_enforces_three_step_tail():
         supported_sampler=True,
         max_consecutive_forecasts=1,
         min_actual_steps_after_forecast=1,
-        min_tail_actual_steps=3,
     )
     forecast_indices = []
     previous_was_forecast = False
@@ -1750,10 +1749,43 @@ def test_twenty_step_res_schedule_refreshes_once_and_enforces_three_step_tail():
         previous_was_forecast = not actual
         runtime.finalize_step(decision["run_id"], decision["step_id"])
 
-    assert forecast_indices == [1, 3, 5, 7, 9, 11, 13, 15]
-    assert runtime.stats.actual_steps == 12
-    assert runtime.stats.forecast_steps == 8
+    assert forecast_indices == [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+    assert runtime.stats.actual_steps == 10
+    assert runtime.stats.forecast_steps == 10
 
+
+
+def test_three_step_res_progressive_stage_uses_configured_tail_only():
+    runtime = _runtime(
+        warmup_steps=0,
+        tail_actual_steps=1,
+        bootstrap_first_forecast=True,
+        window_size=2.0,
+        flex_window=0.0,
+    )
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.6, 0.2, 0.0]),
+        "sample_res_multistep",
+        supported_sampler=True,
+        max_consecutive_forecasts=1,
+        min_actual_steps_after_forecast=1,
+        min_actual_prefix_steps=1,
+    )
+
+    decisions = [
+        _complete_step(runtime, timestep)
+        for timestep in (1.0, 0.6, 0.2)
+    ]
+
+    assert [decision["actual"] for decision in decisions] == [True, False, True]
+    assert [decision["reason"] for decision in decisions] == [
+        "H3 Continuum actual prefix",
+        "one-point bootstrap forecast",
+        "final actual tail",
+    ]
+    assert runtime.stats.actual_steps == 2
+    assert runtime.stats.forecast_steps == 1
+    runtime.end_run(run_id)
 
 def test_aborted_res_refresh_does_not_consume_refresh_state():
     runtime = _runtime(warmup_steps=2, window_size=4.0, tail_actual_steps=0)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -16,7 +16,6 @@ from comfyui_spectrum_h3.sampling import (
     install_sampler_wrappers,
     max_consecutive_forecasts,
     min_actual_steps_after_forecast,
-    min_tail_actual_steps,
     outer_sample_wrapper,
     predict_noise_wrapper,
     sampler_is_supported,
@@ -100,11 +99,10 @@ def test_supported_h3_samplers_limit_forecast_streaks(function_name):
 
 
 @pytest.mark.parametrize("function_name", ("sample_res_multistep", "sample_res_multistep_cfg_pp"))
-def test_res_multistep_policy_refreshes_once_and_protects_tail(function_name):
+def test_res_multistep_policy_keeps_one_refresh_without_hidden_tail_floor(function_name):
     sampler = _sampler(function_name)
 
     assert min_actual_steps_after_forecast(sampler) == 1
-    assert min_tail_actual_steps(sampler) == 3
 
 
 @pytest.mark.parametrize(
@@ -120,11 +118,10 @@ def test_res_multistep_policy_refreshes_once_and_protects_tail(function_name):
         "sample_refdelta_seeds_3",
     ),
 )
-def test_non_res_policy_keeps_one_refresh_and_user_tail(function_name):
+def test_non_res_policy_keeps_one_refresh(function_name):
     sampler = _sampler(function_name)
 
     assert min_actual_steps_after_forecast(sampler) == 1
-    assert min_tail_actual_steps(sampler) == 0
 
 
 @pytest.mark.parametrize(
@@ -142,7 +139,6 @@ def test_sa_policy_separates_stochastic_tail_burst_from_deterministic_refresh(fu
 
     assert max_consecutive_forecasts(sampler) == 1
     assert min_actual_steps_after_forecast(sampler) == 0
-    assert min_tail_actual_steps(sampler) == 0
 
     sampler.extra_options = {"s_noise": 0.0}
     assert max_consecutive_forecasts(sampler) == 1
@@ -227,7 +223,6 @@ def test_unsupported_sampler_has_no_forecast_streak_policy():
 
     assert max_consecutive_forecasts(sampler) is None
     assert min_actual_steps_after_forecast(sampler) == 0
-    assert min_tail_actual_steps(sampler) == 0
 
 
 


### PR DESCRIPTION
## Problem

Spectrum still carries a RES-specific `min_tail_actual_steps=3` floor introduced in v0.1.3 as an empirical quality safeguard for the old monolithic 20-step RES path. It is not a native RES solver requirement.

That absolute floor is now actively counterproductive for few-step and progressive workflows. In particular, a fresh 3-step progressive high-resolution suffix is forced entirely actual (`A A A`) even when the user configured `tail_actual_steps=1`, leaving no forecast opportunity at the expensive target grid.

The separate RES recurrence safeguard remains justified: after a forecast, one exact model evaluation must refresh native `old_denoised` before another forecast can occur. This PR keeps that rule unchanged.

## Change

- remove the RES-only `min_tail_actual_steps()` helper and hardcoded floor of 3;
- stop injecting a sampler-specific final-tail minimum into `SpectrumH3Runtime.start_run`;
- keep `min_actual_steps_after_forecast=1` for `sample_res_multistep` and `sample_res_multistep_cfg_pp`;
- leave the generic runtime tail-floor mechanism intact for callers that explicitly need it;
- make the user-configured `tail_actual_steps` authoritative for RES;
- preserve independent exactness constraints from Continuum prefixes, warmup, external-patch transitions, fallbacks, force-actual mode, and other sampler/runtime contracts;
- update the node tooltip and README so the UI no longer claims RES has a hidden three-step tail.

No native RES equations, sigma ordering, `old_denoised` update ordering, CFG++ behavior, exact-mask handling, or model-wrapper topology are changed.

## Regression coverage

- the existing 20-step RES scheduling test now verifies the one-refresh cadence without a hidden tail floor: with `tail_actual_steps=0`, forecasts may continue through the final eligible alternating position rather than being cut off by the old 3-step floor;
- a new 3-step progressive-style regression uses a one-step Continuum exact prefix plus `tail_actual_steps=1` and verifies the intended `A F A` topology:
  - step 0: exact Continuum prefix;
  - step 1: one-point bootstrap forecast;
  - step 2: configured final exact tail.

## Real progressive RES validation

A full production-stack RES rerun exercises the changed path successfully with VDN-H3, RuntimeBypass DoRA/LoRA, DiffAid, Untwist RoPE, Flow Mixed-Grid, Continuum, and Spectrum enabled.

Observed Spectrum topology:

- standalone low stage, 5 RES steps: `A F A F A` -> 3 actual + 2 forecast;
- standalone high stage, 3 RES steps with Continuum prefix 1: `A F A` -> 2 actual + 1 forecast;
- continuation low/mixed-grid stage, 5 RES steps with Continuum prefix 2: `A A F A A` -> 4 actual + 1 forecast;
- continuation high stage, 3 RES steps with Continuum prefix 1: `A F A` -> 2 actual + 1 forecast.

Across the four RES stages this is 16 logical calls -> 11 actual H3 evaluations + 5 Spectrum forecasts. The two exact handoff probes add 2 actual H3 evaluations, for 13 total actual transformer NFEs across the progressive workflow. This matches the successful Euler control's aggregate `13 actual + 5 forecast + 2 probe` topology.

Critically, both expensive 3-step high-resolution RES stages now use the intended `A F A` schedule. The removed tail floor no longer converts them into `A A A`.

All four RES runs report `fallbacks=0`. The workflow completed normally in 537.36 s; `H3ContinuumSamplerV34` accounted for 423.12 s. The first RES high stage completed in 65.230 s and the continuation high stage in 77.122 s.

Perceptual validation also passed: the maintainer reviewed the decoded result and reported both video quality and audio as excellent, with overall quality better than the matched Euler control. This closes the original empirical-quality rationale for retaining the RES-specific three-step tail floor in the current progressive/VDN workflow.

## Supporting Euler control

The matched Euler progressive control also exercised the intended short-stage topology successfully. Across that workflow it reported 18 logical sampler calls, 13 actual transformer NFEs, 5 Spectrum forecasts, and 2 exact handoff-probe NFEs. The two 3-step high-resolution stages each ran `A F A`, giving 4 actual + 2 forecast high-stage calls in total, with zero Spectrum fallbacks. The decoded output was manually reviewed as excellent.

## Validation status

- temporary edit runner: `compileall` passed;
- `git diff --check` passed;
- GitHub Actions run **576** passed the full eight-lane reviewed ComfyUI/Python matrix, including Ruff, compileall, focused compatibility suites, wheel build, forecaster smoke test, and native MiniMax-H3 tests;
- real production-stack progressive RES rerun passed with the intended schedule and zero Spectrum fallbacks;
- decoded video and audio passed maintainer perceptual validation, with the RES output judged better than the matched Euler control;
- branch is exactly one focused commit over current `main`.
