### PR TITLE
Track numerical attention backends across forecasts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
             tests/test_external_patch_transaction_parity.py \
             --ignore I001,UP037
           python -m ruff check \
+            comfyui_spectrum_h3/backend_history.py \
             comfyui_spectrum_h3/comfy_compiler_compat.py \
             comfyui_spectrum_h3/config.py \
             comfyui_spectrum_h3/generic_correction.py \
@@ -118,6 +119,7 @@ jobs:
             comfyui_spectrum_h3/runtime.py \
             comfyui_spectrum_h3/sampling.py \
             comfyui_spectrum_h3/__init__.py \
+            tests/test_backend_history.py \
             tests/test_comfy_compiler_compat.py \
             tests/test_config.py \
             tests/test_continuum_interop.py \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,390 +1,56 @@
-# Spectrum MiniMax H3 v0.2.25
+# Spectrum MiniMax H3 v0.2.26
 
-v0.2.25 restores stable Spectrum operation with current ComfyUI DynamicVRAM/Comfy Compiler by keeping Spectrum-managed MiniMax H3 solver steps out of Aimdo malloc-graph capture without disabling either system globally.
+v0.2.26 adds a provider-generic numerical-attention history contract so Spectrum can keep forecasts only across backend routes whose next-call identity and actual execution receipts are provably compatible. The contract was then validated in the released ComfyUI-Sol-H3 v0.1.0 production stack.
 
-## Comfy Compiler / DynamicVRAM compatibility
+## Numerical backend history and receipts
 
-PR #102 fixes issue #99, where current ComfyUI could segfault in `comfy_aimdo.malloc_graph.MallocGraph.pop()` during Spectrum H3 sampling. The first narrow candidate only moved retained Spectrum history allocation outside the active malloc graph; real CUDA testing showed that was insufficient because the first prompt could complete while a second prompt in the same process still crashed during `malloc_graph_end()`.
+Spectrum now consumes `attention_backend_history_v1` providers before a model call and `attention_backend_receipts_v1` after actual execution.
 
-The final integration uses a broader, structural boundary:
+- A provider preflight callback returns a stable hashable identity for the next numerical route, or `None` when it cannot prove that route.
+- Actual providers append hashable receipts and qualify them through `accept_receipts(...)` before Spectrum retains the resulting H3 anchor as forecast-safe.
+- Policy or receipt transitions clear incompatible forecaster/controller evidence, invalidate incompatible offline state and require a fresh actual anchor.
+- Provider removal is also a numerical transition rather than silently inheriting the old backend history.
+- Same-step conflicting receipts are executed but are not retained as one mixed numerical anchor.
+- Backend identity participates in rollback snapshots, and a late receipt reset discards residual-probe evidence belonging to the previous numerical backend.
 
-- Spectrum lazily wraps `comfy.model_prefetch.malloc_graph_enabled` and returns `False` only while a supported Spectrum H3 solver step is active on the current worker thread;
-- native MiniMax H3 therefore does not enter or pop an Aimdo malloc graph for Spectrum-managed forwards, where actual and forecast/replay calls intentionally have different allocation/control topology;
-- DynamicVRAM remains enabled;
-- Comfy Compiler remains enabled for non-Spectrum work;
-- normal compiler behavior is restored after every finalized Spectrum step;
-- `end_run` and the next `start_run` both clear stale thread-local bypass state so aborted workflows cannot leak the compatibility scope into later work;
-- the compatibility layer is installed last/outermost so existing Spectrum runtime wrappers cannot replace its cleanup boundary.
+This is intentionally provider-generic. Spectrum does not contain a Sol-H3, Untwist, Diff-Aid or Flow allowlist; each producer has to prove its own routing semantics.
 
-This deliberately trades the Comfy Compiler malloc-graph optimization away only for Spectrum-managed H3 denoiser calls. It does not globally apply the `--disable-comfy-compiler` workaround and does not require `--highvram`.
+## Fail-closed metadata behavior
 
-## Current-Core compatibility coverage
+Backend-history callbacks are metadata/qualification hooks rather than transformer computation. A failing preflight callback or failing `accept_receipts(...)` therefore makes the affected call actual-only instead of aborting the sampling run. CUDA out-of-memory remains a hard resource failure and is propagated.
 
-The reviewed CI matrix now includes ComfyUI `15eb748b3ec5f8a0a2d470b7fb280e2d7579f916` with Python 3.12, `comfy-kitchen==0.2.33`, and `comfy-aimdo==0.5.2`. Native MiniMax test fixtures were also aligned with the current `attention` block argument and current transient H3 transformer-option metadata while preserving caller-owned option values.
+The first provider identity can be established without invalidating an otherwise empty history/archive only before backend-dependent evidence exists. A provider appearing later, provider removal, or a genuine policy/receipt change retains the full conservative reset path.
 
-Older reviewed ComfyUI revisions that predate Comfy Compiler remain supported; the compiler contract test skips only where that API does not yet exist.
+Core Block Sparse Attention still has no predictive backend-history contract and therefore remains actual-only under this mechanism.
 
-## Validation
+## Sol-H3 production validation
 
