### PR TITLE
Bypass Comfy Compiler malloc graphs during Spectrum H3 steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,10 @@ jobs:
             python_version: "3.12"
             comfy_kitchen_version: "0.2.31"
             comfy_aimdo_version: "0.4.15"
+          - comfy_ref: 15eb748b3ec5f8a0a2d470b7fb280e2d7579f916
+            python_version: "3.12"
+            comfy_kitchen_version: "0.2.33"
+            comfy_aimdo_version: "0.5.2"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -91,6 +95,7 @@ jobs:
             tests/test_external_patch_transaction_parity.py \
             --ignore I001,UP037
           python -m ruff check \
+            comfyui_spectrum_h3/comfy_compiler_compat.py \
             comfyui_spectrum_h3/config.py \
             comfyui_spectrum_h3/generic_correction.py \
             comfyui_spectrum_h3/generic_correction_calibration.py \
@@ -113,6 +118,7 @@ jobs:
             comfyui_spectrum_h3/runtime.py \
             comfyui_spectrum_h3/sampling.py \
             comfyui_spectrum_h3/__init__.py \
+            tests/test_comfy_compiler_compat.py \
             tests/test_config.py \
             tests/test_continuum_interop.py \
             tests/test_er_sde_solver_dense_output.py \

--- a/comfyui_spectrum_h3/__init__.py
+++ b/comfyui_spectrum_h3/__init__.py
@@ -1,3 +1,4 @@
+from .comfy_compiler_compat import install_comfy_compiler_compat
 from .config import AGGRESSIVE_PRESET, CONSERVATIVE_PRESET, SpectrumH3Config
 from .er_sde_offline_replay_safety import install_er_sde_offline_replay_safety
 from .er_sde_policy import install_er_sde_tail_policy
@@ -40,6 +41,9 @@ install_external_patch_compat()
 install_visual_reference_patch_compat()
 install_external_patch_hardening()
 install_er_sde_offline_replay_safety()
+# Compiler compatibility must be outermost: it owns the thread-local lifetime
+# from Spectrum step entry through every already-installed finalize/end wrapper.
+install_comfy_compiler_compat()
 
 # External compatibility wraps the already-installed safe end-run hook. Preserve
 # the inner implementation's identity and expose the effective outermost hook

--- a/comfyui_spectrum_h3/comfy_compiler_compat.py
+++ b/comfyui_spectrum_h3/comfy_compiler_compat.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from functools import wraps
+import sys
+import threading
+from typing import Any
+
+from .runtime import SpectrumH3Runtime
+
+
+_STATE = threading.local()
+_RUNTIME_INSTALL_MARKER = "_comfy_compiler_compat_installed"
+
+
+def _bypass_depth() -> int:
+    return int(getattr(_STATE, "bypass_depth", 0))
+
+
+def _compiler_bypass_active() -> bool:
+    return _bypass_depth() > 0
+
+
+def _enter_compiler_bypass() -> None:
+    _STATE.bypass_depth = _bypass_depth() + 1
+
+
+def _exit_compiler_bypass() -> None:
+    depth = _bypass_depth()
+    if depth <= 1:
+        _STATE.bypass_depth = 0
+    else:
+        _STATE.bypass_depth = depth - 1
+
+
+def _clear_compiler_bypass() -> None:
+    _STATE.bypass_depth = 0
+
+
+def _ensure_model_prefetch_hook() -> bool:
+    """Make current-thread Spectrum steps opt out of Comfy Compiler malloc graphs.
+
+    The hook is installed lazily because Spectrum's package can be imported by
+    smoke tests before ComfyUI itself is importable. During an active Spectrum
+    solver step the native MiniMax H3 ``forward`` therefore sees
+    ``malloc_graph_enabled(...) == False`` and does not enter Aimdo's persistent
+    allocation graph. DynamicVRAM and Comfy Compiler remain unchanged outside
+    that narrow thread-local step scope.
+    """
+    model_prefetch = sys.modules.get("comfy.model_prefetch")
+    if model_prefetch is None:
+        return False
+
+    current = getattr(model_prefetch, "malloc_graph_enabled", None)
+    if not callable(current):
+        return False
+    installed = getattr(
+        model_prefetch,
+        "_spectrum_h3_malloc_graph_enabled_wrapper",
+        None,
+    )
+    if current is installed:
+        return True
+
+    @wraps(current)
+    def spectrum_safe_malloc_graph_enabled(device: Any) -> bool:
+        if _compiler_bypass_active():
+            return False
+        return bool(current(device))
+
+    model_prefetch.malloc_graph_enabled = spectrum_safe_malloc_graph_enabled
+    model_prefetch._spectrum_h3_malloc_graph_enabled_wrapper = (
+        spectrum_safe_malloc_graph_enabled
+    )
+    return True
+
+
+def install_comfy_compiler_compat() -> None:
+    """Install Spectrum's step-scoped Comfy Compiler compatibility boundary.
+
+    The first #99 candidate only paused retained-history allocation. The reporter's
+    CUDA retest completed one prompt but the next prompt still crashed in
+    ``MallocGraph.pop``. Spectrum changes the native H3 allocation/control trace
+    more broadly than its retained history alone (actual calls execute the
+    transformer while forecast/replay calls skip it), so the safe boundary is the
+    complete Spectrum solver step, before native H3 decides whether to start a
+    malloc graph.
+
+    This installer must run after Spectrum's other runtime compatibility layers so
+    its start/step/finalize/end scopes remain the outermost lifecycle boundary.
+    """
+    if getattr(SpectrumH3Runtime, _RUNTIME_INSTALL_MARKER, False):
+        _ensure_model_prefetch_hook()
+        return
+
+    original_start_run = SpectrumH3Runtime.start_run
+    original_begin_step = SpectrumH3Runtime.begin_step
+    original_finalize_step = SpectrumH3Runtime.finalize_step
+    original_end_run = SpectrumH3Runtime.end_run
+
+    @wraps(original_start_run)
+    def start_run(self: SpectrumH3Runtime, *args: Any, **kwargs: Any):
+        # Recover conservatively if an earlier Python exception escaped before the
+        # normal end_run/finalize cleanup path on this worker thread.
+        _clear_compiler_bypass()
+        _ensure_model_prefetch_hook()
+        return original_start_run(self, *args, **kwargs)
+
+    @wraps(original_begin_step)
+    def begin_step(self: SpectrumH3Runtime, *args: Any, **kwargs: Any):
+        result = original_begin_step(self, *args, **kwargs)
+        _ensure_model_prefetch_hook()
+        _enter_compiler_bypass()
+        return result
+
+    @wraps(original_finalize_step)
+    def finalize_step(self: SpectrumH3Runtime, *args: Any, **kwargs: Any):
+        try:
+            return original_finalize_step(self, *args, **kwargs)
+        finally:
+            _exit_compiler_bypass()
+
+    @wraps(original_end_run)
+    def end_run(self: SpectrumH3Runtime, *args: Any, **kwargs: Any):
+        try:
+            return original_end_run(self, *args, **kwargs)
+        finally:
+            # An exception can abort a sampler before finalize_step. Never let a
+            # stale thread-local bypass leak into an unrelated later workflow.
+            _clear_compiler_bypass()
+
+    SpectrumH3Runtime.start_run = start_run
+    SpectrumH3Runtime.begin_step = begin_step
+    SpectrumH3Runtime.finalize_step = finalize_step
+    SpectrumH3Runtime.end_run = end_run
+    setattr(SpectrumH3Runtime, _RUNTIME_INSTALL_MARKER, True)
+    _ensure_model_prefetch_hook()
+
+
+__all__ = [
+    "install_comfy_compiler_compat",
+]