-- PR #102 final head `be607cf485dc720cf2557c45e01f21404d75e871` passed GitHub Actions run **#589** across all **9** reviewed ComfyUI/Python matrix jobs.
-- CodeRabbit completed the final diff review with **no actionable comments** and rated merge risk minimal.
-- Real CUDA/runtime validation confirmed that the revised compatibility boundary fixed the crash; the tester also reported no obvious performance regression in normal use.
-- The original failing issue is closed after the accepted runtime retest.
-
-Existing Spectrum forecasting policies, sampler equations, Continuum prefix semantics, external-patch exactness rules, generic correction, offline replay semantics, and non-Spectrum Comfy Compiler behavior are unchanged outside this compatibility boundary.
-
----
-
-# Spectrum MiniMax H3 v0.2.24
-
-v0.2.24 removes two unnecessary actual-evaluation barriers in validated few-step and progressive workflows while preserving the exact anchors required by the underlying samplers and external-patch contracts.
-
-## Qualified terminal Untwist PECE deferral
-
-PR #98 adds a narrow, versioned exception to Spectrum's normal hard external-patch transition rule for active SA-Solver PECE.
-
-- ComfyUI-Untwisting-RoPE v0.2.3 can declare `terminal_pece_exact_corrector_safe=true` only for its reviewed weak terminal spatial-only envelope.
-- Spectrum independently proves that the current call is the terminal predicted PECE phase and that the immediate next logical call is the exact corrected phase for the same outer step before allowing the predictor to remain forecasted.
-- The corrected call remains an actual H3 evaluation and becomes the persistent endpoint. Native SA-Solver sigma/tau/noise/RNG ordering and Adams history remain intact.
-- Missing or malformed capability metadata, PEC/non-PECE sampling, missing correctors, unknown topology, interior transitions, replay, or any stacked unsafe transition retain the ordinary exact hard-boundary promotion.
-- DiffAid's current strong interior hard transition remains exact.
-
-The follow-up short-lifetime regression found that the deferral layer was clearing Spectrum's already-selected one-point bootstrap mechanism under `max_speed`. That turned a valid one-anchor hold into the ordinary multi-point forecaster and produced `Spectrum forecaster does not have enough actual history`. The final fix changes only the external-patch reason and preserves the forecast mechanism chosen by `begin_step()`.
-
-The corrected progressive high stages now execute the intended two-outer-step PECE topology:
+The primary integration is released as [ComfyUI-Sol-H3 v0.1.0](https://github.com/xmarre/ComfyUI-Sol-H3/releases/tag/v0.1.0). On the production RTX PRO 6000 Blackwell stack with VDN, Untwist, Diff-Aid and Flow, the final schedule was:
 
 ```text
-P0  A
-P1  F
-C1  A
+sampler_logical_calls       18
+transformer_actual_nfe      14
+spectrum_forecast_calls      4
+
+low:    8 actual / 2 forecast
+high:   4 actual / 2 forecast
+probe:  2 actual / 0 forecast
 ```
 
-Both exercised high-stage invocations completed as **2 actual / 1 forecast**, confirmed the exact same-outer corrector, and reported zero terminal fail-safe events and zero Spectrum fallbacks. Across the complete corrected progressive workflow, metrics reported **22 logical sampler calls, 17 actual transformer NFEs, 5 Spectrum forecasts, and 2 exact handoff-probe NFEs**.
+The matched Sol-bypassed control uses `13 actual + 5 forecast`. The one additional Sol-enabled actual is the intentional first low-stage `dense -> sol` numerical-backend transition and remains a safety anchor rather than being hidden by the history contract.
 
-The terminal-deferral semantic change also passed matched decoded-media A/B testing. In the validated 0.5 MP four-pass workflow, the new policy produced **32 actual / 16 forecast** calls versus **36 / 12** under the previous terminal-transition policy, saving four real H3 transformer evaluations without a discernible quality regression.
-
-## RES final-tail policy
-
-PR #100 removes the obsolete RES-specific three-step final-tail floor that originated as an empirical safeguard for the old monolithic RES path.
-
-- `tail_actual_steps` is now authoritative for `sample_res_multistep` and `sample_res_multistep_cfg_pp`; Spectrum no longer silently raises the RES final tail to three actual calls.
-- The separate RES recurrence safeguard is unchanged: after a forecast, one exact H3 evaluation still refreshes native `old_denoised` before another forecast may occur.
-- Continuum prefixes, warmup, external-patch transitions, fallbacks, force-actual conditions, and other independent correctness boundaries still take precedence.
-
-A three-step progressive high-resolution RES stage with one exact Continuum prefix and `tail_actual_steps=1` can therefore use:
-
-```text
-A F A
-```
-
-The production progressive RES validation exercised four stages as `A F A F A`, `A F A`, `A A F A A`, and `A F A`. That is **16 logical sampler calls = 11 actual + 5 forecast**; two exact handoff probes bring the workflow to **13 actual transformer NFEs** overall. All four stages reported zero Spectrum fallbacks. Decoded video and audio were reviewed as excellent, with the RES result preferred over the matched Euler control.
-
-## Step/NFE documentation and release process
-
-PR #95 is also included in this release archive. It is documentation/release-process only: it clarifies that UI scheduler steps are outer sigma intervals rather than necessarily one H3 model call, records the `2N - 1` / `3N - 2` multistage call counts, and hardens documentation-only release-note refreshes against stale workflow runs. It does not change sampler or forecasting behavior.
-
-The release workflow now also keeps the level-1 version heading in `RELEASE_NOTES.md` for repository history and version validation while removing that heading from the GitHub release body. The GitHub release title therefore appears only once.
+The same production run confirmed direct VDN API-v3 and Flow mixed-grid routing with 1:1 requested/kernel Q-row accounting and zero square-Q expansion. This release makes no large Sol-Attn speed claim from whole-workflow timing: those runs differ in actual-NFE count, sparse routing/content and cache state, so the backend-history result is the restored, correctly qualified forecast schedule rather than an uncontrolled percentage comparison.
 
 ## Validation
 
-- PR #100: GitHub Actions run **576** passed the full eight-lane reviewed ComfyUI/Python matrix, followed by the successful production-stack RES media validation.
-- PR #98: final PR-head GitHub Actions run **575** passed all eight matrix jobs; the corrected real `max_speed` short-lifetime workflow completed without the prior under-history failure.
-- Combined post-merge `main`: GitHub Actions run **578** passed after PR #100 and PR #98 were both present on `main`.
-- Companion ComfyUI-Untwisting-RoPE #5: merged `main` tests run **23** passed.
+- PR #104 remains one implementation commit on top of v0.2.25 main before release metadata is applied.
+- Its reviewed matrix passed all nine ComfyUI/Python lanes, including the current Comfy Compiler/Aimdo lane.
+- CodeRabbit's substantive findings were fixed and resolved: provider metadata failures are actual-only rather than fatal, and initial provider registration no longer destroys an empty offline capture.
+- The released Sol-H3 native-interop suite exercises Spectrum with Sol-H3, VDN, Untwist, Diff-Aid and Flow.
+- Final real SM120 production execution established the 18 logical / 14 actual / 4 forecast schedule above.
 
-Existing Euler, ER-SDE, SEEDS, ordinary SA-Solver PEC, RefDelta ownership, Continuum prefix semantics, native/all-actual fallbacks, and unsafe external-patch transition handling remain unchanged outside the specific policies above.
-
----
-
-# Spectrum MiniMax H3 v0.2.23
-
-v0.2.23 completes the SA-Solver PECE and RefDelta multi-backend integration and makes **`balanced` the default active-PECE forecast policy** after matched MiniMax-H3 production testing.
-
-## Important: outer steps are not H3 model-call counts
-
-The ComfyUI scheduler's **steps** value counts outer sigma intervals. Some of the newly
-supported solvers expose additional logical H3 model-call opportunities inside those
-intervals, so raw step counts are not NFE-equivalent across sampler families.
-
-For the usual terminal-zero schedule, with `N = len(sigmas) - 1`:
-
-| Sampler topology | Native H3 model-call opportunities | 10 outer steps | 19 outer steps |
-| --- | ---: | ---: | ---: |
-| Euler / RES multistep / ER-SDE | `N` | 10 | 19 |
-| SA-Solver PEC / inactive PECE (`use_pece = false` or `corrector_order = 0`) | `N` | 10 | 19 |
-| SEEDS-2 | `2N - 1` | 19 | 37 |
-| SEEDS-3 | `3N - 2` | 28 | 55 |
-| Active SA-Solver PECE (`use_pece = true`, `corrector_order > 0`) | `2N - 1` | 19 | 37 |
-
-SEEDS omits its internal stage calls on the final sigma-to-zero interval. Active PECE
-with `corrector_order > 0` executes `P0`, then predicted/corrected pairs
-`P1/C1, P2/C2, ...`, giving `N` predicted opportunities plus `N - 1` corrected
-opportunities. With `corrector_order = 0`, PECE collapses to `N`.
-
-Spectrum's actual/forecast ratios are therefore counted over logical H3 model-call opportunities.
-A clean 10-outer-step PECE run contains **19** logical H3 calls: `balanced` is nominally
-**11 actual / 8 forecast** and `max_speed` **10 / 9**. Production safety boundaries may
-promote forecasts to actual, changing the split without changing the 10 outer steps.
-
-## Active SA-Solver PECE
-
-Spectrum now models native ComfyUI PECE as explicit predicted/corrected evaluations:
-
-```text
-P0
-P1 C1
-P2 C2
-...
-```
-
-- `P0` and exact corrected `C_i` evaluations own persistent Spectrum/Adams history.
-- Later predicted `P_i` evaluations are ephemeral current-corrector inputs and never become persistent Adams evidence.
-- Forecasted predicted phases use causal solver-space dense output derived only from exact persistent endpoints; Spectrum's raw hidden-feature forecast is not consumed numerically by SA at that boundary.
-- Every corrected phase remains an exact H3 re-anchor.
-- Native sigma/tau/noise/RNG ordering, stochastic variance, predictor/corrector equations, PECE endpoint replacement, callbacks, and terminal behavior remain unchanged.
-- H3 Continuum prefixes and DiffAid/Untwist hard transitions remain authoritative actual-evaluation boundaries.
-
-## PECE quality/speed policy
-
-`sa_pece_forecast_policy` exposes three reviewed start cadences:
-
-- **`balanced` (default):** P0/P1 exact; clean 10-outer topology is 11 actual / 8 forecast.
-- `max_speed`: P0 exact; clean 10-outer topology is 10 actual / 9 forecast.
-- `stable_start`: P0/P1/P2 exact; clean 10-outer topology is 12 actual / 7 forecast.
-
-Real production stacks may be more conservative because Continuum prefixes, external hard transitions, user warmup, fallbacks, and force-actual conditions take precedence.
-
-Final matched 10-outer testing with runtime LoRA/DoRA hooks, DiffAid, Untwist-RoPE, RefDelta SA-Solver PECE, Spectrum full/model-aware mode, and H3 Continuum produced acceptable decoded output with both `max_speed` and `balanced`. The **balanced run was perceptually better** in the tested workflow, so it is now the release default. The early coarse/colored-shape previews seen during the first few denoising steps also occur with other MiniMax-H3 samplers and are not treated as a PECE correctness failure.
-
-The reviewed maximum-speed production trace completed at 12 actual / 7 forecast for the initial chunk and 13 actual / 6 forecast for the Continuum chunk after hard-transition and Continuum promotions, with zero fallbacks, bypasses, rollbacks, speculative calls, discarded actual calls, or external-patch contract failures.
-
-## RefDelta SEEDS / SA-Solver composition
-
-Spectrum now composes with the RefDelta Solver v0.6.0 sampler family:
-
-- `sample_refdelta_seeds_2`;
-- `sample_refdelta_seeds_3`;
-- `sample_refdelta_sa_solver`;
-- `sample_refdelta_sa_solver_pece`.
-
-RefDelta keeps its own reviewed evidence topology while Spectrum owns forecast scheduling. For PECE, RefDelta persistent evidence mirrors native endpoint replacement—`P0, C1, C2, ...`—and later predicted calls remain ephemeral even when a safety boundary makes one actual. Forecasted persistent endpoints fail closed.
-
-RefDelta SEEDS/SA composition remains causal-only under Spectrum, and unsupported multi-GPU clone paths bypass Spectrum rather than weakening the interop contract. ER-SDE's existing exact-gated-increment contract is unchanged.
-
-The cross-repository CI fixture is pinned to RefDelta Solver v0.6.0 commit:
-
-```text
-21d0191d933fedf2885df082d33eb1bc2fffd529
-```
-
-## Scheduler evidence
-
-The companion RefDelta dedicated SA-Solver scheduler media gate also completed. Exact `simple_control` was slightly preferred over `simple_adams_bounded`, while both produced acceptable decoded output. Spectrum does not own that outer scheduler choice; its PECE forecast policy remains independent.
-
-## Validation
-
-The final release branch retains the eight-lane reviewed ComfyUI/Python matrix, native MiniMax-H3 fixtures, RefDelta cross-repository fixtures, Ruff, compileall, and wheel build. Existing Euler, ER-SDE, RES multistep, native SEEDS, ordinary SA-Solver PEC, Continuum, external-patch, generic-correction, and saved-workflow behavior remain isolated from the new active-PECE policy.
+Existing sampler equations, PECE/SEEDS/SA-Solver ownership, Continuum prefix semantics, external-patch exactness rules, generic correction, offline replay policy and the v0.2.25 Comfy Compiler compatibility boundary are unchanged outside numerical-backend history qualification.
 
 ---
 
-# Spectrum MiniMax H3 v0.2.22
-
-v0.2.22 adds reviewed native Spectrum support for ComfyUI **SEEDS-2, SEEDS-3, and SA-Solver**, including the stochastic MiniMax H3 paths that required sampler-specific state handling rather than ordinary one-call forecasting.
-
-## Native SEEDS-2 / SEEDS-3 support
-
-Spectrum now understands the native multistage SEEDS solver geometry instead of treating each H3 model call as an independent diffusion step.
-
-For stochastic SEEDS:
-
-- native stochastic increments, noise draws, stage equations, and callback ordering remain untouched;
-- Spectrum forecasts the H3 **transformer residual** while rebuilding the exact current-state target input embedding from the native solver latent;
-- stochastic stages share one residual history over the true interleaved model-call coordinates;
-- the outer SEEDS stage remains exact, while supported internal stages may be forecast;
-- one-point bootstrap remains disabled;
-- hard external-patch transitions, Continuum prefix requirements, warmup/readiness, and final-tail exactness remain authoritative;
-- the ordinary model-aware scheduler veto is advisory on the sampler-specific stochastic internal-stage path, while model-aware telemetry, adaptive fit/blend, and generic correction remain active;
-- stochastic SEEDS does not use offline smoothing replay because replaying the model-call sequence independently of the native noise-conditioned stage trajectory would break solver geometry.
-
-The final real SEEDS-2 validation completed cleanly with DiffAid, Untwist-RoPE, and H3 Continuum:
-
-- initial chunk: **11 actual / 8 forecast**, **0 fallbacks**;
-- Continuum chunk: **12 actual / 7 forecast**, **0 fallbacks**;
-- stage 0 stayed exact throughout;
-- the previously observed delayed heavy-noise pattern did not recur.
-
-SEEDS-3 is supported under the same reviewed state-conditioned residual architecture, but remains more conservative because its two consecutive internal stages do not have an exact outer-stage anchor between them.
-
-## Native SA-Solver support
-
-Spectrum now supports native SA-Solver without allowing approximate H3 denoisers to become recursive persistent Adams observations.
-
-The stochastic SA integration uses:
-
-- **actual-only persistent Adams history**;
-- forecast values only as bounded solver-local/ephemeral inputs;
-- causal solver-space dense output built from exact H3 anchors during stochastic intervals;
-- exact native tau/noise draws, predictor/corrector equations, callback ordering, sigma schedule, and final denoising semantics;
-- a one-forecast maximum streak with an exact H3 re-anchor after each skipped transformer call;
-- fail-closed/native behavior for unsupported active PECE corrector configurations.
-
-For H3 Continuum continuation chunks, every SA forecast coordinate uses a latest-exact solver-space hold and ignores the raw Spectrum hidden-feature denoised value at the SA boundary. This removes the remaining continuation-specific instability while preserving the 11/8 NFE target.
-
-Final real-media SA validation completed with:
-
-- initial chunk: **11 actual / 8 forecast**, **0 fallbacks**;
-- Continuum chunk: **11 actual / 8 forecast**, **0 fallbacks**;
-- all eight Continuum forecast coordinates using the reviewed all-forecast latest-exact isolation path;
-- no recurrence of the delayed heavy-noise corruption;
-- no recurrence of the later whole-frame vertical shake/flashing artifact.
-
-## Validation and compatibility
-
-PR #86 is the reviewed SEEDS-2/3 implementation and passed Actions **#495** across all seven supported ComfyUI/Python lanes. PR #87 is the stacked SA-Solver implementation and passed Actions **#511** on its final one-commit head.
-
-Both PRs were additionally validated with real MiniMax H3 media using the production workflow with DiffAid, Untwist-RoPE, H3 Continuum, runtime LoRA hooks, and the current PDD-capable ComfyUI H3 path.
-
-Existing Euler, RES multistep, ER-SDE, RefDelta, Continuum, generic-correction defaults, trust-shrinkage default-off behavior, and ordinary sampler scheduling remain unchanged outside the new sampler-specific paths.
-
----
-
-# Spectrum MiniMax H3 v0.2.21
-
-v0.2.21 restores Spectrum forecast execution with current ComfyUI MiniMax H3 after the PDD LoRA update changed the native output-head contract.
-
-## ComfyUI 0.34 PDD final-layer compatibility
-
-- Fixes `FinalLayer.forward() missing 3 required positional arguments: 'sigma', 'sample_sigmas', and 'shifts'` on the first eligible Spectrum forecast with ComfyUI 0.34.0 and later PDD-capable H3 cores.
-- Spectrum now detects the reviewed native FinalLayer contract and forwards the same current sigma, exact sampler sigma schedule, and video/audio sigma shifts used by native H3.
-- Reviewed older ComfyUI revisions retain the existing four-argument FinalLayer path.
-- An incomplete future PDD argument contract fails explicitly instead of guessing.
-- No H3 Continuum-side workaround is required; Continuum exposed the stale Spectrum forecast output-head call.
-
-## Validation
-
-PR #84 adds focused regression coverage for the PDD projection call and adds ComfyUI commit `2504e68d4d9dedb514e172692f13436623f25aed` to the compatibility matrix with its required `comfy-kitchen` and `comfy-aimdo` versions. All seven ComfyUI/Python lanes pass, including the historical legacy FinalLayer contracts. CodeRabbit reported no actionable code finding.
-
-PR #84 supersedes #83; thanks to @bun-dev for independently identifying the same Core contract break and proposing the compatible call shape.
-
----
-
-## v0.2.20
-
-v0.2.20 fixes the RefDelta API-v1 step-provenance handoff after a tracked ER-SDE model call.
-
-## RefDelta tracked-step provenance
-
-- Fixes `RefDelta requested a model-result classification for the wrong step` immediately after the first successful Spectrum/RefDelta model evaluation.
-- The real runtime trace showed Spectrum's ER-SDE stochastic tracker had already consumed and logged step 0 while the separate RefDelta bridge-local descriptor had not been mirrored reliably through the surrounding ComfyUI/Continuum model-options path.
-- For stochastic RefDelta runs, provenance is now recorded directly from the exact `ERSDEStepDescriptor` that the ER-SDE stochastic tracker successfully consumes. RefDelta therefore uses the same authoritative step classification that Spectrum used for stochastic-state ownership.
-- The existing post-model bridge update remains a redundant consistency path instead of the sole source of RefDelta provenance.
-- Deterministic `s_noise=0` RefDelta runs keep their direct bridge descriptor path because no stochastic tracker exists in that mode.
-- Stale-step and external-increment source validation remain strict; diagnostics now include requested/source and observed step IDs.
-- No model-path, Continuum, RefDelta Solver, prompt, sampler-setting, or workflow changes are required.
-
-## Validation
-
-PR #78 adds regression coverage for the exact failure mode: the tracker consumes step 0 successfully without a separate bridge update, and RefDelta must still classify the same step correctly. Coverage also verifies stale-step rejection, external-increment source checking, replay provenance, and deterministic no-tracker behavior.
-
-The complete six-lane Spectrum ComfyUI/Python matrix passes, including Ruff, compileall, focused external compatibility suites, and native MiniMax H3 fixtures. CodeRabbit reported no actionable merge-blocking finding and rated the runtime change minimal risk.
-
----
-
-## v0.2.19
-
-v0.2.19 fixes RefDelta Solver discovery in the actual ComfyUI custom-node loading layout.
-
-## RefDelta custom-node namespace discovery
-
-- Fixes the runtime failure `RefDelta interop API is unavailable: No module named 'comfyui_refdelta_solver'` that could occur even though the RefDelta sampler itself was already loaded and usable by ComfyUI.
-- Spectrum now recognizes the already-loaded RefDelta implementation when ComfyUI has placed it under a package-relative custom-node namespace instead of exposing `comfyui_refdelta_solver` as a top-level package.
-- Canonical RefDelta imports reuse the exact live config class, sampler function, and interop contract objects instead of importing the same files a second time under a different module identity.
-- The existing strict RefDelta API-v1 checks remain unchanged: function identity, config provenance, interop version, option allowlist, stochastic ownership, and wrapper ordering still fail closed on drift.
-- No `PYTHONPATH` changes, pip installation, duplicated model path, or workflow changes are required.
-
-## Validation
-
-PR #76 adds a regression for the exact nested ComfyUI package layout that produced the failure. The complete six-lane Spectrum ComfyUI/Python matrix passes, including Ruff, compileall, focused external compatibility tests, and native MiniMax H3 fixtures. CodeRabbit reported no actionable findings on the substantive compatibility change.
-
-This patch changes discovery only. RefDelta solver behavior, Spectrum forecasting policy, stochastic compensation, Continuum interoperability, Diff-Aid handling, Untwisting RoPE handling, and offline replay semantics remain unchanged.
-
----
-
-## v0.2.18
-
-v0.2.18 adds explicit compatibility with MiniMax H3 RefDelta Solver v0.2.0+.
-
-## RefDelta API v1
-
-- `sample_refdelta_er_sde` is admitted only when the installed function, config type, option set, and versioned interop marker match the reviewed contract.
-- Spectrum passes actual/forecast/replay provenance to RefDelta. Forecasted denoised values continue through ER-SDE solver history but cannot enter RefDelta's raw-model risk or correction evidence.
-- RefDelta publishes the exact stochastic increment after its risk and endpoint gates. Spectrum retains that tensor for the next skipped-state compensation instead of reconstructing an ungated native increment.
-- Native-equivalence RefDelta configurations continue through the reviewed native ER-SDE ownership path.
-- Deterministic `s_noise=0` RefDelta runs still receive actual/forecast provenance without allocating a stochastic tracker.
-- Offline replay preserves source-actual provenance and aborts safely to the completed first pass if interop state becomes inconsistent.
-
-## Validation and failure policy
-
-The test matrix covers the shared API contract, exact gated-increment transfer, missing-publication rejection, actual/forecast/replay classification, native ComfyUI contracts, Python 3.12/3.13, Ruff, compileall, and wheel construction. Unreviewed RefDelta versions, options, stochastic callbacks, wrapper ordering, or bridge state disable forecasting or fail explicitly rather than silently changing stochastic ownership.
-The cross-repository jobs pin the exact RefDelta API-v1 commit reviewed for this release.
-Release validation covers six Spectrum matrix jobs and the four-job RefDelta native fixture matrix.
-
-Existing native ER-SDE, Euler, RES multistep, Turbo, Continuum, Diff-Aid, Untwisting RoPE, masked H3, refinement, model-aware, and offline-replay behavior remains unchanged.
-
----
-
-## v0.2.17
-
-v0.2.17 completes the current H3 Continuum interoperability work: native masked continuation can remain forecast-capable where the installed ComfyUI core exposes the required per-token H3 mask helper, and the learned-latent sampler-2 refinement path can use Spectrum without inheriting sampler-1's Continuum actual-prefix policy.
-
-## Native Masked H3 forecasting
-
-Spectrum now reconstructs native MiniMax H3 FinalLayer modulation for mixed VIDEO/AUDIO denoise masks instead of disabling forecasting for the entire masked continuation chunk.
-
-- Per-row VIDEO and AUDIO timestep selections follow native H3 mask semantics.
-- Scalar fully-generating paths retain the existing fast path.
-- Residual/shadow output-head evaluation uses the same reconstruction.
-- Per-row timestep index tensors are placed on the target latent device, avoiding CPU/CUDA index-device mismatches in FinalLayer implementations that use `index_select`.
-- On older reviewed ComfyUI cores that do not expose `mask_row_values`, a masked forecast fails closed to one native H3 transformer evaluation instead of raising during output-head reconstruction.
-- Malformed audio mask layouts continue to fail explicitly.
-
-## Short learned-latent refinement
-
-The integrated MiniMax H3 latent upscaler/refiner supplies an explicit `h3_refinement` API-v1 marker on a clone of Continuum's exact per-chunk MODEL. Spectrum validates that contract and lets its sampler-2 actual-prefix policy override the generation-only Continuum prefix carried by sampler 1.
-
-Normal Continuum generation still preserves its two-step actual prefix. A valid three-step sampler-2 refinement can therefore use:
-
-```text
-actual -> forecast -> actual
-```
-
-with the normal warmup/final-tail safety rules.
-
-Spectrum continues to honor genuine external-patch hard transitions. DiffAid v1.0.7 removes the artificial partial-denoise transition at its source by evaluating marked refinement against the full H3 sigma reference; Spectrum does not bypass a real model-function transition.
-
-## Coordinated runtime validation
-
-The complete real CUDA path was validated with:
-
-- H3 Continuum exact `refine_state` handoff;
-- MiniMax H3 learned latent upscale + internal sampler-2 refinement;
-- DiffAid marked-refinement sigma semantics;
-- Untwisting RoPE external-patch metadata;
-- native ER-SDE;
-- Spectrum enabled on both the main Continuum generation and sampler 2.
-
-A three-step high-resolution refinement produced `2 actual + 1 forecast` per refined chunk, with no inherited Continuum-prefix force-actual and no artificial DiffAid middle-step transition. The resulting media quality was user-validated as impeccable.
-
-The tested 0.7 MP native -> 1.75x learned-upscale workflow reduced the Refine node from roughly 302.5 s with three native refinement NFEs to roughly 212.7 s with the middle NFE forecast, while preserving the tested output quality.
-
-## Validation and compatibility
-
-The PR test matrix covers Python 3.10-3.13, the forecaster smoke test, Ruff/compileall, focused H3/external compatibility suites, and native MiniMax H3 fixtures across the reviewed ComfyUI revisions.
-
-This release is coordinated with:
-
-- ComfyUI-DiffAid-Patches v1.0.7;
-- H3 Continuum v3.4.1;
-- the integrated MiniMax H3 Latent Upscaler + Refine release.
-
-Existing Spectrum defaults, generic-correction defaults, normal 19-step Continuum forecasting policy, ER-SDE stochastic ownership, offline-replay policy, and real external-patch transition barriers remain unchanged.
+Previous release notes through v0.2.25 are preserved verbatim in `docs/RELEASE_NOTES_v0.2.25_AND_EARLIER.md`.

--- a/comfyui_spectrum_h3/backend_history.py
+++ b/comfyui_spectrum_h3/backend_history.py
@@ -1,0 +1,108 @@
+"""Numerical attention policy/receipt identity, independent of any sparse package.
+
+A provider in attention_backend_history_v1 maps the current layout/options/model
+into a hashable preflight identity, or None when routing cannot be predicted.
+Actual attention providers append hashable receipts before the last block returns.
+Opaque routing is actual-only per call; it never aborts sampling.
+"""
+from dataclasses import dataclass
+
+import torch
+
+POLICIES = "attention_backend_history_v1"
+RECEIPTS = "attention_backend_receipts_v1"
+
+
+@dataclass
+class BackendHistory:
+    policy: object = None
+    receipt: object = None
+    forecast_safe: bool = False
+
+
+def _provider_identity(provider, *, layout, options, model):
+    try:
+        return provider(layout=layout, options=options, model=model)
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - metadata providers fail closed to actual-only
+        return None
+
+
+def _provider_accepts(provider, receipts):
+    accept = getattr(provider, "accept_receipts", None)
+    if not callable(accept):
+        return False
+    try:
+        return bool(accept(receipts))
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - metadata providers fail closed to actual-only
+        return False
+
+
+def _runtime_has_backend_evidence(runtime) -> bool:
+    history = runtime._backend_history
+    if history.policy is not None or history.receipt is not None:
+        return True
+    if runtime._history_topology is not None or runtime._history_labels is not None:
+        return True
+    forecasters = [runtime._primary_forecaster, *runtime._stage_forecasters.values()]
+    if any(forecaster.history_length for forecaster in forecasters):
+        return True
+    step = runtime._step
+    if step is not None and (step.calls or step.actual_records or step.used_history_rows):
+        return True
+    archive = runtime._offline_archive
+    if archive is not None and (archive.steps or archive.anchors):
+        return True
+    return runtime._offline_smoother is not None
+
+
+def preflight(options, layout, model):
+    policies = options.get(POLICIES, {})
+    if not policies:
+        # Core BSA predates the provider contract. Preserve its operator while
+        # requiring actual execution; never forecast across its unreported schedule.
+        callbacks = options.get("callbacks", {})
+        if any("block_sparse_attention" in group for group in callbacks.values()):
+            return ("core_bsa_unreported",), False
+        return None, True
+    identities = []
+    safe = True
+    for name, provider in sorted(policies.items()):
+        identity = _provider_identity(provider, layout=layout, options=options, model=model)
+        safe = safe and identity is not None
+        identities.append((name, identity))
+    return tuple(identities), safe
+
+
+def prepare(runtime, run_id, step_id, options, layout, model):
+    identity, safe = preflight(options, layout, model)
+    if identity is None:
+        if runtime._backend_history.policy is None:
+            return options, None
+        identity, safe = ("provider_removed",), False
+    # The first declared provider establishes the run's numerical identity. There
+    # is nothing to invalidate until Spectrum has retained backend-dependent
+    # evidence. A provider appearing later in the run still goes through the full
+    # transition/reset path below.
+    if runtime._backend_history.policy is None and not _runtime_has_backend_evidence(runtime):
+        runtime._backend_history = BackendHistory(policy=identity)
+    runtime.prepare_backend_history(run_id, step_id, identity, safe)
+    return {**options, RECEIPTS: []}, (identity, safe)
+
+
+def observe(runtime, run_id, step_id, options, policy):
+    if policy is None:
+        return
+    identity, safe = policy
+    receipts = tuple(options.get(RECEIPTS, ()))
+    # A fallback is not proof that the next call follows the same route. Until a
+    # provider can predict it, execute actuals and re-enable forecasts after SOL
+    # eligibility returns. Stable dense warmup is predictable through its policy.
+    safe = safe and bool(receipts) and all(
+        _provider_accepts(provider, receipts)
+        for provider in options.get(POLICIES, {}).values()
+    )
+    runtime.observe_backend_history(run_id, step_id, identity, receipts, safe)

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -455,7 +455,7 @@ def _execute_actual(
         dit_replacements[("double_block", first_index)] = capture_state_input
 
     def capture_replacement(args, replacement_context):
-        nonlocal actual_target, observed, state_input_target
+        nonlocal actual_target, observed, state_input_target, residual_probe
         output = existing(args, replacement_context) if existing is not None else replacement_context["original_block"](args)
         if not isinstance(output, dict) or "img" not in output or not torch.is_tensor(output["img"]):
             raise RuntimeError("final MiniMax H3 block replacement did not return {'img': tensor}")
@@ -468,6 +468,12 @@ def _execute_actual(
         # second full target tensor on the GPU before the required CPU archive.
         target = hidden[aa:vb].unsqueeze(0)
         actual_target = target
+        from .backend_history import observe
+        resets_before = runtime.stats.backend_history_resets
+        observe(runtime, run_id, step_id, local_options,
+                local_options.get("attention_backend_preflight_v1"))
+        if runtime.stats.backend_history_resets != resets_before:
+            residual_probe = None  # discard old-backend shadow/hold evidence
         if runtime.active_state_conditioned_residual:
             try:
                 if state_input_target is None:
@@ -686,6 +692,10 @@ def diffusion_model_wrapper(
     labels = branch_labels(options)
     expected_shape = (1, (ab - aa) + (vb - va), int(inner.hidden_size))
     topology = topology_signature(inner, video_x, audio_x, context, layout, options, payload)
+    from .backend_history import prepare
+    options, backend_policy = prepare(runtime, int(run_id), int(step_id), options, layout, inner)
+    if backend_policy is not None:
+        options["attention_backend_preflight_v1"] = backend_policy
     call_id, actual = runtime.begin_model_call(
         int(run_id),
         int(step_id),

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -8,7 +8,9 @@ from typing import Any
 
 import torch
 
+from .backend_history import BackendHistory
 from .config import SpectrumH3Config
+from .er_sde_stochastic import ERSDEStepDescriptor
 from .experiments import (
     OfflineFeatureArchive,
     OfflineSmoother,
@@ -16,7 +18,6 @@ from .experiments import (
     measure_stream_residual,
     tensor_all_finite,
 )
-from .er_sde_stochastic import ERSDEStepDescriptor
 from .forecast import ForecasterSnapshot, HistoryWeightForecaster
 from .model_aware import (
     ModelAwareController,
@@ -78,6 +79,8 @@ class RuntimeStats:
     actual_steps: int = 0
     forecast_steps: int = 0
     actual_transformer_calls: int = 0
+    backend_history_resets: int = 0
+    backend_opaque_actual_calls: int = 0
     forecast_model_calls: int = 0
     forecast_fallbacks: int = 0
     bypassed_steps: int = 0
@@ -279,6 +282,7 @@ class _RunState:
 class RuntimeRollbackSnapshot:
     next_step_id: int
     forecaster: ForecasterSnapshot
+    backend_history: BackendHistory
     history_topology: tuple[Any, ...] | None
     history_labels: tuple[Any, ...] | None
     current_window: float
@@ -319,6 +323,7 @@ class SpectrumH3Runtime:
         self._run_counter = 0
         self._run: _RunState | None = None
         self._step: _StepState | None = None
+        self._backend_history = BackendHistory()
         self._history_topology: tuple[Any, ...] | None = None
         self._history_labels: tuple[Any, ...] | None = None
         self._current_window = float(self.config.window_size)
@@ -1088,6 +1093,7 @@ class SpectrumH3Runtime:
                 )
                 controller.set_profile(self._model_profile)
                 self._stage_model_aware[stage_index] = controller
+        self._backend_history = BackendHistory()
         self._history_topology = None
         self._history_labels = None
         self._current_window = float(self.config.window_size)
@@ -1170,6 +1176,7 @@ class SpectrumH3Runtime:
         self._primary_model_aware.reset()
         self._primary_model_aware.set_profile(self._model_profile)
         self.model_aware = self._primary_model_aware
+        self._backend_history = BackendHistory()
         self._history_topology = None
         self._history_labels = None
         self._consecutive_forecasts = 0
@@ -1618,6 +1625,65 @@ class SpectrumH3Runtime:
     def fallback_current_step(self, run_id: int, step_id: int, reason: str) -> None:
         step = self._require_step(run_id, step_id)
         self._fallback_or_retry(step, reason)
+
+    def _reset_backend_history(self, step, reason):
+        # Clear every stage and feedback controller. Keeping a stage bank here
+        # would allow an old numerical backend to reappear after stage switching.
+        if step.mode == "replay":
+            raise OfflineReplayAbort(reason)
+        if any(call.used_forecast for call in step.calls):
+            raise ForecastRetryActual(reason)
+        for forecaster in [self._primary_forecaster, self.forecaster, *self._stage_forecasters.values()]:
+            forecaster.reset()
+        for controller in [self._primary_model_aware, self.model_aware, *self._stage_model_aware.values()]:
+            controller.reset()
+            controller.set_profile(self._model_profile)
+        self._history_topology = None
+        self._history_labels = None
+        self._consecutive_forecasts = 0
+        self._required_feedback_actuals = 0
+        self._rollback_requested = False
+        if self._offline_archive is not None:
+            self._offline_archive.invalidate(reason)
+        self._offline_smoother = None
+        step.mode = "actual"
+        step.reason = reason
+        step.bootstrap_forecast = False
+        step.model_aware_decision = None
+        step.residual_expected = False
+        step.residual_records.clear()
+        if step.actual_records:
+            step.retain_history = False
+            step.actual_records.clear()
+        self.stats.backend_history_resets += 1
+
+    def prepare_backend_history(self, run_id, step_id, identity, safe):
+        step = self._require_step(run_id, step_id)
+        old = self._backend_history
+        if old.policy != identity:
+            self._reset_backend_history(step, "numerical backend policy transition")
+            self._backend_history = BackendHistory(policy=identity)
+        if not safe or not self._backend_history.forecast_safe:
+            if step.mode == "replay":
+                raise OfflineReplayAbort("unpredictable numerical attention backend")
+            if any(call.used_forecast for call in step.calls):
+                raise ForecastRetryActual("numerical backend requires an actual call")
+            step.mode = "actual"
+            step.bootstrap_forecast = False
+            step.reason = "numerical backend requires an actual call"
+            self.stats.backend_opaque_actual_calls += 1
+
+    def observe_backend_history(self, run_id, step_id, identity, receipts, safe):
+        step = self._require_step(run_id, step_id)
+        old = self._backend_history
+        if old.receipt is not None and old.receipt != receipts:
+            self._reset_backend_history(step, "actual numerical backend receipt transition")
+            # Multiple conditioning subcalls with distinct routing cannot share a
+            # single anchor. Execute the step, but do not retain a mixed anchor.
+            if step.actual_records:
+                step.retain_history = False
+                step.actual_records.clear()
+        self._backend_history = BackendHistory(identity, receipts, safe)
 
     def begin_model_call(
         self,
@@ -2879,6 +2945,8 @@ class SpectrumH3Runtime:
         return RuntimeRollbackSnapshot(
             next_step_id=self._run.next_step_id,
             forecaster=self.forecaster.snapshot(),
+            backend_history=BackendHistory(self._backend_history.policy, self._backend_history.receipt,
+                                           self._backend_history.forecast_safe),
             history_topology=self._history_topology,
             history_labels=self._history_labels,
             current_window=self._current_window,
@@ -3012,6 +3080,8 @@ class SpectrumH3Runtime:
 
         self._run.next_step_id = snapshot.next_step_id
         self.forecaster.restore(snapshot.forecaster)
+        self._backend_history = BackendHistory(snapshot.backend_history.policy, snapshot.backend_history.receipt,
+                                               snapshot.backend_history.forecast_safe)
         self._history_topology = snapshot.history_topology
         self._history_labels = snapshot.history_labels
         self._current_window = snapshot.current_window

--- a/docs/BACKEND_HISTORY.md
+++ b/docs/BACKEND_HISTORY.md
@@ -1,0 +1,21 @@
+# Numerical attention backend history
+
+Production companion: [ComfyUI-Sol-H3 v0.1.0](https://github.com/xmarre/ComfyUI-Sol-H3/releases/tag/v0.1.0).
+
+`attention_backend_history_v1` maps provider keys to callbacks accepting `layout`, `options`, and `model` keyword arguments. They return an immutable preflight identity, or None for routing that cannot be predicted. Providers also expose `accept_receipts(receipts)` to qualify actual routing as forecastable. Actual implementations append hashable receipts to the per-call `attention_backend_receipts_v1` list before final-block return.
+
+Provider callbacks are metadata/qualification hooks rather than part of the transformer computation. If a preflight callback or `accept_receipts` fails, Spectrum treats that provider as unprovable and executes actual-only for the affected routing instead of aborting the sampling run. CUDA out-of-memory remains a hard resource failure and is propagated.
+
+The consumer reads preflight before `begin_model_call` and receipts before `observe_actual`. Policy/receipt changes clear stage banks and controllers, invalidate incompatible offline archives and require fresh actuals. Backend identity participates in rollback snapshots. Same-step conflicting routing is executed but not retained as one mixed numerical anchor. Pending old-backend residual probes are discarded when a late receipt resets history.
+
+The first provider identity in a run may be established without a reset only while no backend-dependent evidence exists yet: no retained forecaster history/topology, no current-step model evidence, and no recorded offline archive steps/anchors. This avoids invalidating an otherwise empty offline-capture archive at step 0. A provider appearing after evidence exists, provider removal, or a genuine identity/receipt transition still performs the full conservative reset.
+
+Opaque policies execute actual-only for the affected call. Core Block Sparse Attention currently does not publish this interface, so its compatibility path is actual-only. Offline replay is unavailable when its archive spans incompatible backends; this must not be described as a forecasting speedup. Provider removal also invalidates inherited history.
+
+## Production evidence
+
+The released Sol-H3 v0.1.0 stack on RTX PRO 6000 Blackwell exercised this contract together with VDN API v3, Untwist preprocessing, Diff-Aid and Flow mixed-grid routing. The final schedule was `18` logical calls, `14` actual transformer NFEs and `4` Spectrum forecasts (`low 8/2`, `high 4/2`, `probe 2/0`). The Sol-bypassed control uses `13 actual + 5 forecast`; the additional Sol actual is the intentional first `dense -> sol` numerical-backend transition.
+
+This confirms that the contract restores forecasting once the active backend route is provable without weakening real numerical transitions. Whole-workflow Sol timing is not treated as a controlled speed A/B because actual-NFE count, sparse routing/content and cache state differ between those runs.
+
+Validation includes the full Spectrum CPU/current-Comfy matrix, cross-package Sol-H3 native-interop coverage for replacement/provider composition and repeated scopes, and the final real SM120 production run described above.

--- a/docs/RELEASE_NOTES_v0.2.25_AND_EARLIER.md
+++ b/docs/RELEASE_NOTES_v0.2.25_AND_EARLIER.md
@@ -1,0 +1,390 @@
+# Spectrum MiniMax H3 v0.2.25
+
+v0.2.25 restores stable Spectrum operation with current ComfyUI DynamicVRAM/Comfy Compiler by keeping Spectrum-managed MiniMax H3 solver steps out of Aimdo malloc-graph capture without disabling either system globally.
+
+## Comfy Compiler / DynamicVRAM compatibility
+
+PR #102 fixes issue #99, where current ComfyUI could segfault in `comfy_aimdo.malloc_graph.MallocGraph.pop()` during Spectrum H3 sampling. The first narrow candidate only moved retained Spectrum history allocation outside the active malloc graph; real CUDA testing showed that was insufficient because the first prompt could complete while a second prompt in the same process still crashed during `malloc_graph_end()`.
+
+The final integration uses a broader, structural boundary:
+
+- Spectrum lazily wraps `comfy.model_prefetch.malloc_graph_enabled` and returns `False` only while a supported Spectrum H3 solver step is active on the current worker thread;
+- native MiniMax H3 therefore does not enter or pop an Aimdo malloc graph for Spectrum-managed forwards, where actual and forecast/replay calls intentionally have different allocation/control topology;
+- DynamicVRAM remains enabled;
+- Comfy Compiler remains enabled for non-Spectrum work;
+- normal compiler behavior is restored after every finalized Spectrum step;
+- `end_run` and the next `start_run` both clear stale thread-local bypass state so aborted workflows cannot leak the compatibility scope into later work;
+- the compatibility layer is installed last/outermost so existing Spectrum runtime wrappers cannot replace its cleanup boundary.
+
+This deliberately trades the Comfy Compiler malloc-graph optimization away only for Spectrum-managed H3 denoiser calls. It does not globally apply the `--disable-comfy-compiler` workaround and does not require `--highvram`.
+
+## Current-Core compatibility coverage
+
+The reviewed CI matrix now includes ComfyUI `15eb748b3ec5f8a0a2d470b7fb280e2d7579f916` with Python 3.12, `comfy-kitchen==0.2.33`, and `comfy-aimdo==0.5.2`. Native MiniMax test fixtures were also aligned with the current `attention` block argument and current transient H3 transformer-option metadata while preserving caller-owned option values.
+
+Older reviewed ComfyUI revisions that predate Comfy Compiler remain supported; the compiler contract test skips only where that API does not yet exist.
+
+## Validation
+
+- PR #102 final head `be607cf485dc720cf2557c45e01f21404d75e871` passed GitHub Actions run **#589** across all **9** reviewed ComfyUI/Python matrix jobs.
+- CodeRabbit completed the final diff review with **no actionable comments** and rated merge risk minimal.
+- Real CUDA/runtime validation confirmed that the revised compatibility boundary fixed the crash; the tester also reported no obvious performance regression in normal use.
+- The original failing issue is closed after the accepted runtime retest.
+
+Existing Spectrum forecasting policies, sampler equations, Continuum prefix semantics, external-patch exactness rules, generic correction, offline replay semantics, and non-Spectrum Comfy Compiler behavior are unchanged outside this compatibility boundary.
+
+---
+
+# Spectrum MiniMax H3 v0.2.24
+
+v0.2.24 removes two unnecessary actual-evaluation barriers in validated few-step and progressive workflows while preserving the exact anchors required by the underlying samplers and external-patch contracts.
+
+## Qualified terminal Untwist PECE deferral
+
+PR #98 adds a narrow, versioned exception to Spectrum's normal hard external-patch transition rule for active SA-Solver PECE.
+
+- ComfyUI-Untwisting-RoPE v0.2.3 can declare `terminal_pece_exact_corrector_safe=true` only for its reviewed weak terminal spatial-only envelope.
+- Spectrum independently proves that the current call is the terminal predicted PECE phase and that the immediate next logical call is the exact corrected phase for the same outer step before allowing the predictor to remain forecasted.
+- The corrected call remains an actual H3 evaluation and becomes the persistent endpoint. Native SA-Solver sigma/tau/noise/RNG ordering and Adams history remain intact.
+- Missing or malformed capability metadata, PEC/non-PECE sampling, missing correctors, unknown topology, interior transitions, replay, or any stacked unsafe transition retain the ordinary exact hard-boundary promotion.
+- DiffAid's current strong interior hard transition remains exact.
+
+The follow-up short-lifetime regression found that the deferral layer was clearing Spectrum's already-selected one-point bootstrap mechanism under `max_speed`. That turned a valid one-anchor hold into the ordinary multi-point forecaster and produced `Spectrum forecaster does not have enough actual history`. The final fix changes only the external-patch reason and preserves the forecast mechanism chosen by `begin_step()`.
+
+The corrected progressive high stages now execute the intended two-outer-step PECE topology:
+
+```text
+P0  A
+P1  F
+C1  A
+```
+
+Both exercised high-stage invocations completed as **2 actual / 1 forecast**, confirmed the exact same-outer corrector, and reported zero terminal fail-safe events and zero Spectrum fallbacks. Across the complete corrected progressive workflow, metrics reported **22 logical sampler calls, 17 actual transformer NFEs, 5 Spectrum forecasts, and 2 exact handoff-probe NFEs**.
+
+The terminal-deferral semantic change also passed matched decoded-media A/B testing. In the validated 0.5 MP four-pass workflow, the new policy produced **32 actual / 16 forecast** calls versus **36 / 12** under the previous terminal-transition policy, saving four real H3 transformer evaluations without a discernible quality regression.
+
+## RES final-tail policy
+
+PR #100 removes the obsolete RES-specific three-step final-tail floor that originated as an empirical safeguard for the old monolithic RES path.
+
+- `tail_actual_steps` is now authoritative for `sample_res_multistep` and `sample_res_multistep_cfg_pp`; Spectrum no longer silently raises the RES final tail to three actual calls.
+- The separate RES recurrence safeguard is unchanged: after a forecast, one exact H3 evaluation still refreshes native `old_denoised` before another forecast may occur.
+- Continuum prefixes, warmup, external-patch transitions, fallbacks, force-actual conditions, and other independent correctness boundaries still take precedence.
+
+A three-step progressive high-resolution RES stage with one exact Continuum prefix and `tail_actual_steps=1` can therefore use:
+
+```text
+A F A
+```
+
+The production progressive RES validation exercised four stages as `A F A F A`, `A F A`, `A A F A A`, and `A F A`. That is **16 logical sampler calls = 11 actual + 5 forecast**; two exact handoff probes bring the workflow to **13 actual transformer NFEs** overall. All four stages reported zero Spectrum fallbacks. Decoded video and audio were reviewed as excellent, with the RES result preferred over the matched Euler control.
+
+## Step/NFE documentation and release process
+
+PR #95 is also included in this release archive. It is documentation/release-process only: it clarifies that UI scheduler steps are outer sigma intervals rather than necessarily one H3 model call, records the `2N - 1` / `3N - 2` multistage call counts, and hardens documentation-only release-note refreshes against stale workflow runs. It does not change sampler or forecasting behavior.
+
+The release workflow now also keeps the level-1 version heading in `RELEASE_NOTES.md` for repository history and version validation while removing that heading from the GitHub release body. The GitHub release title therefore appears only once.
+
+## Validation
+
+- PR #100: GitHub Actions run **576** passed the full eight-lane reviewed ComfyUI/Python matrix, followed by the successful production-stack RES media validation.
+- PR #98: final PR-head GitHub Actions run **575** passed all eight matrix jobs; the corrected real `max_speed` short-lifetime workflow completed without the prior under-history failure.
+- Combined post-merge `main`: GitHub Actions run **578** passed after PR #100 and PR #98 were both present on `main`.
+- Companion ComfyUI-Untwisting-RoPE #5: merged `main` tests run **23** passed.
+
+Existing Euler, ER-SDE, SEEDS, ordinary SA-Solver PEC, RefDelta ownership, Continuum prefix semantics, native/all-actual fallbacks, and unsafe external-patch transition handling remain unchanged outside the specific policies above.
+
+---
+
+# Spectrum MiniMax H3 v0.2.23
+
+v0.2.23 completes the SA-Solver PECE and RefDelta multi-backend integration and makes **`balanced` the default active-PECE forecast policy** after matched MiniMax-H3 production testing.
+
+## Important: outer steps are not H3 model-call counts
+
+The ComfyUI scheduler's **steps** value counts outer sigma intervals. Some of the newly
+supported solvers expose additional logical H3 model-call opportunities inside those
+intervals, so raw step counts are not NFE-equivalent across sampler families.
+
+For the usual terminal-zero schedule, with `N = len(sigmas) - 1`:
+
+| Sampler topology | Native H3 model-call opportunities | 10 outer steps | 19 outer steps |
+| --- | ---: | ---: | ---: |
+| Euler / RES multistep / ER-SDE | `N` | 10 | 19 |
+| SA-Solver PEC / inactive PECE (`use_pece = false` or `corrector_order = 0`) | `N` | 10 | 19 |
+| SEEDS-2 | `2N - 1` | 19 | 37 |
+| SEEDS-3 | `3N - 2` | 28 | 55 |
+| Active SA-Solver PECE (`use_pece = true`, `corrector_order > 0`) | `2N - 1` | 19 | 37 |
+
+SEEDS omits its internal stage calls on the final sigma-to-zero interval. Active PECE
+with `corrector_order > 0` executes `P0`, then predicted/corrected pairs
+`P1/C1, P2/C2, ...`, giving `N` predicted opportunities plus `N - 1` corrected
+opportunities. With `corrector_order = 0`, PECE collapses to `N`.
+
+Spectrum's actual/forecast ratios are therefore counted over logical H3 model-call opportunities.
+A clean 10-outer-step PECE run contains **19** logical H3 calls: `balanced` is nominally
+**11 actual / 8 forecast** and `max_speed` **10 / 9**. Production safety boundaries may
+promote forecasts to actual, changing the split without changing the 10 outer steps.
+
+## Active SA-Solver PECE
+
+Spectrum now models native ComfyUI PECE as explicit predicted/corrected evaluations:
+
+```text
+P0
+P1 C1
+P2 C2
+...
+```
+
+- `P0` and exact corrected `C_i` evaluations own persistent Spectrum/Adams history.
+- Later predicted `P_i` evaluations are ephemeral current-corrector inputs and never become persistent Adams evidence.
+- Forecasted predicted phases use causal solver-space dense output derived only from exact persistent endpoints; Spectrum's raw hidden-feature forecast is not consumed numerically by SA at that boundary.
+- Every corrected phase remains an exact H3 re-anchor.
+- Native sigma/tau/noise/RNG ordering, stochastic variance, predictor/corrector equations, PECE endpoint replacement, callbacks, and terminal behavior remain unchanged.
+- H3 Continuum prefixes and DiffAid/Untwist hard transitions remain authoritative actual-evaluation boundaries.
+
+## PECE quality/speed policy
+
+`sa_pece_forecast_policy` exposes three reviewed start cadences:
+
+- **`balanced` (default):** P0/P1 exact; clean 10-outer topology is 11 actual / 8 forecast.
+- `max_speed`: P0 exact; clean 10-outer topology is 10 actual / 9 forecast.
+- `stable_start`: P0/P1/P2 exact; clean 10-outer topology is 12 actual / 7 forecast.
+
+Real production stacks may be more conservative because Continuum prefixes, external hard transitions, user warmup, fallbacks, and force-actual conditions take precedence.
+
+Final matched 10-outer testing with runtime LoRA/DoRA hooks, DiffAid, Untwist-RoPE, RefDelta SA-Solver PECE, Spectrum full/model-aware mode, and H3 Continuum produced acceptable decoded output with both `max_speed` and `balanced`. The **balanced run was perceptually better** in the tested workflow, so it is now the release default. The early coarse/colored-shape previews seen during the first few denoising steps also occur with other MiniMax-H3 samplers and are not treated as a PECE correctness failure.
+
+The reviewed maximum-speed production trace completed at 12 actual / 7 forecast for the initial chunk and 13 actual / 6 forecast for the Continuum chunk after hard-transition and Continuum promotions, with zero fallbacks, bypasses, rollbacks, speculative calls, discarded actual calls, or external-patch contract failures.
+
+## RefDelta SEEDS / SA-Solver composition
+
+Spectrum now composes with the RefDelta Solver v0.6.0 sampler family:
+
+- `sample_refdelta_seeds_2`;
+- `sample_refdelta_seeds_3`;
+- `sample_refdelta_sa_solver`;
+- `sample_refdelta_sa_solver_pece`.
+
+RefDelta keeps its own reviewed evidence topology while Spectrum owns forecast scheduling. For PECE, RefDelta persistent evidence mirrors native endpoint replacement—`P0, C1, C2, ...`—and later predicted calls remain ephemeral even when a safety boundary makes one actual. Forecasted persistent endpoints fail closed.
+
+RefDelta SEEDS/SA composition remains causal-only under Spectrum, and unsupported multi-GPU clone paths bypass Spectrum rather than weakening the interop contract. ER-SDE's existing exact-gated-increment contract is unchanged.
+
+The cross-repository CI fixture is pinned to RefDelta Solver v0.6.0 commit:
+
+```text
+21d0191d933fedf2885df082d33eb1bc2fffd529
+```
+
+## Scheduler evidence
+
+The companion RefDelta dedicated SA-Solver scheduler media gate also completed. Exact `simple_control` was slightly preferred over `simple_adams_bounded`, while both produced acceptable decoded output. Spectrum does not own that outer scheduler choice; its PECE forecast policy remains independent.
+
+## Validation
+
+The final release branch retains the eight-lane reviewed ComfyUI/Python matrix, native MiniMax-H3 fixtures, RefDelta cross-repository fixtures, Ruff, compileall, and wheel build. Existing Euler, ER-SDE, RES multistep, native SEEDS, ordinary SA-Solver PEC, Continuum, external-patch, generic-correction, and saved-workflow behavior remain isolated from the new active-PECE policy.
+
+---
+
+# Spectrum MiniMax H3 v0.2.22
+
+v0.2.22 adds reviewed native Spectrum support for ComfyUI **SEEDS-2, SEEDS-3, and SA-Solver**, including the stochastic MiniMax H3 paths that required sampler-specific state handling rather than ordinary one-call forecasting.
+
+## Native SEEDS-2 / SEEDS-3 support
+
+Spectrum now understands the native multistage SEEDS solver geometry instead of treating each H3 model call as an independent diffusion step.
+
+For stochastic SEEDS:
+
+- native stochastic increments, noise draws, stage equations, and callback ordering remain untouched;
+- Spectrum forecasts the H3 **transformer residual** while rebuilding the exact current-state target input embedding from the native solver latent;
+- stochastic stages share one residual history over the true interleaved model-call coordinates;
+- the outer SEEDS stage remains exact, while supported internal stages may be forecast;
+- one-point bootstrap remains disabled;
+- hard external-patch transitions, Continuum prefix requirements, warmup/readiness, and final-tail exactness remain authoritative;
+- the ordinary model-aware scheduler veto is advisory on the sampler-specific stochastic internal-stage path, while model-aware telemetry, adaptive fit/blend, and generic correction remain active;
+- stochastic SEEDS does not use offline smoothing replay because replaying the model-call sequence independently of the native noise-conditioned stage trajectory would break solver geometry.
+
+The final real SEEDS-2 validation completed cleanly with DiffAid, Untwist-RoPE, and H3 Continuum:
+
+- initial chunk: **11 actual / 8 forecast**, **0 fallbacks**;
+- Continuum chunk: **12 actual / 7 forecast**, **0 fallbacks**;
+- stage 0 stayed exact throughout;
+- the previously observed delayed heavy-noise pattern did not recur.
+
+SEEDS-3 is supported under the same reviewed state-conditioned residual architecture, but remains more conservative because its two consecutive internal stages do not have an exact outer-stage anchor between them.
+
+## Native SA-Solver support
+
+Spectrum now supports native SA-Solver without allowing approximate H3 denoisers to become recursive persistent Adams observations.
+
+The stochastic SA integration uses:
+
+- **actual-only persistent Adams history**;
+- forecast values only as bounded solver-local/ephemeral inputs;
+- causal solver-space dense output built from exact H3 anchors during stochastic intervals;
+- exact native tau/noise draws, predictor/corrector equations, callback ordering, sigma schedule, and final denoising semantics;
+- a one-forecast maximum streak with an exact H3 re-anchor after each skipped transformer call;
+- fail-closed/native behavior for unsupported active PECE corrector configurations.
+
+For H3 Continuum continuation chunks, every SA forecast coordinate uses a latest-exact solver-space hold and ignores the raw Spectrum hidden-feature denoised value at the SA boundary. This removes the remaining continuation-specific instability while preserving the 11/8 NFE target.
+
+Final real-media SA validation completed with:
+
+- initial chunk: **11 actual / 8 forecast**, **0 fallbacks**;
+- Continuum chunk: **11 actual / 8 forecast**, **0 fallbacks**;
+- all eight Continuum forecast coordinates using the reviewed all-forecast latest-exact isolation path;
+- no recurrence of the delayed heavy-noise corruption;
+- no recurrence of the later whole-frame vertical shake/flashing artifact.
+
+## Validation and compatibility
+
+PR #86 is the reviewed SEEDS-2/3 implementation and passed Actions **#495** across all seven supported ComfyUI/Python lanes. PR #87 is the stacked SA-Solver implementation and passed Actions **#511** on its final one-commit head.
+
+Both PRs were additionally validated with real MiniMax H3 media using the production workflow with DiffAid, Untwist-RoPE, H3 Continuum, runtime LoRA hooks, and the current PDD-capable ComfyUI H3 path.
+
+Existing Euler, RES multistep, ER-SDE, RefDelta, Continuum, generic-correction defaults, trust-shrinkage default-off behavior, and ordinary sampler scheduling remain unchanged outside the new sampler-specific paths.
+
+---
+
+# Spectrum MiniMax H3 v0.2.21
+
+v0.2.21 restores Spectrum forecast execution with current ComfyUI MiniMax H3 after the PDD LoRA update changed the native output-head contract.
+
+## ComfyUI 0.34 PDD final-layer compatibility
+
+- Fixes `FinalLayer.forward() missing 3 required positional arguments: 'sigma', 'sample_sigmas', and 'shifts'` on the first eligible Spectrum forecast with ComfyUI 0.34.0 and later PDD-capable H3 cores.
+- Spectrum now detects the reviewed native FinalLayer contract and forwards the same current sigma, exact sampler sigma schedule, and video/audio sigma shifts used by native H3.
+- Reviewed older ComfyUI revisions retain the existing four-argument FinalLayer path.
+- An incomplete future PDD argument contract fails explicitly instead of guessing.
+- No H3 Continuum-side workaround is required; Continuum exposed the stale Spectrum forecast output-head call.
+
+## Validation
+
+PR #84 adds focused regression coverage for the PDD projection call and adds ComfyUI commit `2504e68d4d9dedb514e172692f13436623f25aed` to the compatibility matrix with its required `comfy-kitchen` and `comfy-aimdo` versions. All seven ComfyUI/Python lanes pass, including the historical legacy FinalLayer contracts. CodeRabbit reported no actionable code finding.
+
+PR #84 supersedes #83; thanks to @bun-dev for independently identifying the same Core contract break and proposing the compatible call shape.
+
+---
+
+## v0.2.20
+
+v0.2.20 fixes the RefDelta API-v1 step-provenance handoff after a tracked ER-SDE model call.
+
+## RefDelta tracked-step provenance
+
+- Fixes `RefDelta requested a model-result classification for the wrong step` immediately after the first successful Spectrum/RefDelta model evaluation.
+- The real runtime trace showed Spectrum's ER-SDE stochastic tracker had already consumed and logged step 0 while the separate RefDelta bridge-local descriptor had not been mirrored reliably through the surrounding ComfyUI/Continuum model-options path.
+- For stochastic RefDelta runs, provenance is now recorded directly from the exact `ERSDEStepDescriptor` that the ER-SDE stochastic tracker successfully consumes. RefDelta therefore uses the same authoritative step classification that Spectrum used for stochastic-state ownership.
+- The existing post-model bridge update remains a redundant consistency path instead of the sole source of RefDelta provenance.
+- Deterministic `s_noise=0` RefDelta runs keep their direct bridge descriptor path because no stochastic tracker exists in that mode.
+- Stale-step and external-increment source validation remain strict; diagnostics now include requested/source and observed step IDs.
+- No model-path, Continuum, RefDelta Solver, prompt, sampler-setting, or workflow changes are required.
+
+## Validation
+
+PR #78 adds regression coverage for the exact failure mode: the tracker consumes step 0 successfully without a separate bridge update, and RefDelta must still classify the same step correctly. Coverage also verifies stale-step rejection, external-increment source checking, replay provenance, and deterministic no-tracker behavior.
+
+The complete six-lane Spectrum ComfyUI/Python matrix passes, including Ruff, compileall, focused external compatibility suites, and native MiniMax H3 fixtures. CodeRabbit reported no actionable merge-blocking finding and rated the runtime change minimal risk.
+
+---
+
+## v0.2.19
+
+v0.2.19 fixes RefDelta Solver discovery in the actual ComfyUI custom-node loading layout.
+
+## RefDelta custom-node namespace discovery
+
+- Fixes the runtime failure `RefDelta interop API is unavailable: No module named 'comfyui_refdelta_solver'` that could occur even though the RefDelta sampler itself was already loaded and usable by ComfyUI.
+- Spectrum now recognizes the already-loaded RefDelta implementation when ComfyUI has placed it under a package-relative custom-node namespace instead of exposing `comfyui_refdelta_solver` as a top-level package.
+- Canonical RefDelta imports reuse the exact live config class, sampler function, and interop contract objects instead of importing the same files a second time under a different module identity.
+- The existing strict RefDelta API-v1 checks remain unchanged: function identity, config provenance, interop version, option allowlist, stochastic ownership, and wrapper ordering still fail closed on drift.
+- No `PYTHONPATH` changes, pip installation, duplicated model path, or workflow changes are required.
+
+## Validation
+
+PR #76 adds a regression for the exact nested ComfyUI package layout that produced the failure. The complete six-lane Spectrum ComfyUI/Python matrix passes, including Ruff, compileall, focused external compatibility tests, and native MiniMax H3 fixtures. CodeRabbit reported no actionable findings on the substantive compatibility change.
+
+This patch changes discovery only. RefDelta solver behavior, Spectrum forecasting policy, stochastic compensation, Continuum interoperability, Diff-Aid handling, Untwisting RoPE handling, and offline replay semantics remain unchanged.
+
+---
+
+## v0.2.18
+
+v0.2.18 adds explicit compatibility with MiniMax H3 RefDelta Solver v0.2.0+.
+
+## RefDelta API v1
+
+- `sample_refdelta_er_sde` is admitted only when the installed function, config type, option set, and versioned interop marker match the reviewed contract.
+- Spectrum passes actual/forecast/replay provenance to RefDelta. Forecasted denoised values continue through ER-SDE solver history but cannot enter RefDelta's raw-model risk or correction evidence.
+- RefDelta publishes the exact stochastic increment after its risk and endpoint gates. Spectrum retains that tensor for the next skipped-state compensation instead of reconstructing an ungated native increment.
+- Native-equivalence RefDelta configurations continue through the reviewed native ER-SDE ownership path.
+- Deterministic `s_noise=0` RefDelta runs still receive actual/forecast provenance without allocating a stochastic tracker.
+- Offline replay preserves source-actual provenance and aborts safely to the completed first pass if interop state becomes inconsistent.
+
+## Validation and failure policy
+
+The test matrix covers the shared API contract, exact gated-increment transfer, missing-publication rejection, actual/forecast/replay classification, native ComfyUI contracts, Python 3.12/3.13, Ruff, compileall, and wheel construction. Unreviewed RefDelta versions, options, stochastic callbacks, wrapper ordering, or bridge state disable forecasting or fail explicitly rather than silently changing stochastic ownership.
+The cross-repository jobs pin the exact RefDelta API-v1 commit reviewed for this release.
+Release validation covers six Spectrum matrix jobs and the four-job RefDelta native fixture matrix.
+
+Existing native ER-SDE, Euler, RES multistep, Turbo, Continuum, Diff-Aid, Untwisting RoPE, masked H3, refinement, model-aware, and offline-replay behavior remains unchanged.
+
+---
+
+## v0.2.17
+
+v0.2.17 completes the current H3 Continuum interoperability work: native masked continuation can remain forecast-capable where the installed ComfyUI core exposes the required per-token H3 mask helper, and the learned-latent sampler-2 refinement path can use Spectrum without inheriting sampler-1's Continuum actual-prefix policy.
+
+## Native Masked H3 forecasting
+
+Spectrum now reconstructs native MiniMax H3 FinalLayer modulation for mixed VIDEO/AUDIO denoise masks instead of disabling forecasting for the entire masked continuation chunk.
+
+- Per-row VIDEO and AUDIO timestep selections follow native H3 mask semantics.
+- Scalar fully-generating paths retain the existing fast path.
+- Residual/shadow output-head evaluation uses the same reconstruction.
+- Per-row timestep index tensors are placed on the target latent device, avoiding CPU/CUDA index-device mismatches in FinalLayer implementations that use `index_select`.
+- On older reviewed ComfyUI cores that do not expose `mask_row_values`, a masked forecast fails closed to one native H3 transformer evaluation instead of raising during output-head reconstruction.
+- Malformed audio mask layouts continue to fail explicitly.
+
+## Short learned-latent refinement
+
+The integrated MiniMax H3 latent upscaler/refiner supplies an explicit `h3_refinement` API-v1 marker on a clone of Continuum's exact per-chunk MODEL. Spectrum validates that contract and lets its sampler-2 actual-prefix policy override the generation-only Continuum prefix carried by sampler 1.
+
+Normal Continuum generation still preserves its two-step actual prefix. A valid three-step sampler-2 refinement can therefore use:
+
+```text
+actual -> forecast -> actual
+```
+
+with the normal warmup/final-tail safety rules.
+
+Spectrum continues to honor genuine external-patch hard transitions. DiffAid v1.0.7 removes the artificial partial-denoise transition at its source by evaluating marked refinement against the full H3 sigma reference; Spectrum does not bypass a real model-function transition.
+
+## Coordinated runtime validation
+
+The complete real CUDA path was validated with:
+
+- H3 Continuum exact `refine_state` handoff;
+- MiniMax H3 learned latent upscale + internal sampler-2 refinement;
+- DiffAid marked-refinement sigma semantics;
+- Untwisting RoPE external-patch metadata;
+- native ER-SDE;
+- Spectrum enabled on both the main Continuum generation and sampler 2.
+
+A three-step high-resolution refinement produced `2 actual + 1 forecast` per refined chunk, with no inherited Continuum-prefix force-actual and no artificial DiffAid middle-step transition. The resulting media quality was user-validated as impeccable.
+
+The tested 0.7 MP native -> 1.75x learned-upscale workflow reduced the Refine node from roughly 302.5 s with three native refinement NFEs to roughly 212.7 s with the middle NFE forecast, while preserving the tested output quality.
+
+## Validation and compatibility
+
+The PR test matrix covers Python 3.10-3.13, the forecaster smoke test, Ruff/compileall, focused H3/external compatibility suites, and native MiniMax H3 fixtures across the reviewed ComfyUI revisions.
+
+This release is coordinated with:
+
+- ComfyUI-DiffAid-Patches v1.0.7;
+- H3 Continuum v3.4.1;
+- the integrated MiniMax H3 Latent Upscaler + Refine release.
+
+Existing Spectrum defaults, generic-correction defaults, normal 19-step Continuum forecasting policy, ER-SDE stochastic ownership, offline-replay policy, and real external-patch transition barriers remain unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-spectrum-minimax-h3"
 description = "A ComfyUI custom node implementing Spectrum spectral feature forecasting for native MiniMax H3 audio-video generation."
-version = "0.2.25"
+version = "0.2.26"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/tests/test_backend_history.py
+++ b/tests/test_backend_history.py
@@ -1,0 +1,277 @@
+import pytest
+import torch
+
+from comfyui_spectrum_h3.backend_history import BackendHistory, observe, prepare
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
+
+
+class Policy:
+    def __init__(
+        self,
+        identity="dense",
+        safe=True,
+        *,
+        preflight_error=None,
+        receipt_error=None,
+    ):
+        self.identity = identity
+        self.safe = safe
+        self.preflight_error = preflight_error
+        self.receipt_error = receipt_error
+
+    def __call__(self, **kw):
+        if self.preflight_error is not None:
+            raise self.preflight_error
+        return self.identity if self.safe else None
+
+    def accept_receipts(self, receipts):
+        if self.receipt_error is not None:
+            raise self.receipt_error
+        return all(item[2] != "fallback" for item in receipts)
+
+
+def runtime():
+    config = SpectrumH3Config(
+        degree=1,
+        max_history=4,
+        warmup_steps=2,
+        tail_actual_steps=0,
+        window_size=2,
+        bootstrap_first_forecast=False,
+        offline_smoothing_replay=False,
+    )
+    r = SpectrumH3Runtime(config)
+    r.start_run(torch.linspace(1, 0, 10), "euler", supported_sampler=True)
+    return r
+
+
+def call(r, policy, t, receipt="dense", want_actual=None):
+    decision = r.begin_step(torch.tensor([t]))
+    run, step = decision["run_id"], decision["step_id"]
+    options, pending = prepare(
+        r,
+        run,
+        step,
+        {"attention_backend_history_v1": {"test": policy}},
+        None,
+        None,
+    )
+    idx, actual = r.begin_model_call(
+        run,
+        step,
+        topology=(
+            ("video", (1, 24, 2, 4, 4)),
+            ("audio", (1, 32, 2, 8)),
+            ("hidden", 4),
+            ("target_audio_rows", 1),
+            ("target_video_rows", 2),
+        ),
+        labels=((0, "positive"),),
+        expected_shape=(1, 3, 4),
+    )
+    if want_actual is not None:
+        assert actual is want_actual
+    if actual:
+        options["attention_backend_receipts_v1"].append(("test", 0, receipt))
+        observe(r, run, step, options, pending)
+        r.observe_actual(run, step, idx, torch.ones(1, 3, 4) * t)
+    else:
+        assert (
+            r.predict(
+                run,
+                step,
+                idx,
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            )
+            is not None
+        )
+    r.finalize_step(run, step)
+    return actual
+
+
+def test_dense_sol_fallback_and_resume_partition_history():
+    r = runtime()
+    p = Policy()
+    call(r, p, 1.0, want_actual=True)
+    call(r, p, 0.9, want_actual=True)
+    call(r, p, 0.8, want_actual=False)
+    p.identity = "sol"
+    call(r, p, 0.7, receipt="sol", want_actual=True)
+    assert r.forecaster.history_length == 1
+    assert not r.stats.disabled
+    call(r, p, 0.6, receipt="sol", want_actual=True)
+    # An observed per-call fallback cannot pollute preceding SOL anchors.
+    r._required_actual_refreshes = 1
+    call(r, p, 0.5, receipt="fallback", want_actual=True)
+    assert r.forecaster.history_length == 1
+    call(r, p, 0.4, receipt="sol", want_actual=True)
+    assert r.forecaster.history_length == 1
+    assert r.stats.backend_history_resets >= 3
+
+
+def test_opaque_provider_and_core_bsa_execute_without_run_disable():
+    r = runtime()
+    p = Policy(safe=False)
+    for t in (1.0, 0.9, 0.8, 0.7):
+        call(r, p, t, want_actual=True)
+    assert not r.stats.disabled
+    decision = r.begin_step(torch.tensor([0.6]))
+    _options, pending = prepare(
+        r,
+        decision["run_id"],
+        decision["step_id"],
+        {"callbacks": {"on_prepare_state": {"block_sparse_attention": []}}},
+        None,
+        None,
+    )
+    assert pending is not None
+    assert r._step.mode == "actual"
+    assert not r.stats.disabled
+
+
+def test_provider_callback_failures_are_actual_only_without_disabling_run():
+    r = runtime()
+    call(
+        r,
+        Policy(preflight_error=RuntimeError("preflight failed")),
+        1.0,
+        want_actual=True,
+    )
+    assert not r._backend_history.forecast_safe
+    assert not r.stats.disabled
+    call(
+        r,
+        Policy(receipt_error=RuntimeError("receipt failed")),
+        0.9,
+        want_actual=True,
+    )
+    assert not r._backend_history.forecast_safe
+    assert not r.stats.disabled
+
+
+def test_provider_callback_oom_still_propagates():
+    r = runtime()
+    decision = r.begin_step(torch.tensor([1.0]))
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        prepare(
+            r,
+            decision["run_id"],
+            decision["step_id"],
+            {
+                "attention_backend_history_v1": {
+                    "test": Policy(
+                        preflight_error=torch.cuda.OutOfMemoryError("preflight oom")
+                    )
+                }
+            },
+            None,
+            None,
+        )
+
+    r = runtime()
+    decision = r.begin_step(torch.tensor([1.0]))
+    run, step = decision["run_id"], decision["step_id"]
+    options, pending = prepare(
+        r,
+        run,
+        step,
+        {
+            "attention_backend_history_v1": {
+                "test": Policy(
+                    receipt_error=torch.cuda.OutOfMemoryError("receipt oom")
+                )
+            }
+        },
+        None,
+        None,
+    )
+    options["attention_backend_receipts_v1"].append(("test", 0, "dense"))
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        observe(r, run, step, options, pending)
+
+
+def test_backend_identity_is_run_scoped_and_rollback_restored():
+    r = runtime()
+    call(r, Policy(), 1.0)
+    snapshot = r.create_rollback_snapshot()
+    call(r, Policy("sol"), 0.9, receipt="sol")
+    r.restore_rollback_snapshot(snapshot)
+    assert r._backend_history.policy == (("test", "dense"),)
+    r.end_run(r.active_run_id)
+    r.start_run(torch.linspace(1, 0, 10), "euler", supported_sampler=True)
+    assert r._backend_history == BackendHistory()
+
+
+def test_history_reset_clears_every_stage_bank():
+    r = runtime()
+    from comfyui_spectrum_h3.forecast import HistoryWeightForecaster
+
+    bank = HistoryWeightForecaster(
+        degree=1,
+        ridge_lambda=0.01,
+        max_history=4,
+        history_storage="system_ram",
+    )
+    r._stage_forecasters[1] = bank
+    call(r, Policy("dense"), 1.0, receipt="dense")
+    call(r, Policy("sol"), 0.9, receipt="sol")
+    assert bank.history_length == 0
+
+
+def test_same_step_mixed_receipts_are_executed_but_not_archived():
+    r = runtime()
+    p = Policy("sol")
+    decision = r.begin_step(torch.tensor([1.0]))
+    run, step = decision["run_id"], decision["step_id"]
+    for branch, route in enumerate(("sol", "fallback")):
+        options, pending = prepare(
+            r,
+            run,
+            step,
+            {"attention_backend_history_v1": {"test": p}},
+            None,
+            None,
+        )
+        idx, actual = r.begin_model_call(
+            run,
+            step,
+            topology=("native",),
+            labels=((branch, str(branch)),),
+            expected_shape=(1, 3, 4),
+        )
+        assert actual
+        options["attention_backend_receipts_v1"].append(("test", 0, route))
+        observe(r, run, step, options, pending)
+        r.observe_actual(run, step, idx, torch.ones(1, 3, 4))
+    assert not r._step.retain_history
+    assert not r._step.actual_records
+    r.finalize_step(run, step)
+    assert r.forecaster.history_length == 0
+    assert r.stats.actual_transformer_calls == 2
+    assert not r.stats.disabled
+
+
+def test_initial_backend_identity_preserves_empty_offline_archive_then_transition_invalidates():
+    r = runtime()
+    r.begin_offline_capture(total_steps=9, sampler_name="euler")
+    p = Policy("sol")
+    call(r, p, 1.0, receipt="sol", want_actual=True)
+    assert r._offline_archive.valid
+    assert r.stats.backend_history_resets == 0
+    p.identity = "dense"
+    call(r, p, 0.9, receipt="dense", want_actual=True)
+    assert not r._offline_archive.valid
+    assert r.stats.backend_history_resets >= 1
+    assert not r.stats.disabled
+
+
+def test_removed_provider_does_not_reuse_sparse_anchors():
+    r = runtime()
+    call(r, Policy("sol"), 1.0, receipt="sol", want_actual=True)
+    decision = r.begin_step(torch.tensor([0.9]))
+    prepare(r, decision["run_id"], decision["step_id"], {}, None, None)
+    assert r.forecaster.history_length == 0
+    assert r._step.mode == "actual"
+    assert not r.stats.disabled


### PR DESCRIPTION
## Release candidate: v0.2.26

This PR adds Spectrum's provider-generic numerical-attention history/receipt contract and is now release-ready after the primary Sol-H3 GPU/runtime gate passed in the published [ComfyUI-Sol-H3 v0.1.0](https://github.com/xmarre/ComfyUI-Sol-H3/releases/tag/v0.1.0).

## Backend-history contract

`attention_backend_history_v1` providers publish a stable preflight identity for the next numerical route, or `None` when that route cannot be proven. Actual providers append `attention_backend_receipts_v1` receipts and qualify them through `accept_receipts(...)` before Spectrum retains the resulting H3 anchor as forecast-safe.

Policy/receipt changes, provider removal and late conflicting routing conservatively reset incompatible stage banks/controllers and offline evidence. Same-step conflicting receipts execute but are not retained as one mixed anchor. Backend identity is also included in rollback snapshots.

The consumer remains provider-generic: Spectrum contains no Sol-H3/Untwist/Diff-Aid/Flow allowlist.

## Failure policy

Backend-history callbacks are metadata hooks, not transformer execution. Failing preflight or receipt-qualification callbacks therefore make the affected route actual-only instead of aborting the sampler. CUDA OOM is propagated as a real resource failure.

The first provider identity may be established without resetting only while no backend-dependent evidence exists. Later provider appearance/removal or a real policy/receipt transition retains the full reset path.

## Production result

The released Sol-H3 stack on RTX PRO 6000 Blackwell, with VDN, Untwist, Diff-Aid and Flow, now settles at:

```text
sampler_logical_calls       18
transformer_actual_nfe      14
spectrum_forecast_calls      4

low:    8 actual / 2 forecast
high:   4 actual / 2 forecast
probe:  2 actual / 0 forecast
```

The Sol-bypassed control is `13 actual + 5 forecast`. The one extra Sol-enabled actual is the intentional first low-stage `dense -> sol` numerical-backend transition and remains a safety anchor.

This removes the earlier all-actual `18/0` history-opacity confound without weakening a real backend transition. Whole-workflow Sol timing is still not treated as a controlled percentage A/B because NFE count, sparse routing/content and cache state differ.

## Release documentation

- `docs/BACKEND_HISTORY.md` now points to the released Sol-H3 v0.1.0 production companion and records the 18/14/4 result.
- `RELEASE_NOTES.md` contains the v0.2.26 contract/result summary.
- Historical notes through v0.2.25 are preserved verbatim in `docs/RELEASE_NOTES_v0.2.25_AND_EARLIER.md`.
- `pyproject.toml` is bumped to `0.2.26`; existing release/registry automation will publish from tested `main`.

## Validation / topology

```text
head:    10d201415ac92b326bb375825cf5b66bbb331d4e
parent:  2482f52604da037c29e3f613e10057e8aaa83abb
tree:    240deda2bd39477cd882c433f851e96c3a224588
commits: 1
```

Final PR-head CI run `34310558359` passed all **9/9** reviewed ComfyUI/Python matrix jobs, including the current Comfy Compiler/Aimdo lane. Earlier CodeRabbit substantive findings were fixed and resolved. The real SM120 production gate is now satisfied by Sol-H3 v0.1.0.

Existing sampler equations, PECE/SEEDS/SA-Solver ownership, Continuum prefix semantics, external-patch exactness, generic correction, offline replay policy and the v0.2.25 Comfy Compiler compatibility boundary are unchanged outside numerical-backend history qualification.