--- a/tests/test_comfy_compiler_compat.py
+++ b/tests/test_comfy_compiler_compat.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import SpectrumH3Runtime
+from comfyui_spectrum_h3 import comfy_compiler_compat as compat
+from comfyui_spectrum_h3.config import SpectrumH3Config
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope():
+    compat._clear_compiler_bypass()
+    yield
+    compat._clear_compiler_bypass()
+
+
+def _install_fake_model_prefetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[types.ModuleType, list[object]]:
+    calls: list[object] = []
+    module = types.ModuleType("comfy.model_prefetch")
+
+    def malloc_graph_enabled(device):
+        calls.append(device)
+        return True
+
+    module.malloc_graph_enabled = malloc_graph_enabled
+    monkeypatch.setitem(sys.modules, "comfy.model_prefetch", module)
+    assert compat._ensure_model_prefetch_hook()
+    return module, calls
+
+
+def _runtime() -> SpectrumH3Runtime:
+    return SpectrumH3Runtime(
+        SpectrumH3Config(
+            degree=1,
+            max_history=4,
+            warmup_steps=1,
+            tail_actual_steps=0,
+            window_size=2.0,
+            bootstrap_first_forecast=False,
+            offline_smoothing_replay=False,
+        )
+    )
+
+
+def test_runtime_step_scope_disables_compiler_until_finalize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+    runtime = _runtime()
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+    )
+
+    decision = runtime.begin_step(torch.tensor([1.0]))
+    assert compat._compiler_bypass_active()
+    assert module.malloc_graph_enabled("cuda:0") is False
+    assert calls == []
+
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=(("target_audio_rows", 1), ("target_video_rows", 1)),
+        labels=((0, "positive"),),
+        expected_shape=(1, 2, 3),
+    )
+    assert actual
+    runtime.observe_actual(
+        decision["run_id"],
+        decision["step_id"],
+        call_id,
+        torch.zeros((1, 2, 3)),
+    )
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+
+    assert not compat._compiler_bypass_active()
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+    runtime.end_run(run_id)
+
+
+def test_end_run_clears_unfinalized_runtime_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+    runtime = _runtime()
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+    )
+
+    runtime.begin_step(torch.tensor([1.0]))
+    assert module.malloc_graph_enabled("cuda:0") is False
+    runtime.end_run(run_id)
+
+    assert not compat._compiler_bypass_active()
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+
+
+def test_start_run_clears_stale_scope_from_prior_aborted_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+    compat._enter_compiler_bypass()
+    runtime = _runtime()
+
+    run_id = runtime.start_run(
+        torch.tensor([1.0, 0.0]),
+        "sample_euler",
+        supported_sampler=True,
+    )
+
+    assert not compat._compiler_bypass_active()
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+    runtime.end_run(run_id)
+
+
+def test_compiler_stays_enabled_outside_spectrum_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+
+
+def test_active_spectrum_scope_disables_malloc_graph_without_calling_original(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+
+    compat._enter_compiler_bypass()
+    assert module.malloc_graph_enabled("cuda:0") is False
+    assert calls == []
+
+    compat._exit_compiler_bypass()
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+
+
+def test_nested_scope_remains_disabled_until_outer_scope_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+
+    compat._enter_compiler_bypass()
+    compat._enter_compiler_bypass()
+    compat._exit_compiler_bypass()
+    assert module.malloc_graph_enabled("cuda:0") is False
+    assert calls == []
+
+    compat._exit_compiler_bypass()
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+
+
+def test_end_run_style_clear_cannot_leak_scope_to_later_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, calls = _install_fake_model_prefetch(monkeypatch)
+
+    compat._enter_compiler_bypass()
+    compat._clear_compiler_bypass()
+
+    assert module.malloc_graph_enabled("cuda:0") is True
+    assert calls == ["cuda:0"]
+
+
+def test_model_prefetch_hook_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    module, _ = _install_fake_model_prefetch(monkeypatch)
+    installed = module.malloc_graph_enabled
+
+    assert compat._ensure_model_prefetch_hook()
+    assert module.malloc_graph_enabled is installed
+
+
+def test_missing_model_prefetch_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "comfy.model_prefetch", raising=False)
+    assert compat._ensure_model_prefetch_hook() is False
+
+
+def test_reviewed_comfy_compiler_contract_when_present() -> None:
+    from comfy import model_prefetch
+
+    gate = getattr(model_prefetch, "malloc_graph_enabled", None)
+    if gate is None:
+        pytest.skip("reviewed ComfyUI revision predates Comfy Compiler malloc graphs")
+
+    assert callable(gate)
+    assert callable(getattr(model_prefetch, "malloc_graph_begin", None))
+    assert callable(getattr(model_prefetch, "malloc_graph_end", None))
+
+    # Current Core (a99d1f9 / #16148) exposes this public context manager for
+    # long-lived allocations. Older reviewed compiler revisions do not, and the
+    # Spectrum compatibility boundary deliberately does not require it.
+    pause = getattr(model_prefetch, "pause_malloc_graph", None)
+    if pause is not None:
+        assert callable(pause)
+
+
+def test_runtime_scope_compat_is_installed_once() -> None:
+    start_run = SpectrumH3Runtime.start_run
+    begin_step = SpectrumH3Runtime.begin_step
+    finalize_step = SpectrumH3Runtime.finalize_step
+    end_run = SpectrumH3Runtime.end_run
+    assert getattr(
+        SpectrumH3Runtime,
+        "_comfy_compiler_compat_installed",
+        False,
+    )
+
+    compat.install_comfy_compiler_compat()
+
+    assert SpectrumH3Runtime.start_run is start_run
+    assert SpectrumH3Runtime.begin_step is begin_step
+    assert SpectrumH3Runtime.finalize_step is finalize_step
+    assert SpectrumH3Runtime.end_run is end_run

--- a/tests/test_h3_masked_native_wrapper.py
+++ b/tests/test_h3_masked_native_wrapper.py
@@ -42,7 +42,7 @@ class _CountingBlock(torch.nn.Module):
         super().__init__()
         self.calls = 0
 
-    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options=None):
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options=None, attention=None):
         self.calls += 1
         return x + t_emb[0].mean().to(x.dtype) * 0.01
 

--- a/tests/test_native_equivalence.py
+++ b/tests/test_native_equivalence.py
@@ -35,7 +35,7 @@ class _CountingBlock(torch.nn.Module):
         super().__init__()
         self.calls = 0
 
-    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options=None):
+    def forward(self, x, t_emb, mod_segments, rope_freqs, transformer_options=None, attention=None):
         self.calls += 1
         return x + t_emb[0].mean().to(x.dtype) * 0.01
 
@@ -301,7 +301,7 @@ def test_sa_solver_state_conditioned_forecast_uses_exact_current_input_and_skips
     runtime.end_run(run_id)
 
 
-def test_forced_actual_wrapper_is_native_equivalent_and_does_not_mutate_options():
+def test_forced_actual_wrapper_is_native_equivalent_and_preserves_existing_option_values():
     _, _, PackedLayout = _native_imports()
     model, _ = _tiny_model()
     x, context, payload = _inputs(PackedLayout)
@@ -314,7 +314,7 @@ def test_forced_actual_wrapper_is_native_equivalent_and_does_not_mutate_options(
     )
     run_id = runtime.start_run(torch.tensor([1.0, 0.5, 0.0]), "sample_euler", supported_sampler=True)
     wrapped, _ = _wrapped_call(model, runtime, 1.0, 500.0, x, context, payload)
-    assert native_options == before
+    assert native_options["sentinel"] == before["sentinel"]
     assert isinstance(wrapped, list) and len(wrapped) == 2
     for native_part, wrapped_part in zip(native, wrapped, strict=True):
         assert native_part.shape == wrapped_part.shape


### PR DESCRIPTION
## Scope

Fix #99 without disabling DynamicVRAM or Comfy Compiler for the rest of ComfyUI. The branch remains exactly one commit directly on the published v0.2.24 release commit `a360f64fbfa54681ded100a64ded86a5713ddf17` and remains **draft** until the affected CUDA workflow is reproduced successfully.

## What the first CUDA retest disproved

The first candidate only moved Spectrum's retained CUDA history allocation outside the active Aimdo malloc graph. That was too narrow.

The reporter's retest completed the first prompt, then the **second prompt still segfaulted** in:

```text
comfy_aimdo/malloc_graph.py -> MallocGraph.pop
comfy/model_prefetch.py -> malloc_graph_end
comfy/ldm/minimax/model.py -> MiniMaxH3Model.forward
```

That result rejects the earlier assumption that the retained-history clone was the whole failure. The first prompt also reported `Comfy model compiler graph breaks: 21`, so the allocator was still seeing a non-stable Spectrum execution trace before the later native crash.

## Root integration problem

Current native MiniMax H3 starts a persistent Comfy Compiler/Aimdo allocation graph **before** invoking diffusion-model wrappers and only pops it after the wrapped `_forward` returns. Spectrum therefore executes inside that graph.

Spectrum does not preserve native H3's allocation/control topology across calls:

- an **actual** Spectrum call executes the transformer and observes the final hidden state;
- a **forecast/replay** call skips the transformer and evaluates Spectrum's predictor plus the native output head instead;
- state-conditioned paths can also create Spectrum-owned buffers whose lifetime spans native block scopes.

Aimdo can recover some divergent allocations as graph breaks/rogue allocations, but repeatedly presenting one persistent model graph with materially different traces is not a contract Spectrum can safely rely on. The reporter's second-prompt crash in `MallocGraph.pop` is the real-media evidence that the history-only ownership fix did not restore that invariant.

This is also consistent with current upstream work. ComfyUI master `a99d1f9c14f4594fe1e9d7e17c1997bf104d89fb` merged #16148, which added `pause_malloc_graph()` specifically because long-lived H3 sparse-attention allocations crossing block/step lifetimes caused graph breaks and retained-VRAM problems. That upstream fix addresses sparse attention; it does not make Spectrum's alternate actual/forecast execution topology graph-stable.

## Fix

Make Comfy Compiler opt-out **step-scoped and Spectrum-scoped** instead of globally disabled:

- install a lazy wrapper around `comfy.model_prefetch.malloc_graph_enabled`;
- enter a thread-local bypass immediately after a supported Spectrum solver step begins, before `predict_noise` reaches native MiniMax H3;
- while that Spectrum step is active, `malloc_graph_enabled(...)` returns `False`, so native H3 never calls `malloc_graph_begin()` and consequently never reaches the failing `malloc_graph_end()/MallocGraph.pop()` path for that call;
- clear the bypass in `finalize_step` with `finally` semantics;
- also clear it from `end_run`, covering aborted runs that never finalize their current step;
- clear any stale thread-local scope at the next `start_run` as a second recovery boundary;
- preserve the original `malloc_graph_enabled` behavior everywhere outside an active Spectrum step.

This leaves **DynamicVRAM enabled**. It also leaves Comfy Compiler enabled for non-Spectrum work. The compatibility cost is limited to Spectrum-managed H3 denoiser calls, which no longer receive the new allocation-graph optimization.

The previous `observe_actual` pause/ownership monkeypatch is removed; once the entire Spectrum H3 forward is outside the malloc graph, special-casing one retained tensor is unnecessary and would add another allocator-state interaction without benefit.

## Lifecycle ordering

The compatibility layer is installed **last/outermost** after Spectrum's existing runtime wrappers. This is required because generic-correction, post-run safety, external-patch compatibility, ER-SDE policy, and related layers also wrap `start_run`, `begin_step`, `finalize_step`, or `end_run`. Installing the compiler boundary earlier would let later wrappers replace its cleanup hooks and make stale thread-local state possible after errors.

## Why this boundary is intentionally broader

`--disable-comfy-compiler` is already a confirmed workaround for #99. This patch applies the same proven safety boundary only where Spectrum changes the native execution contract. It avoids allocator resets, synchronization, graph aborts, or hand-edited Aimdo state.

The relevant invariant is now structural: **no Spectrum-managed native H3 forward enters an Aimdo malloc graph**. Therefore the observed `MallocGraph.pop` crash path is unreachable for Spectrum calls by construction, rather than merely hoping all escaping allocations were individually identified.

## Compatibility work

The CI matrix contains current ComfyUI `15eb748b3ec5f8a0a2d470b7fb280e2d7579f916` with:

- `comfy-kitchen==0.2.33`
- `comfy-aimdo==0.5.2`
- Python 3.12

The tiny native fixtures also retain the current-Core compatibility updates discovered while building that lane:

- native MiniMax replacement blocks accept the current `attention` keyword;
- the options-equivalence test preserves pre-existing caller values rather than incorrectly requiring native Core not to append its own transient H3 metadata.

Current ComfyUI master was additionally source-audited at `a99d1f9c14f4594fe1e9d7e17c1997bf104d89fb`; its requirements remain `comfy-kitchen==0.2.33` / `comfy-aimdo==0.5.2`, and its MiniMax compiler entry point still uses the same `malloc_graph_enabled()` gate this compatibility layer intercepts.

Older reviewed ComfyUI revisions in the matrix predate the compiler gate. The contract test now explicitly skips that assertion on those revisions rather than treating absence of a not-yet-existing API as a regression.

## Validation

GitHub Actions run **#589** (`34057236214`) is green across all **9** matrix jobs, including the current-ComfyUI/Aimdo lane.

The test coverage includes:

- compiler behavior remains unchanged outside Spectrum;
- an active Spectrum step forces the malloc-graph gate off before model execution;
- the original gate is not invoked while the bypass is active;
- normal finalization restores compiler behavior;
- `end_run` clears an unfinalized scope;
- `start_run` clears stale scope left by an earlier aborted workflow;
- nested scope accounting cannot re-enable the compiler early;
- lazy hook installation is idempotent;
- older ComfyUI revisions without the compiler API remain supported;
- the reviewed current compiler begin/end contract remains present, with the newer upstream `pause_malloc_graph` API accepted when available;
- the existing native/external compatibility and full native test suites remain green across the matrix.

Current candidate head: `be607cf485dc720cf2557c45e01f21404d75e871`.

CPU CI establishes structural/API compatibility; it does **not** prove a native CUDA allocator crash is gone.

## Required CUDA gate before merge

Retest on current ComfyUI with **no** `--disable-comfy-compiler` and **no** `--highvram` workaround:

1. run the same Spectrum workflow that previously crashed;
2. let it complete fully;
3. run another prompt/workflow immediately in the same ComfyUI process — the first candidate specifically failed on the second prompt;
4. preferably run a third consecutive generation.

Comfy Compiler should remain globally enabled, but Spectrum's H3 sampling calls themselves should no longer create/pop an Aimdo malloc graph. Keep this PR draft until that consecutive-prompt CUDA gate passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Improved compatibility with newer ComfyUI and Python 3.12 environments.
  - Prevented compiler memory-graph handling from interfering with Spectrum H3 execution.
  - Added safer cleanup and recovery when execution ends unexpectedly.

- **Bug Fixes**
  - Improved consistency of native H3 wrapper behavior across supported execution paths.

- **Tests**
  - Expanded coverage for compiler compatibility, nested execution scopes, cleanup, and repeated setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->