### PR TITLE
Audit core BlockSparseAttention and recover cold-to-primed forecasts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,11 @@ jobs:
             python_version: "3.12"
             comfy_kitchen_version: "0.2.33"
             comfy_aimdo_version: "0.5.2"
+          - comfy_ref: be92396834f9b6e3e361cfe30e7eed693137a448
+            python_version: "3.12"
+            comfy_kitchen_version: "0.2.33"
+            comfy_aimdo_version: "0.5.3"
+            fixture_required: true
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -58,6 +63,22 @@ jobs:
           repository: xmarre/ComfyUI-MiniMax-H3-RefDelta-Solver
           ref: 21d0191d933fedf2885df082d33eb1bc2fffd529
           path: RefDeltaSolver
+
+      - name: Check out reviewed Untwist interop
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: xmarre/ComfyUI-Untwisting-RoPE
+          ref: 63c8d8df5e08dfdad4b397480d966b90f9b5a6c6
+          path: UntwistRoPE
+
+      - name: Check out reviewed Flow interop
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: xmarre/MiniMax-H3-Flow-Aligned-Regenerate
+          ref: 860f308cc4f84f920d0c1facd4ece028584a02a0
+          path: FlowRegenerate
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -96,6 +117,15 @@ jobs:
             --ignore I001,UP037
           python -m ruff check \
             comfyui_spectrum_h3/backend_history.py \
+            comfyui_spectrum_h3/bsa_transition_probe.py \
+            comfyui_spectrum_h3/bsa_transition_probe_compat.py \
+            comfyui_spectrum_h3/bsa_transition_probe_manual.py \
+            comfyui_spectrum_h3/core_bsa_compat.py \
+            comfyui_spectrum_h3/core_bsa_diagnostics.py \
+            comfyui_spectrum_h3/core_bsa_flow_compat.py \
+            comfyui_spectrum_h3/core_bsa_forecast_recovery.py \
+            comfyui_spectrum_h3/core_bsa_preprocess_compat.py \
+            comfyui_spectrum_h3/source_code_audit.py \
             comfyui_spectrum_h3/comfy_compiler_compat.py \
             comfyui_spectrum_h3/config.py \
             comfyui_spectrum_h3/generic_correction.py \
@@ -120,6 +150,18 @@ jobs:
             comfyui_spectrum_h3/sampling.py \
             comfyui_spectrum_h3/__init__.py \
             tests/test_backend_history.py \
+            tests/test_bsa_transition_probe.py \
+            tests/test_bsa_transition_probe_activation.py \
+            tests/test_bsa_transition_probe_kitchen_compat.py \
+            tests/test_bsa_transition_probe_manual.py \
+            tests/test_core_bsa_compat.py \
+            tests/test_core_bsa_flow_compat.py \
+            tests/test_core_bsa_flow_identity.py \
+            tests/test_core_bsa_forecast_recovery.py \
+            tests/test_core_bsa_preprocess_compat.py \
+            tests/test_core_bsa_source_hardening.py \
+            tests/test_reviewed_bsa_fixture_gate.py \
+            tests/test_scheduler_bootstrap_entitlement.py \
             tests/test_comfy_compiler_compat.py \
             tests/test_config.py \
             tests/test_continuum_interop.py \
@@ -155,7 +197,7 @@ jobs:
       - name: Run focused external compatibility suites
         env:
           COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
-          PYTHONPATH: ${{ github.workspace }}/ComfyUI:${{ github.workspace }}/RefDeltaSolver
+          PYTHONPATH: ${{ github.workspace }}/ComfyUI:${{ github.workspace }}/RefDeltaSolver:${{ github.workspace }}/UntwistRoPE:${{ github.workspace }}/FlowRegenerate
         run: |
           python -m pytest -q \
             tests/test_external_patch_compat.py \
@@ -175,7 +217,8 @@ jobs:
       - name: Run tests against native MiniMax H3
         env:
           COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
-          PYTHONPATH: ${{ github.workspace }}/ComfyUI:${{ github.workspace }}/RefDeltaSolver
+          PYTHONPATH: ${{ github.workspace }}/ComfyUI:${{ github.workspace }}/RefDeltaSolver:${{ github.workspace }}/UntwistRoPE:${{ github.workspace }}/FlowRegenerate
+          SPECTRUM_REQUIRE_REVIEWED_BSA_FIXTURE: ${{ matrix.fixture_required && '1' || '0' }}
         run: |
           python -m pytest -q \
             --ignore=tests/test_external_patch_compat.py \

--- a/comfyui_spectrum_h3/__init__.py
+++ b/comfyui_spectrum_h3/__init__.py
@@ -1,5 +1,9 @@
+from .bsa_transition_probe_compat import install_bsa_transition_probe_compat
+from .bsa_transition_probe_manual import install_bsa_transition_probe_manual_only
 from .comfy_compiler_compat import install_comfy_compiler_compat
 from .config import AGGRESSIVE_PRESET, CONSERVATIVE_PRESET, SpectrumH3Config
+from .core_bsa_forecast_recovery import install_core_bsa_forecast_recovery
+from .core_bsa_loader_compat import install_core_bsa_loader_compat
 from .er_sde_offline_replay_safety import install_er_sde_offline_replay_safety
 from .er_sde_policy import install_er_sde_tail_policy
 from .external_patch_compat import install_external_patch_compat
@@ -23,6 +27,9 @@ from .replay_trust_shadow import install_replay_native_trust_shadow
 from .runtime import SpectrumH3Runtime
 from .trust_probe import install_forecast_trust_probe
 
+install_core_bsa_loader_compat()
+install_bsa_transition_probe_compat()
+install_bsa_transition_probe_manual_only()
 install_generic_residual_correction()
 install_postrun_safety()
 install_forecast_trust_probe()
@@ -41,6 +48,9 @@ install_external_patch_compat()
 install_visual_reference_patch_compat()
 install_external_patch_hardening()
 install_er_sde_offline_replay_safety()
+# The BSA recovery wrapper must see the final scheduler/rollback decision made by
+# the compatibility layers above. Compiler compatibility remains outermost.
+install_core_bsa_forecast_recovery()
 # Compiler compatibility must be outermost: it owns the thread-local lifetime
 # from Spectrum step entry through every already-installed finalize/end wrapper.
 install_comfy_compiler_compat()

--- a/comfyui_spectrum_h3/backend_history.py
+++ b/comfyui_spectrum_h3/backend_history.py
@@ -6,11 +6,14 @@ Actual attention providers append hashable receipts before the last block return
 Opaque routing is actual-only per call; it never aborts sampling.
 """
 from dataclasses import dataclass
+import logging
 
 import torch
 
 POLICIES = "attention_backend_history_v1"
 RECEIPTS = "attention_backend_receipts_v1"
+
+LOG = logging.getLogger(__name__)
 
 
 @dataclass
@@ -59,26 +62,106 @@ def _runtime_has_backend_evidence(runtime) -> bool:
     return runtime._offline_smoother is not None
 
 
-def preflight(options, layout, model):
+def _preflight(options, layout, model):
     policies = options.get(POLICIES, {})
-    if not policies:
-        # Core BSA predates the provider contract. Preserve its operator while
-        # requiring actual execution; never forecast across its unreported schedule.
-        callbacks = options.get("callbacks", {})
-        if any("block_sparse_attention" in group for group in callbacks.values()):
-            return ("core_bsa_unreported",), False
-        return None, True
-    identities = []
-    safe = True
-    for name, provider in sorted(policies.items()):
-        identity = _provider_identity(provider, layout=layout, options=options, model=model)
-        safe = safe and identity is not None
-        identities.append((name, identity))
-    return tuple(identities), safe
+    if policies:
+        identities = []
+        safe = True
+        for name, provider in sorted(policies.items()):
+            identity = _provider_identity(provider, layout=layout, options=options, model=model)
+            safe = safe and identity is not None
+            identities.append((name, identity))
+        return tuple(identities), safe, None
+
+    # Core ComfyUI BSA does not publish the generic provider contract. Spectrum
+    # owns narrowly source-gated compatibility audits for the exact reviewed BSA,
+    # Untwist preprocessor and Flow block-wrapper composition. Any unknown source
+    # or ownership remains actual-only.
+    from . import core_bsa_flow_compat, core_bsa_preprocess_compat
+
+    if core_bsa_flow_compat.has_core_bsa_evidence(options):
+        audit, reason = core_bsa_preprocess_compat.probe(options, layout, model)
+        if audit is not None:
+            return audit.identity, audit.safe, audit
+        return ("core_bsa_unreported", reason or "unrecognized"), False, None
+
+    return None, True, None
+
+
+def preflight(options, layout, model):
+    identity, safe, _audit = _preflight(options, layout, model)
+    return identity, safe
+
+
+def _debug_core_bsa_preflight(
+    runtime,
+    run_id,
+    step_id,
+    identity,
+    safe,
+    audit,
+    *,
+    options,
+    layout,
+    model,
+):
+    if not runtime.config.debug:
+        return
+    if audit is not None:
+        routes = ",".join(str(spec[0]) for spec in audit.route_specs)
+        flow_mode = getattr(audit, "flow_mixed", None)
+        LOG.warning(
+            "Spectrum H3 core-BSA preflight run_id=%s step=%s result=audited safe=%s "
+            "seq_len=%s routes=%s flow_mixed=%s failure=%s",
+            run_id,
+            step_id,
+            bool(safe),
+            audit.seq_len,
+            routes,
+            flow_mode,
+            audit.failure,
+        )
+        return
+    if (
+        isinstance(identity, tuple)
+        and len(identity) >= 2
+        and identity[0] == "core_bsa_unreported"
+    ):
+        detail = None
+        if identity[1] == "ownership_unproven":
+            try:
+                from . import core_bsa_diagnostics
+
+                detail = core_bsa_diagnostics.ownership_diagnostic(
+                    options,
+                    layout,
+                    model,
+                )
+            except Exception as exc:  # noqa: BLE001 - debug detail cannot affect sampling
+                detail = f"diagnostic_failed:{type(exc).__name__}:{exc}"
+        LOG.warning(
+            "Spectrum H3 core-BSA preflight run_id=%s step=%s result=unreported "
+            "safe=False reason=%s detail=%s",
+            run_id,
+            step_id,
+            identity[1],
+            detail,
+        )
 
 
 def prepare(runtime, run_id, step_id, options, layout, model):
-    identity, safe = preflight(options, layout, model)
+    identity, safe, audit = _preflight(options, layout, model)
+    _debug_core_bsa_preflight(
+        runtime,
+        run_id,
+        step_id,
+        identity,
+        safe,
+        audit,
+        options=options,
+        layout=layout,
+        model=model,
+    )
     if identity is None:
         if runtime._backend_history.policy is None:
             return options, None
@@ -90,7 +173,15 @@ def prepare(runtime, run_id, step_id, options, layout, model):
     if runtime._backend_history.policy is None and not _runtime_has_backend_evidence(runtime):
         runtime._backend_history = BackendHistory(policy=identity)
     runtime.prepare_backend_history(run_id, step_id, identity, safe)
-    return {**options, RECEIPTS: []}, (identity, safe)
+
+    prepared = {**options, RECEIPTS: []}
+    if audit is not None:
+        from . import core_bsa_flow_compat
+
+        prepared = core_bsa_flow_compat.instrument_actual_options(
+            prepared, audit, RECEIPTS
+        )
+    return prepared, (identity, safe)
 
 
 def observe(runtime, run_id, step_id, options, policy):
@@ -98,11 +189,50 @@ def observe(runtime, run_id, step_id, options, policy):
         return
     identity, safe = policy
     receipts = tuple(options.get(RECEIPTS, ()))
-    # A fallback is not proof that the next call follows the same route. Until a
-    # provider can predict it, execute actuals and re-enable forecasts after SOL
-    # eligibility returns. Stable dense warmup is predictable through its policy.
-    safe = safe and bool(receipts) and all(
-        _provider_accepts(provider, receipts)
-        for provider in options.get(POLICIES, {}).values()
-    )
+
+    from . import core_bsa_compat
+
+    audit = options.get(core_bsa_compat.PRIVATE_AUDIT_KEY)
+    if audit is not None:
+        accepted = core_bsa_compat.accepts_actual(audit, receipts)
+        safe = safe and accepted
+        if runtime.config.debug:
+            routes = ",".join(
+                str(item[4]) if isinstance(item, tuple) and len(item) > 4 else "malformed"
+                for item in receipts
+            )
+            LOG.warning(
+                "Spectrum H3 core-BSA observe run_id=%s step=%s accepted=%s "
+                "preflight_safe=%s receipts=%s expected=%s failure=%s routes=%s",
+                run_id,
+                step_id,
+                bool(accepted),
+                bool(policy[1]),
+                len(receipts),
+                len(audit.expected_receipts),
+                audit.failure,
+                routes,
+            )
+    else:
+        # A fallback is not proof that the next call follows the same route. Until
+        # a provider can predict it, execute actuals and re-enable forecasts after
+        # the provider reports a stable route.
+        safe = safe and bool(receipts) and all(
+            _provider_accepts(provider, receipts)
+            for provider in options.get(POLICIES, {}).values()
+        )
+        if (
+            runtime.config.debug
+            and isinstance(identity, tuple)
+            and len(identity) >= 2
+            and identity[0] == "core_bsa_unreported"
+        ):
+            LOG.warning(
+                "Spectrum H3 core-BSA observe run_id=%s step=%s accepted=False "
+                "reason=%s receipts=%s",
+                run_id,
+                step_id,
+                identity[1],
+                len(receipts),
+            )
     runtime.observe_backend_history(run_id, step_id, identity, receipts, safe)

--- a/comfyui_spectrum_h3/bsa_transition_probe.py
+++ b/comfyui_spectrum_h3/bsa_transition_probe.py
@@ -1,0 +1,573 @@
+"""Bounded matched-input BSA calibration and hidden-hold diagnostics.
+
+On this diagnostic PR, audited-safe core-BSA CUDA runs enable the probe
+automatically and write reports below ComfyUI's normal output directory. The
+SPECTRUM_H3_BSA_DIAGNOSTICS environment variable remains only as an optional
+override/disable switch; no shell setup is required for the production handoff.
+
+Attention comparisons repeat only the reviewed sparse attention closure. They do
+not replay a transformer or simulate the downstream trajectory of a skipped NFE.
+The unmodified actual output and pool update remain the control trajectory.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import hashlib
+import json
+import importlib.metadata
+import importlib.util
+import logging
+import os
+from pathlib import Path
+import random
+import sys
+import threading
+import uuid
+
+import torch
+
+LOG = logging.getLogger(__name__)
+_ACTIVE = ContextVar("spectrum_bsa_transition_probe", default=None)
+_LOCK = threading.Lock()
+_SESSION = uuid.uuid4().hex[:12]
+ENV = "SPECTRUM_H3_BSA_DIAGNOSTICS"
+AUTO_OUTPUT_SUBDIR = "spectrum_h3_bsa_diagnostics"
+_DISABLED = frozenset({"", "0", "false", "off", "no", "disable", "disabled"})
+
+
+def _diagnostic_directory(*, automatic):
+    """Resolve an explicit override, or auto-enable for an audited-safe CUDA run."""
+    configured = os.environ.get(ENV)
+    if configured is not None:
+        value = configured.strip()
+        if value.lower() in _DISABLED:
+            return None
+        return Path(value).expanduser()
+    if not automatic or not torch.cuda.is_available():
+        return None
+    try:
+        import folder_paths
+        output_root = Path(folder_paths.get_output_directory())
+    except (ImportError, AttributeError, TypeError, RuntimeError):
+        output_root = Path.cwd() / "output"
+    return output_root.expanduser() / AUTO_OUTPUT_SUBDIR
+
+
+def delta(reference, candidate):
+    """Chunked FP32 vector math with FP64 accumulation of chunk reductions."""
+    if reference.shape != candidate.shape:
+        raise ValueError("diagnostic tensor shapes differ")
+    a, b = reference.detach().reshape(-1), candidate.detach().reshape(-1)
+    n = a.numel()
+    if n == 0:
+        return {"finite": True, "elements": 0, "rmse": 0.0, "relative_l2": None,
+                "reference_rms": 0.0, "mae": 0.0, "max_abs": 0.0, "cosine": None}
+    sums = torch.zeros(5, dtype=torch.float64, device=a.device)
+    maximum = torch.zeros((), dtype=torch.float32, device=a.device)
+    finite = torch.ones((), dtype=torch.bool, device=a.device)
+    for start in range(0, n, 262144):
+        x = a[start:start + 262144].to(dtype=torch.float32)
+        y = b[start:start + 262144].to(device=a.device, dtype=torch.float32)
+        finite &= torch.isfinite(x).all() & torch.isfinite(y).all()
+        diff = y - x
+        chunk = torch.stack((diff.square().sum(), x.square().sum(),
+                             y.square().sum(), (x * y).sum(), diff.abs().sum()))
+        sums += chunk.to(dtype=torch.float64)
+        maximum = torch.maximum(maximum, diff.abs().max())
+    if not bool(finite.item()):
+        return {"finite": False, "elements": n}
+    err, ref, cand, dot, abs_sum = sums.tolist()
+    return {"finite": True, "elements": n, "rmse": (err / n) ** 0.5,
+            "relative_l2": (err / ref) ** 0.5 if ref else None,
+            "reference_rms": (ref / n) ** 0.5,
+            "mae": abs_sum / n, "max_abs": maximum.item(),
+            "cosine": dot / (ref * cand) ** 0.5 if ref and cand else None}
+
+
+def _tensor_state(tensor):
+    value = tensor.detach().to(dtype=torch.float32)
+    stats = torch.stack((value.min(), value.max(), value.mean(), value.square().mean().sqrt()))
+    minimum, maximum, mean, rms = stats.tolist()
+    return {"shape": list(value.shape), "dtype": str(tensor.dtype),
+            "min": minimum, "max": maximum, "mean": mean, "rms": rms}
+
+
+def _calibration_state(values):
+    return {"kmean": _tensor_state(values[0]), "vscale": _tensor_state(values[1])}
+
+
+def _same_bytes(tensor, saved):
+    return torch.equal(
+        tensor.contiguous().view(torch.uint8),
+        saved.contiguous().view(torch.uint8),
+    )
+
+
+def _pool_entry(patch, key):
+    pooled = getattr(patch, "pooled", None)
+    if not isinstance(pooled, dict):
+        return None
+    entry = pooled.get(key)
+    if (not isinstance(entry, (tuple, list)) or len(entry) != 2
+            or not all(torch.is_tensor(value) and value.dtype == torch.float32
+                       and value.ndim == 2 for value in entry)):
+        return None
+    return entry
+
+
+def _capture_cold_successor(audit, routes):
+    """Retain exact post-cold pool owners and bytes for the adjacent transition proof."""
+    state = {}
+    for index, route in enumerate(routes):
+        if route != "h3_chunked_sparse_cold":
+            continue
+        key = (index, audit.seq_len, audit.uuids)
+        entry = _pool_entry(audit.patch, key)
+        if entry is None:
+            raise RuntimeError(
+                f"BSA diagnostic lost accepted cold pool state for block {index}"
+            )
+        state[index] = (
+            entry[0],
+            entry[1],
+            entry[0].detach().clone(),
+            entry[1].detach().clone(),
+        )
+    return state
+
+
+def _verify_cold_successor(audit, sparse, predecessor):
+    """Prove current primed state is exactly the previous accepted cold output."""
+    for index in sparse:
+        expected = predecessor.get(index)
+        if expected is None:
+            return False, index, "predecessor_snapshot_missing"
+        key = (index, audit.seq_len, audit.uuids)
+        entry = _pool_entry(audit.patch, key)
+        if entry is None:
+            return False, index, "current_pool_missing_or_malformed"
+        if entry[0] is not expected[0] or entry[1] is not expected[1]:
+            return False, index, "pool_tensor_owner_changed"
+        if not _same_bytes(entry[0], expected[2]) or not _same_bytes(entry[1], expected[3]):
+            return False, index, "pool_tensor_contents_changed"
+    return True, None, None
+
+
+class PoolSnapshot:
+    """Preserve dict, entry and tensor identities as well as tensor contents."""
+    def __init__(self, patch):
+        if not isinstance(patch.pooled, dict):
+            raise TypeError("BSA pool is not a dictionary")
+        self.patch, self.mapping = patch, patch.pooled
+        self.entries = dict(patch.pooled)
+        self.values = {}
+        for key, entry in self.entries.items():
+            if (not isinstance(entry, (tuple, list)) or len(entry) != 2
+                    or not all(torch.is_tensor(t) and t.dtype == torch.float32
+                               and t.ndim == 2 for t in entry)):
+                raise ValueError("BSA pool entry is malformed")
+            self.values[key] = tuple(t.detach().clone() for t in entry)
+
+    def restore(self):
+        with torch.no_grad():
+            for key, entry in self.entries.items():
+                for tensor, saved in zip(entry, self.values[key]):
+                    tensor.copy_(saved)
+            self.mapping.clear()
+            self.mapping.update(self.entries)
+            self.patch.pooled = self.mapping
+
+    def verify(self):
+        if self.patch.pooled is not self.mapping or self.mapping.keys() != self.entries.keys():
+            raise RuntimeError("BSA diagnostic failed to restore pool dictionary")
+        for key, entry in self.entries.items():
+            if self.mapping[key] is not entry:
+                raise RuntimeError("BSA diagnostic failed to restore pool entry identity")
+            for tensor, saved in zip(entry, self.values[key]):
+                # Byte comparison also verifies NaN payloads, without _version.
+                if not _same_bytes(tensor, saved):
+                    raise RuntimeError("BSA diagnostic failed to restore pool contents")
+
+
+class IsolationStatus:
+    def __init__(self):
+        self.pool_restored = False
+        self.rng_restored = False
+
+
+@contextmanager
+def isolated_pool(patch, device):
+    """Restore after success, Python exceptions and OOM without masking the primary failure."""
+    saved = PoolSnapshot(patch)
+    status = IsolationStatus()
+    python_rng = random.getstate()
+    cpu_rng = torch.get_rng_state().clone()
+    cuda_device = None
+    cuda_rng = None
+    if device.type == "cuda":
+        cuda_device = device.index if device.index is not None else torch.cuda.current_device()
+        cuda_rng = torch.cuda.get_rng_state(cuda_device).clone()
+    devices = [] if cuda_device is None else [cuda_device]
+    try:
+        with torch.random.fork_rng(devices=devices):
+            yield status
+    finally:
+        primary = sys.exception()
+        restoration_errors = []
+        try:
+            random.setstate(python_rng)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - stdlib state restore is deterministic
+            restoration_errors.append(f"Python RNG restore failed: {exc}")
+        try:
+            saved.restore()
+            saved.verify()
+            status.pool_restored = True
+        except (RuntimeError, TypeError, ValueError) as exc:
+            restoration_errors.append(f"pool restore failed: {exc}")
+        try:
+            cpu_ok = torch.equal(torch.get_rng_state(), cpu_rng)
+            cuda_ok = True if cuda_rng is None else torch.equal(
+                torch.cuda.get_rng_state(cuda_device), cuda_rng
+            )
+            python_ok = random.getstate() == python_rng
+            status.rng_restored = bool(cpu_ok and cuda_ok and python_ok)
+            if not status.rng_restored:
+                restoration_errors.append("RNG state did not restore exactly")
+        except (RuntimeError, TypeError, ValueError) as exc:
+            restoration_errors.append(f"RNG verification failed: {exc}")
+        if restoration_errors:
+            message = "BSA diagnostic restoration failure: " + "; ".join(restoration_errors)
+            if primary is not None:
+                try:
+                    primary.add_note(message)
+                except AttributeError:  # pragma: no cover - Python 3.11+ has add_note
+                    pass
+            else:
+                raise RuntimeError(message)
+
+
+def _semantic_identity(value):
+    # Diagnostics only. This never supplies a production backend identity.
+    if isinstance(value, tuple):
+        return tuple(_semantic_identity(x) for x in value
+                     if not (isinstance(x, tuple) and x
+                             and x[0] in ("routes", "pool_ownership")))
+    return value
+
+
+def _identity_digest(identity):
+    return hashlib.sha256(repr(identity).encode()).hexdigest()
+
+
+class Probe:
+    def __init__(self, directory, run_id, config):
+        directory = Path(directory).expanduser()
+        directory.mkdir(parents=True, exist_ok=True)
+        self.path = directory / f"bsa-{_SESSION}-{uuid.uuid4().hex[:8]}-run{run_id}.jsonl"
+        self.file = self.path.open("x", encoding="utf-8")
+        self.run_id = run_id
+        self.config = config
+        self.previous = None
+        self.anchor = None
+        self.pending = None
+        self.examined = False
+        self.extra_attention_calls = 0
+        self.started_attention_calls = 0
+        self.errors = 0
+        self.calls = 0
+        self.write("start", schema_version=3, torch_version=torch.__version__,
+                   scope="matched-input sparse attention; full target-hidden one-point hold",
+                   diagnostic_transformer_nfe=0, max_attention_calls_per_run=6,
+                   production_policy="unchanged", source_revision=_revision())
+        LOG.warning("Spectrum H3 BSA diagnostic report: %s", self.path)
+
+    def write(self, event, **data):
+        self.file.write(json.dumps({"event": event, "run_id": self.run_id, **data},
+                                   allow_nan=False) + "\n")
+        self.file.flush()
+
+    def close(self):
+        if self.file.closed:
+            return
+        self.write("end", tracked_actual_calls=self.calls,
+                   diagnostic_attention_calls_started=self.started_attention_calls,
+                   diagnostic_attention_calls_completed=self.extra_attention_calls,
+                   diagnostic_transformer_nfe=0, errors=self.errors,
+                   pending_next_actual=self.pending is not None)
+        self.anchor = self.pending = self.previous = None
+        self.file.close()
+
+
+def _revision():
+    # Hash installed diagnostic source, without invoking git in the sampling path.
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def get_probe(runtime, run_id, *, automatic=False):
+    directory = _diagnostic_directory(automatic=automatic)
+    if directory is None:
+        return None
+    run = runtime._run
+    item = getattr(runtime, "_bsa_transition_probe", None)
+    if item is not None and item[0] is not run:
+        item[1].close()
+        item = None
+    if item is None:
+        version = importlib.metadata.version("comfy-kitchen")
+        spec = importlib.util.find_spec("comfy_kitchen.backends.cuda")
+        source = Path(spec.origin).read_bytes() if spec and spec.origin else b""
+        blob = hashlib.sha1(b"blob " + str(len(source)).encode() + b"\0" + source).hexdigest()
+        if version != "0.2.33" or blob != "15fcab4a9d166fae67db6ca4f3410274ad6840d9":
+            raise RuntimeError("BSA diagnostics require reviewed comfy-kitchen 0.2.33 CUDA wrapper")
+        probe = Probe(directory, run_id, runtime.config)
+        probe.write("source", comfy_kitchen=version, cuda_wrapper_git_blob=blob)
+        runtime._bsa_transition_probe = (run, probe)
+        return probe
+    return item[1]
+
+
+def finish(runtime):
+    item = getattr(runtime, "_bsa_transition_probe", None)
+    if item is not None:
+        item[1].close()
+        runtime._bsa_transition_probe = None
+
+
+class Actual:
+    def __init__(self, probe, runtime, step_id, call_id, audit):
+        self.probe, self.runtime, self.audit = probe, runtime, audit
+        self.step_id, self.call_id = step_id, call_id
+        self.identity = _semantic_identity(audit.identity)
+        sparse = [i for i, spec in enumerate(audit.route_specs) if spec[0] != "h3_dense"]
+        self.selected = {sparse[0], sparse[len(sparse)//2], sparse[-1]} if sparse else set()
+        self.routes = tuple(spec[0] for spec in audit.route_specs)
+        prev = probe.previous
+        transition_shape = bool(
+            not probe.examined
+            and prev
+            and prev[0] == step_id - 1
+            and prev[1] == self.identity
+            and sparse
+            and all(
+                self.routes[i] == "h3_chunked_sparse_primed"
+                and prev[2][i] == "h3_chunked_sparse_cold"
+                for i in sparse
+            )
+        )
+        self.predecessor_pool_continuity = None
+        self.predecessor_pool_mismatch_block = None
+        self.predecessor_pool_mismatch_reason = None
+        if transition_shape:
+            continuity, block, reason = _verify_cold_successor(audit, sparse, prev[3])
+            self.predecessor_pool_continuity = continuity
+            self.predecessor_pool_mismatch_block = block
+            self.predecessor_pool_mismatch_reason = reason
+            if not continuity:
+                probe.write(
+                    "skipped",
+                    step=step_id,
+                    reason="cold_to_primed_pool_successor_discontinuity",
+                    block=block,
+                    mismatch=reason,
+                    identity=_identity_digest(self.identity),
+                )
+        self.candidate = bool(transition_shape and self.predecessor_pool_continuity)
+        self.next_actual = bool(probe.pending and probe.pending["identity"] == self.identity
+                                and step_id == probe.pending["step"] + 1)
+        self.stale = {}
+        self.hidden = None
+        self.rows = None
+        self.measurements = []
+
+    def wrap_attention(self, function, index):
+        if index not in self.selected or not (self.candidate or self.next_actual):
+            return function
+
+        def measured(h, *args, **kwargs):
+            key = (index, self.audit.seq_len, self.audit.uuids)
+            patch = self.audit.patch
+            entry = patch.pooled.get(key)
+            if entry is None:
+                raise RuntimeError("BSA diagnostic expected primed pool")
+            old = tuple(t.detach().clone() for t in entry)
+            # Only this call contributes to the control trajectory and receipts.
+            actual = function(h, *args, **kwargs)
+            fresh = tuple(t.detach().clone() for t in patch.pooled[key])
+            if self.candidate:
+                self.stale[index] = (entry, old)
+                replacement = None
+                label = "cold_vs_primed"
+                alternative_mode = "cold_current_input_two_pass"
+            else:
+                stored = self.probe.pending["stale"].get(index)
+                if stored is None or any(a is not b for a, b in zip(stored[0], entry)):
+                    raise RuntimeError("BSA diagnostic pool ownership changed before next actual")
+                replacement = stored[1]
+                label = "skipped_refresh_next_actual"
+                alternative_mode = "primed_with_stale_pre_skipped_step_calibration"
+            self.probe.started_attention_calls += 1
+            if self.probe.started_attention_calls > 6:
+                raise RuntimeError("BSA diagnostic attention-call budget exceeded")
+            self.probe.write("attention_begin", step=self.step_id, block=index, measurement=label,
+                             route=self.routes[index])
+            actual_nfe_before = self.runtime.stats.actual_transformer_calls
+            forecast_calls_before = self.runtime.stats.forecast_model_calls
+            with isolated_pool(patch, h.device) as isolation:
+                if replacement is None:
+                    del patch.pooled[key]
+                else:
+                    for tensor, saved in zip(patch.pooled[key], replacement):
+                        tensor.copy_(saved)
+                alternative = function(h, *args, **kwargs)
+            if (self.runtime.stats.actual_transformer_calls != actual_nfe_before
+                    or self.runtime.stats.forecast_model_calls != forecast_calls_before):
+                raise RuntimeError("BSA diagnostic attention repeat changed transformer/forecast counters")
+            measurement = delta(actual, alternative)
+            self.probe.extra_attention_calls += 1
+            growth = fresh[1] / old[1].clamp_min(1e-8)
+            stale_growth = None if replacement is None else (
+                fresh[1] / replacement[1].clamp_min(1e-8)
+            )
+            headroom_count = None if stale_growth is None else int((stale_growth > 1.1).sum().item())
+            self.measurements.append({
+                "measurement": label,
+                "block": index,
+                "route": self.routes[index],
+                "scope": "attention_output_projection_at_fixed_actual_block_input",
+                "error": measurement,
+                "control_output_source": "unmodified_primary_attention_call",
+                "alternative_output_discarded": True,
+                "alternative_calibration_mode": alternative_mode,
+                "control_pool_entry_identity": id(entry),
+                "control_kmean_tensor_identity": id(entry[0]),
+                "control_vscale_tensor_identity": id(entry[1]),
+                "control_supplied_calibration": _calibration_state(old),
+                "alternative_supplied_calibration": (
+                    None if replacement is None else _calibration_state(replacement)
+                ),
+                "next_calibration": _calibration_state(fresh),
+                "pool_restored": isolation.pool_restored,
+                "rng_restored": isolation.rng_restored,
+                "diagnostic_transformer_nfe_delta": (
+                    self.runtime.stats.actual_transformer_calls - actual_nfe_before
+                ),
+                "diagnostic_forecast_counter_delta": (
+                    self.runtime.stats.forecast_model_calls - forecast_calls_before
+                ),
+                "kmean_change": delta(old[0], fresh[0]),
+                "vscale_change": delta(old[1], fresh[1]),
+                "vscale_range_growth_max": growth.max().item(),
+                "alternative_scale_headroom_exceeded_channels": headroom_count,
+                "alternative_scale_channels": (
+                    None if stale_growth is None else stale_growth.numel()
+                ),
+                "alternative_scale_growth_max": (
+                    None if stale_growth is None else stale_growth.max().item()
+                ),
+            })
+            return actual
+        return measured
+
+    def capture_hidden(self, target, audio_rows):
+        self.rows = audio_rows
+        # Retain only a cold anchor, or the candidate target used for comparison.
+        if self.candidate or "h3_chunked_sparse_cold" in self.routes:
+            self.hidden = target.detach().to(device="cpu", copy=True)
+
+    def complete(self, accepted):
+        p = self.probe
+        p.calls += 1
+        successor_state = _capture_cold_successor(self.audit, self.routes) if accepted else {}
+        p.write("actual", step=self.step_id, call=self.call_id, accepted=bool(accepted),
+                receipts_expected=self.audit.block_count,
+                seq_len=self.audit.seq_len, flow_mixed=bool(getattr(self.audit, "flow_mixed", False)),
+                identity=_identity_digest(self.identity), candidate=self.candidate,
+                predecessor_pool_continuity=self.predecessor_pool_continuity,
+                predecessor_pool_mismatch_block=self.predecessor_pool_mismatch_block,
+                predecessor_pool_mismatch_reason=self.predecessor_pool_mismatch_reason,
+                captured_cold_successor_blocks=len(successor_state),
+                next_actual=self.next_actual, core_bsa_source_blob=self.audit.source_blob,
+                patch_generation=self.audit.patch_generation,
+                routes=list(self.routes), measurements=self.measurements)
+        if not accepted:
+            raise RuntimeError("BSA diagnostic actual audit rejected; report is incomplete")
+        if self.candidate:
+            if p.anchor is None or self.hidden is None or p.anchor.shape != self.hidden.shape:
+                raise RuntimeError("BSA diagnostic missing compatible hidden anchor")
+            run = self.runtime._run
+            hold = p.anchor
+            # Exactly the values produced by predict_one_point_hold. Do not call
+            # runtime.predict: it consumes production history rows and counters.
+            p.write("forecast_vs_actual", step=self.step_id,
+                    forecast="one_point_hold_candidate_not_executed",
+                    scope="complete_target_hidden_audio_and_video",
+                    audio=delta(self.hidden[:, :self.rows], hold[:, :self.rows]),
+                    video=delta(self.hidden[:, self.rows:], hold[:, self.rows:]),
+                    previous_to_current_actual=delta(hold, self.hidden),
+                    prior_committed_forecasts=self.runtime.stats.forecast_model_calls,
+                    bootstrap_config=bool(self.runtime.config.bootstrap_first_forecast),
+                    degree=self.runtime.config.degree,
+                    continuum_prefix=run.min_actual_prefix_steps,
+                    state_conditioned_residual=bool(run.state_conditioned_residual),
+                    policy_step=self.runtime._step.policy_step_id,
+                    candidate_backend_transition="h3_chunked_sparse_cold->h3_chunked_sparse_primed",
+                    predecessor_pool_continuity=True,
+                    diagnostic_transformer_nfe=0)
+            p.pending = {"identity": self.identity, "step": self.step_id, "stale": self.stale}
+            p.examined = True
+            p.anchor = None
+        elif self.next_actual:
+            p.pending = None
+        elif p.pending is not None:
+            p.write("skipped", reason="next actual was not the adjacent compatible call")
+            p.pending = None
+        if "h3_chunked_sparse_cold" in self.routes and not p.examined:
+            p.anchor = self.hidden
+        p.previous = (self.step_id, self.identity, self.routes, successor_state)
+
+
+@contextmanager
+def actual_scope(runtime, run_id, step_id, call_id, options):
+    from .core_bsa_compat import PRIVATE_AUDIT_KEY
+    audit = options.get(PRIVATE_AUDIT_KEY)
+    probe = get_probe(runtime, run_id, automatic=bool(audit is not None and audit.safe))
+    if probe is None:
+        yield None
+        return
+    if audit is None or not audit.safe:
+        probe.write("skipped", step=step_id, reason="audited safe core BSA required")
+        probe.anchor = probe.previous = probe.pending = None
+        yield None
+        return
+    if (runtime.active_state_conditioned_residual or runtime.offline_phase is not None
+            or runtime._run.separate_stage_histories or call_id != 0):
+        raise RuntimeError("BSA diagnostics require single-pass absolute-hidden single-call stages")
+    if not _LOCK.acquire(blocking=False):
+        raise RuntimeError("concurrent BSA diagnostic calls are unsupported")
+    token = None
+    try:
+        current = Actual(probe, runtime, step_id, call_id, audit)
+        token = _ACTIVE.set(current)
+        yield current
+    except BaseException as exc:
+        probe.errors += 1
+        probe.write("error", step=step_id, type=type(exc).__name__, message=str(exc))
+        raise
+    finally:
+        if token is not None:
+            _ACTIVE.reset(token)
+        _LOCK.release()
+
+
+def attention(function, audit, index):
+    current = _ACTIVE.get()
+    if current is None or current.audit is not audit:
+        return function
+    return current.wrap_attention(function, index)
+
+
+def hidden(target, audio_rows):
+    current = _ACTIVE.get()
+    if current is not None:
+        current.capture_hidden(target, audio_rows)

--- a/comfyui_spectrum_h3/bsa_transition_probe_compat.py
+++ b/comfyui_spectrum_h3/bsa_transition_probe_compat.py
@@ -1,0 +1,293 @@
+"""Compatibility and lifecycle helpers for the BSA transition diagnostic.
+
+The diagnostic accepts source-built/current comfy-kitchen as long as the public
+``sol_attn_chunked`` calibration contract is present.  It also groups all Spectrum
+runtime segments executed by one ComfyUI prompt into one JSONL report, because one
+video generation can legitimately contain several low/high sampler invocations.
+"""
+from __future__ import annotations
+
+import atexit
+import hashlib
+import importlib
+import importlib.metadata
+import inspect
+import json
+from pathlib import Path
+import threading
+import uuid
+
+
+_SINK_LOCK = threading.Lock()
+_SINKS = {}
+
+
+def _source_provenance():
+    """Return installed comfy-kitchen provenance after checking the API contract."""
+    version = importlib.metadata.version("comfy-kitchen")
+    cuda = importlib.import_module("comfy_kitchen.backends.cuda")
+    function = getattr(cuda, "sol_attn_chunked", None)
+    if not callable(function):
+        raise TypeError(
+            "BSA diagnostics require a comfy-kitchen CUDA backend exposing sol_attn_chunked"
+        )
+
+    try:
+        parameters = inspect.signature(function).parameters
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "BSA diagnostics could not inspect comfy-kitchen sol_attn_chunked"
+        ) from exc
+    missing = sorted({"kmean", "vscale"} - set(parameters))
+    if missing:
+        raise RuntimeError(
+            "BSA diagnostics require sol_attn_chunked calibration parameters: "
+            + ", ".join(missing)
+        )
+
+    source_path = getattr(cuda, "__file__", None)
+    source = b""
+    if source_path:
+        try:
+            source = Path(source_path).read_bytes()
+        except OSError:
+            pass
+    blob = (
+        hashlib.sha1(b"blob " + str(len(source)).encode() + b"\0" + source).hexdigest()
+        if source
+        else None
+    )
+    return version, blob, str(inspect.signature(function))
+
+
+def _execution_generation_id():
+    """Use ComfyUI's prompt id as the generation boundary when available."""
+    try:
+        from comfy_execution.utils import get_executing_context
+
+        context = get_executing_context()
+    except (ImportError, AttributeError, RuntimeError):
+        return None
+    prompt_id = getattr(context, "prompt_id", None)
+    return None if prompt_id is None else str(prompt_id)
+
+
+def _generation_digest(generation_id):
+    return hashlib.sha256(generation_id.encode()).hexdigest()[:12]
+
+
+class _GenerationSink:
+    def __init__(self, directory, generation_id, *, persistent, session):
+        directory = Path(directory).expanduser()
+        directory.mkdir(parents=True, exist_ok=True)
+        self.generation_id = generation_id
+        self.generation = _generation_digest(generation_id)
+        self.persistent = persistent
+        self.path = directory / f"bsa-{session}-generation-{self.generation}.jsonl"
+        self.file = self.path.open("x", encoding="utf-8")
+        self.lock = threading.Lock()
+        self.active = 0
+        self.closed = False
+
+    def write(self, payload):
+        with self.lock:
+            if self.closed:
+                raise RuntimeError("BSA diagnostic generation report is already closed")
+            self.file.write(json.dumps(payload, allow_nan=False) + "\n")
+            self.file.flush()
+
+    def close(self):
+        with self.lock:
+            if not self.closed:
+                self.file.close()
+                self.closed = True
+
+
+def _acquire_sink(directory, generation_id, *, session):
+    persistent = generation_id is not None
+    if generation_id is None:
+        generation_id = f"standalone-{uuid.uuid4().hex}"
+    key = (str(Path(directory).expanduser().resolve()), generation_id, session)
+    with _SINK_LOCK:
+        for old_key, old in list(_SINKS.items()):
+            if old_key != key and old.active == 0:
+                old.close()
+                del _SINKS[old_key]
+        sink = _SINKS.get(key)
+        created = sink is None or sink.closed
+        if created:
+            sink = _GenerationSink(
+                directory,
+                generation_id,
+                persistent=persistent,
+                session=session,
+            )
+            _SINKS[key] = sink
+        sink.active += 1
+    return key, sink, created
+
+
+def _release_sink(key, sink):
+    with _SINK_LOCK:
+        sink.active = max(0, sink.active - 1)
+        if sink.active == 0 and not sink.persistent:
+            sink.close()
+            _SINKS.pop(key, None)
+
+
+def _close_sinks():
+    with _SINK_LOCK:
+        for sink in _SINKS.values():
+            sink.close()
+        _SINKS.clear()
+
+
+atexit.register(_close_sinks)
+
+
+def install_bsa_transition_probe_compat():
+    """Install source-build compatibility and generation-scoped report aggregation."""
+    from . import bsa_transition_probe as probe
+
+    if getattr(probe.get_probe, "_spectrum_compatible_kitchen", False):
+        return
+
+    base_probe = probe.Probe
+    base_actual = probe.Actual
+
+    class GenerationProbe(base_probe):
+        """One run segment writing into a prompt-scoped generation report."""
+
+        def __init__(self, directory, run_id, config):
+            generation_id = _execution_generation_id()
+            self._sink_key, self._sink, created = _acquire_sink(
+                directory,
+                generation_id,
+                session=probe._SESSION,
+            )
+            self.path = self._sink.path
+            self.file = self._sink.file
+            self.generation = self._sink.generation
+            self.run_instance = uuid.uuid4().hex[:8]
+            self.run_id = run_id
+            self.config = config
+            self.previous = None
+            self.anchor = None
+            self.pending = None
+            self.examined = False
+            self.extra_attention_calls = 0
+            self.started_attention_calls = 0
+            self.errors = 0
+            self.calls = 0
+            self._closed = False
+            self.write(
+                "start",
+                schema_version=4,
+                torch_version=probe.torch.__version__,
+                scope="matched-input sparse attention; full target-hidden one-point hold",
+                diagnostic_transformer_nfe=0,
+                max_attention_calls_per_run=6,
+                production_policy="unchanged",
+                source_revision=probe._revision(),
+                report_scope="one_jsonl_per_comfyui_prompt_generation",
+            )
+            if created:
+                probe.LOG.warning("Spectrum H3 BSA diagnostic report: %s", self.path)
+
+        def write(self, event, **data):
+            self._sink.write({
+                "event": event,
+                "generation": self.generation,
+                "run_instance": self.run_instance,
+                "run_id": self.run_id,
+                **data,
+            })
+
+        def close(self):
+            if self._closed:
+                return
+            self.write(
+                "end",
+                tracked_actual_calls=self.calls,
+                diagnostic_attention_calls_started=self.started_attention_calls,
+                diagnostic_attention_calls_completed=self.extra_attention_calls,
+                diagnostic_transformer_nfe=0,
+                errors=self.errors,
+                pending_next_actual=self.pending is not None,
+            )
+            self.anchor = self.pending = self.previous = None
+            self._closed = True
+            _release_sink(self._sink_key, self._sink)
+
+    class GenerationActual(base_actual):
+        """Permit candidate-C measurement across a settings-only identity change.
+
+        The shadow still executes the current actual step's own attention closure.
+        The only substituted state is the stale calibration from the immediately
+        preceding candidate, and exact tensor ownership is proved before enabling
+        the measurement.  Sequence/pool discontinuities therefore remain rejected.
+        """
+
+        def __init__(self, diagnostic, runtime, step_id, call_id, audit):
+            super().__init__(diagnostic, runtime, step_id, call_id, audit)
+            self.next_actual_identity_changed = False
+            pending = diagnostic.pending
+            if self.next_actual or pending is None or step_id != pending["step"] + 1:
+                return
+            if not self.selected or any(
+                self.routes[index] != "h3_chunked_sparse_primed" for index in self.selected
+            ):
+                return
+            for index in self.selected:
+                stored = pending["stale"].get(index)
+                key = (index, audit.seq_len, audit.uuids)
+                entry = probe._pool_entry(audit.patch, key)
+                if (
+                    stored is None
+                    or entry is None
+                    or any(owner is not current for owner, current in zip(stored[0], entry))
+                ):
+                    return
+            self.next_actual = True
+            self.next_actual_identity_changed = pending["identity"] != self.identity
+
+        def complete(self, accepted):
+            if self.next_actual:
+                self.probe.write(
+                    "next_actual_scope",
+                    step=self.step_id,
+                    semantic_identity_changed=self.next_actual_identity_changed,
+                    safety_basis=(
+                        "adjacent call + same calibration tensor owners + current-step attention closure"
+                    ),
+                )
+            return super().complete(accepted)
+
+    probe.Probe = GenerationProbe
+    probe.Actual = GenerationActual
+
+    def get_probe(runtime, run_id, *, automatic=False):
+        directory = probe._diagnostic_directory(automatic=automatic)
+        if directory is None:
+            return None
+        run = runtime._run
+        item = getattr(runtime, "_bsa_transition_probe", None)
+        if item is not None and item[0] is not run:
+            item[1].close()
+            item = None
+        if item is None:
+            version, blob, signature = _source_provenance()
+            current = probe.Probe(directory, run_id, runtime.config)
+            current.write(
+                "source",
+                comfy_kitchen=version,
+                cuda_wrapper_git_blob=blob,
+                sol_attn_chunked_signature=signature,
+                compatibility_basis="runtime_api_contract_not_exact_build_pin",
+            )
+            runtime._bsa_transition_probe = (run, current)
+            return current
+        return item[1]
+
+    get_probe._spectrum_compatible_kitchen = True
+    probe.get_probe = get_probe

--- a/comfyui_spectrum_h3/bsa_transition_probe_manual.py
+++ b/comfyui_spectrum_h3/bsa_transition_probe_manual.py
@@ -1,0 +1,23 @@
+"""Disable automatic BSA shadow probes after CUDA evidence collection.
+
+The transition probe remains available through SPECTRUM_H3_BSA_DIAGNOSTICS, but
+production-candidate runs must not silently pay its sparse-attention shadow-call
+overhead.  This installer preserves the existing explicit environment override
+and only suppresses the audited-safe-CUDA automatic default.
+"""
+from functools import wraps
+
+
+def install_bsa_transition_probe_manual_only() -> None:
+    from . import bsa_transition_probe as probe
+
+    current = probe._diagnostic_directory
+    if getattr(current, "_spectrum_manual_only", False):
+        return
+
+    @wraps(current)
+    def manual_only(*, automatic):
+        return current(automatic=False)
+
+    manual_only._spectrum_manual_only = True
+    probe._diagnostic_directory = manual_only

--- a/comfyui_spectrum_h3/core_bsa_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_compat.py
@@ -1,0 +1,949 @@
+"""Fail-closed Spectrum compatibility audit for ComfyUI core BlockSparseAttention.
+
+This adapter deliberately recognizes only reviewed upstream implementations.  It
+does not modify ComfyUI or ask core BSA to publish Spectrum-specific metadata.
+Instead, Spectrum proves ownership/configuration before a model call and wraps
+only the copied MiniMax-H3 block replacements for actual-call verification.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import hashlib
+import importlib
+import itertools
+import math
+from pathlib import Path
+import threading
+import types
+from typing import Any
+import weakref
+
+import torch
+
+ADAPTER_KEY = "spectrum_core_bsa_v1"
+ADAPTER_VERSION = 1
+PRIVATE_AUDIT_KEY = "_spectrum_core_bsa_audit_v1"
+
+# Comfy-Org/ComfyUI comfy_extras/nodes_sparse_attention.py as reviewed at
+# be92396834f9b6e3e361cfe30e7eed693137a448 (unchanged from its parent).
+# Any source change is actual-only until the new implementation is audited.
+AUDITED_BSA_GIT_BLOBS = frozenset(
+    {"006d1eb352f946a7c85595edf75d3cda9ac79194"}
+)
+
+_MISSING = object()
+_IDENTITY_LOCK = threading.RLock()
+_IDENTITY_COUNTER = itertools.count(1)
+_IDENTITY_REGISTRY: dict[int, tuple[weakref.ReferenceType[Any] | None, int, Any | None]] = {}
+
+
+def _release_lifetime_generation(
+    object_id: int,
+    generation: int,
+    reference: weakref.ReferenceType[Any],
+) -> None:
+    with _IDENTITY_LOCK:
+        current = _IDENTITY_REGISTRY.get(object_id)
+        if current is not None and current[0] is reference and current[1] == generation:
+            _IDENTITY_REGISTRY.pop(object_id, None)
+
+
+def _lifetime_generation(value: Any) -> int:
+    """Return a process-lifetime generation immune to CPython address reuse."""
+    if value is None:
+        return 0
+    object_id = id(value)
+    with _IDENTITY_LOCK:
+        current = _IDENTITY_REGISTRY.get(object_id)
+        if current is not None:
+            reference, generation, strong = current
+            owner = strong if reference is None else reference()
+            if owner is value:
+                return generation
+            if owner is None:
+                _IDENTITY_REGISTRY.pop(object_id, None)
+
+        generation = next(_IDENTITY_COUNTER)
+
+        def cleanup(reference, *, object_id=object_id, generation=generation):
+            _release_lifetime_generation(object_id, generation, reference)
+
+        try:
+            reference = weakref.ref(value, cleanup)
+        except TypeError:
+            # Rare non-weakrefable callable owners are kept alive rather than
+            # allowing their address to be recycled into backend history.
+            _IDENTITY_REGISTRY[object_id] = (None, generation, value)
+        else:
+            _IDENTITY_REGISTRY[object_id] = (reference, generation, None)
+        return generation
+
+
+@dataclass
+class CoreBSAAudit:
+    identity: tuple[Any, ...]
+    safe: bool
+    patch: Any
+    patch_generation: int
+    block_count: int
+    seq_len: int
+    uuids: tuple[Any, ...]
+    layout_identity: tuple[Any, ...]
+    settings_identity: tuple[Any, ...]
+    route_specs: tuple[tuple[str, tuple[int, int], tuple[int, int]], ...]
+    pool_specs: tuple[tuple[int, int, str | None], ...]
+    expected_receipts: tuple[tuple[Any, ...], ...]
+    source_blob: str
+    current_override: Any
+    failure: str | None = None
+
+
+def has_core_bsa_callback(options: dict[str, Any]) -> bool:
+    callbacks = options.get("callbacks", {})
+    if not isinstance(callbacks, dict):
+        return False
+    try:
+        return any("block_sparse_attention" in group for group in callbacks.values())
+    except Exception:  # noqa: BLE001 - malformed metadata is not trusted
+        return False
+
+
+def _looks_like_core_bsa_callable(function: Any, owner: str, local_name: str) -> bool:
+    base = getattr(function, "__func__", function)
+    return (
+        getattr(base, "__module__", None) == "comfy_extras.nodes_sparse_attention"
+        and getattr(base, "__qualname__", None) == f"{owner}.<locals>.{local_name}"
+    )
+
+
+def has_core_bsa_evidence(options: dict[str, Any]) -> bool:
+    """Detect current core BSA even if another node dropped its callback metadata."""
+    if has_core_bsa_callback(options):
+        return True
+    if _looks_like_core_bsa_callable(
+        options.get("optimized_attention_override"), "make_attention_override", "override"
+    ):
+        return True
+    patches_replace = options.get("patches_replace", {})
+    if not isinstance(patches_replace, dict):
+        return False
+    dit = patches_replace.get("dit", {})
+    if not isinstance(dit, dict):
+        return False
+    return any(
+        _looks_like_core_bsa_callable(replacement, "make_h3_block_patch", "block_patch")
+        for replacement in dit.values()
+    )
+
+
+@lru_cache(maxsize=8)
+def _hash_git_blob(path: str, mtime_ns: int, size: int) -> str | None:
+    try:
+        data = Path(path).read_bytes()
+    except OSError:
+        return None
+    if len(data) != size:
+        return None
+    payload = f"blob {len(data)}\0".encode() + data
+    return hashlib.sha1(payload, usedforsecurity=False).hexdigest()
+
+
+def _module_blob_sha(module: Any) -> str | None:
+    source = getattr(module, "__file__", None)
+    if not isinstance(source, str):
+        return None
+    path = Path(source)
+    if path.suffix != ".py":
+        return None
+    try:
+        stat = path.stat()
+        resolved = str(path.resolve())
+    except OSError:
+        return None
+    return _hash_git_blob(resolved, int(stat.st_mtime_ns), int(stat.st_size))
+
+
+def _load_audited_module() -> tuple[Any | None, str | None]:
+    try:
+        module = importlib.import_module("comfy_extras.nodes_sparse_attention")
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - unavailable/old ComfyUI stays actual-only
+        return None, "module_unavailable"
+    blob = _module_blob_sha(module)
+    if blob not in AUDITED_BSA_GIT_BLOBS:
+        return None, "source_unreviewed"
+    required = (
+        "SparseAttnPatch",
+        "make_attention_override",
+        "make_h3_block_patch",
+        "HEAD_DIM",
+        "BLOCK_SIZE",
+        "PRODUCER_CHUNK",
+        "ck",
+    )
+    if any(not hasattr(module, name) for name in required):
+        return None, "source_shape_changed"
+    if (
+        int(module.HEAD_DIM) != 128
+        or int(module.BLOCK_SIZE) != 64
+        or int(module.PRODUCER_CHUNK) != 4096
+    ):
+        return None, "source_constants_changed"
+    return module, blob
+
+
+def _nested_code(function: Any, name: str) -> types.CodeType | None:
+    code = getattr(function, "__code__", None)
+    if not isinstance(code, types.CodeType):
+        return None
+    pending = [code]
+    while pending:
+        parent = pending.pop()
+        for value in parent.co_consts:
+            if isinstance(value, types.CodeType):
+                if value.co_name == name:
+                    return value
+                pending.append(value)
+    return None
+
+
+def _closure_values(function: Any) -> dict[str, Any] | None:
+    code = getattr(function, "__code__", None)
+    closure = getattr(function, "__closure__", None)
+    if not isinstance(code, types.CodeType):
+        return None
+    if not code.co_freevars:
+        return {}
+    if closure is None or len(closure) != len(code.co_freevars):
+        return None
+    values: dict[str, Any] = {}
+    try:
+        for name, cell in zip(code.co_freevars, closure):
+            values[name] = cell.cell_contents
+    except ValueError:
+        return None
+    return values
+
+
+def _callable_identity(function: Any) -> tuple[Any, ...]:
+    if function is None:
+        return ("comfy.default",)
+    base = getattr(function, "__func__", function)
+    return (
+        str(getattr(base, "__module__", type(base).__module__)),
+        str(getattr(base, "__qualname__", type(base).__qualname__)),
+        _lifetime_generation(base),
+    )
+
+
+def _attention_owner_identity(provider: Any) -> tuple[Any, ...]:
+    transforms = []
+    seen = set()
+    current = provider
+    while current is not None and hasattr(current, "attention_preprocess_v1"):
+        if id(current) in seen:
+            return ("cyclic_preprocess", _lifetime_generation(current))
+        seen.add(id(current))
+        contract = current.attention_preprocess_v1
+        if not isinstance(contract, tuple) or len(contract) != 2:
+            return ("invalid_preprocess", _callable_identity(current))
+        transform, current = contract
+        transforms.append(_callable_identity(transform))
+    return (tuple(transforms), _callable_identity(current))
+
+
+def _freeze(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return tuple(sorted((str(key), _freeze(item)) for key, item in value.items()))
+    if isinstance(value, (tuple, list)):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted((_freeze(item) for item in value), key=repr))
+    return repr(value)
+
+
+def _normalize_layout(layout: Any) -> tuple[int, tuple[Any, ...]] | None:
+    seq_len = getattr(layout, "seq_len", None)
+    signature = getattr(layout, "signature", None)
+    segments = getattr(layout, "segments", None)
+    if type(seq_len) is not int or seq_len <= 0 or not isinstance(segments, (tuple, list)):
+        return None
+    normalized = []
+    cursor = 0
+    try:
+        for start, stop, kind in segments:
+            a, b = int(start), int(stop)
+            if a != cursor or b <= a or b > seq_len:
+                return None
+            normalized.append((a, b, str(kind)))
+            cursor = b
+    except (TypeError, ValueError):
+        return None
+    if cursor != seq_len:
+        return None
+    return seq_len, (
+        ("signature", _freeze(signature)),
+        ("segments", tuple(normalized)),
+    )
+
+
+def _normalize_uuids(options: dict[str, Any]) -> tuple[Any, ...] | None:
+    try:
+        uuids = tuple(options.get("uuids", ()))
+        hash(uuids)
+    except (TypeError, ValueError):
+        return None
+    return uuids
+
+
+def _sigma_value(options: dict[str, Any]) -> float | None:
+    sigmas = options.get("sigmas")
+    if sigmas is None:
+        return None
+    try:
+        if len(sigmas) == 0:
+            return None
+        value = float(sigmas[0])
+        return value if math.isfinite(value) else None
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except (TypeError, ValueError, RuntimeError):
+        return None
+
+
+def _settings_identity(patch: Any) -> tuple[Any, ...] | None:
+    try:
+        dense_blocks = tuple(sorted(int(index) for index in patch.dense_blocks))
+        tau = float(patch.tau)
+        topk_ratio = float(patch.topk_ratio)
+        sigma_start = float(patch.sigma_start)
+        sigma_end = float(patch.sigma_end)
+        if not all(math.isfinite(value) for value in (tau, topk_ratio, sigma_start, sigma_end)):
+            return None
+        settings = (
+            bool(patch.vsa),
+            tau,
+            topk_ratio,
+            int(patch.extra_tokens),
+            sigma_start,
+            sigma_end,
+            int(patch.min_tokens),
+            dense_blocks,
+            str(patch.sink_conditioning),
+        )
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return settings
+
+
+def _runtime_execution_identity(model: Any) -> tuple[Any, ...] | None:
+    blocks = getattr(model, "blocks", None)
+    if not isinstance(blocks, (tuple, list, torch.nn.ModuleList)) or not blocks:
+        return None
+    forwards = []
+    qkv = []
+    try:
+        for block in blocks:
+            attn = block.attn
+            projection = attn.qkv_proj
+            weight = projection.weight
+            forwards.append(_callable_identity(attn.forward))
+            qkv.append(
+                (
+                    int(attn.head_dim),
+                    str(weight.dtype),
+                    type(projection).__module__,
+                    type(projection).__qualname__,
+                    type(weight).__module__,
+                    type(weight).__qualname__,
+                )
+            )
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return (
+        ("model_dtype", str(getattr(model, "dtype", None))),
+        ("attention_forwards", tuple(forwards)),
+        ("qkv_execution", tuple(qkv)),
+    )
+
+
+def _candidate_cuda_device(blocks: Any) -> torch.device | None:
+    try:
+        cuda_devices = {
+            torch.device(block.attn.qkv_proj.weight.device)
+            for block in blocks
+            if torch.device(block.attn.qkv_proj.weight.device).type == "cuda"
+        }
+    except (AttributeError, TypeError, ValueError, RuntimeError):
+        return None
+    if len(cuda_devices) == 1:
+        return next(iter(cuda_devices))
+    if len(cuda_devices) > 1:
+        return None
+    try:
+        if not torch.cuda.is_available():
+            return None
+        return torch.device("cuda", torch.cuda.current_device())
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except (RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _sparse_runtime_eligible(model: Any, module: Any) -> bool:
+    blocks = getattr(model, "blocks", ())
+    if not blocks:
+        return False
+    compute_dtype = getattr(model, "dtype", None)
+    try:
+        weight_dtypes = {block.attn.qkv_proj.weight.dtype for block in blocks}
+        head_dims = {int(block.attn.head_dim) for block in blocks}
+    except (AttributeError, TypeError, ValueError):
+        return False
+    if compute_dtype is None and len(weight_dtypes) == 1:
+        compute_dtype = next(iter(weight_dtypes))
+    if compute_dtype is not torch.bfloat16:
+        return False
+    if head_dims != {int(module.HEAD_DIM)}:
+        return False
+    device = _candidate_cuda_device(blocks)
+    if device is None:
+        return False
+    try:
+        return bool(module.ck.sol_attn_is_available(device))
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - kernel introspection fails closed
+        return False
+
+
+def _conditioning_sinks(
+    patch: Any, layout_identity: tuple[Any, ...], seq_len: int
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    segments = dict()
+    try:
+        segment_rows = dict(layout_identity)["segments"]
+        for start, stop, kind in segment_rows:
+            segments.setdefault(kind, (int(start), int(stop)))
+        mode = str(patch.sink_conditioning)
+    except (TypeError, ValueError, AttributeError):
+        return None
+    if mode == "off":
+        return (0, 0), (0, 0)
+    if mode not in {"exact_kv", "exact_kv_and_rows"}:
+        return None
+    video = segments.get("video")
+    if video is None or video[0] <= 0:
+        return (0, 0), (0, 0)
+    block_size = 64
+    sink = (0, (video[0] + block_size - 1) // block_size)
+    if mode != "exact_kv_and_rows":
+        return sink, (0, 0)
+    audio = segments.get("audio")
+    if audio is None:
+        return sink, sink
+    sink_q = (audio[0] // block_size, sink[1])
+    if not (0 <= sink_q[0] <= sink_q[1] <= (seq_len + block_size - 1) // block_size):
+        return None
+    return sink, sink_q
+
+
+def _replacement_ownership(
+    module: Any, model: Any, options: dict[str, Any]
+) -> tuple[Any, tuple[Any, ...]] | None:
+    block_patch_code = _nested_code(module.make_h3_block_patch, "block_patch")
+    attention_code = _nested_code(module.make_h3_block_patch, "attention")
+    override_code = _nested_code(module.make_attention_override, "override")
+    if block_patch_code is None or attention_code is None or override_code is None:
+        return None
+
+    blocks = getattr(model, "blocks", None)
+    if blocks is None:
+        return None
+    replacements = options.get("patches_replace", {})
+    if not isinstance(replacements, dict):
+        return None
+    dit = replacements.get("dit", {})
+    if not isinstance(dit, dict):
+        return None
+
+    patch = None
+    replacement_ids = []
+    for index, block in enumerate(blocks):
+        replacement = dit.get(("double_block", index))
+        if getattr(replacement, "__code__", None) is not block_patch_code:
+            return None
+        closure = _closure_values(replacement)
+        if closure is None:
+            return None
+        owner = closure.get("patch")
+        if type(owner) is not module.SparseAttnPatch:
+            return None
+        if patch is None:
+            patch = owner
+        elif owner is not patch:
+            return None
+        if closure.get("block") is not block or closure.get("block_index") != index:
+            return None
+        attention = closure.get("attention")
+        if getattr(attention, "__code__", None) is not attention_code:
+            return None
+        attention_closure = _closure_values(attention)
+        if (
+            attention_closure is None
+            or attention_closure.get("patch") is not patch
+            or attention_closure.get("block") is not block
+            or attention_closure.get("block_index") != index
+        ):
+            return None
+        replacement_ids.append(_callable_identity(replacement))
+
+    if patch is None:
+        return None
+    current = options.get("optimized_attention_override")
+    if getattr(current, "__code__", None) is not override_code:
+        return None
+    closure = _closure_values(current)
+    if closure is None or closure.get("patch") is not patch:
+        return None
+    installed = getattr(patch, "installed", None)
+    if not isinstance(installed, set) or current not in installed:
+        return None
+    previous = closure.get("previous")
+    if getattr(previous, "__code__", None) is override_code:
+        return None
+    previous_closure = _closure_values(previous) if previous is not None else None
+    if previous_closure is not None and type(previous_closure.get("patch")) is module.SparseAttnPatch:
+        return None
+
+    return patch, (
+        ("inherited_attention", _attention_owner_identity(previous)),
+        ("h3_replacements", tuple(replacement_ids)),
+        ("bsa_override", _callable_identity(current)),
+    )
+
+
+def _pool_entry(
+    patch: Any,
+    key: tuple[Any, ...],
+    expected: tuple[int, int, str | None] | None = None,
+) -> tuple[Any, ...]:
+    pooled = getattr(patch, "pooled", None)
+    if not isinstance(pooled, dict):
+        return ("invalid",)
+    entry = pooled.get(key, _MISSING)
+    if entry is _MISSING:
+        return ("missing",)
+    if (
+        not isinstance(entry, (tuple, list))
+        or len(entry) != 2
+        or not all(torch.is_tensor(value) for value in entry)
+    ):
+        return ("invalid",)
+    if expected is not None:
+        heads, head_dim, device = expected
+        required_shape = (heads, head_dim)
+        if any(
+            tuple(value.shape) != required_shape
+            or value.dtype is not torch.float32
+            or (device is not None and str(value.device) != device)
+            for value in entry
+        ):
+            return ("invalid",)
+    return ("present", entry[0], entry[1])
+
+
+def _pool_ownership_identity(
+    patch: Any,
+    block_count: int,
+    seq_len: int,
+    uuids: tuple[Any, ...],
+    pool_specs: tuple[tuple[int, int, str | None], ...],
+) -> tuple[Any, ...]:
+    ownership = []
+    for index in range(block_count):
+        state = _pool_entry(patch, (index, seq_len, uuids), pool_specs[index])
+        if state[0] == "present":
+            ownership.append(
+                (
+                    index,
+                    _lifetime_generation(state[1]),
+                    _lifetime_generation(state[2]),
+                    str(state[1].device),
+                    str(state[2].device),
+                )
+            )
+        else:
+            ownership.append((index, state[0]))
+    return tuple(ownership)
+
+
+def _classify_pool_transition(
+    before: tuple[Any, ...],
+    after: tuple[Any, ...],
+    *,
+    sparse_selected: bool,
+) -> str:
+    if before[0] == "missing":
+        if sparse_selected and after[0] == "present":
+            return "h3_chunked_sparse_cold"
+        if not sparse_selected and after[0] == "missing":
+            return "h3_dense"
+        return "unknown"
+    if before[0] != "present" or after[0] != "present":
+        return "unknown"
+    if before[1] is not after[1] or before[2] is not after[2]:
+        return "unknown"
+    return "h3_chunked_sparse_primed" if sparse_selected else "h3_dense"
+
+
+def _route_specs(
+    patch: Any,
+    block_count: int,
+    seq_len: int,
+    uuids: tuple[Any, ...],
+    layout_identity: tuple[Any, ...],
+    options: dict[str, Any],
+    sparse_runtime_ok: bool,
+    pool_specs: tuple[tuple[int, int, str | None], ...],
+) -> tuple[tuple[tuple[str, tuple[int, int], tuple[int, int]], ...], bool] | None:
+    sigma = _sigma_value(options)
+    if sigma is None:
+        return None
+    settings = _settings_identity(patch)
+    if settings is None:
+        return None
+    vsa, _tau, _topk, _extra, sigma_start, sigma_end, min_tokens, dense_blocks, _sink_mode = settings
+    if vsa:
+        return None
+
+    inside_window = sigma_end <= sigma <= sigma_start
+    sinks = _conditioning_sinks(patch, layout_identity, seq_len)
+    if sinks is None:
+        return None
+    sink, sink_q = sinks
+    dense_set = set(dense_blocks)
+    specs = []
+    safe = True
+    for index in range(block_count):
+        if not inside_window or seq_len < min_tokens or index in dense_set:
+            specs.append(("h3_dense", (0, 0), (0, 0)))
+            continue
+        if not sparse_runtime_ok:
+            safe = False
+            specs.append(("h3_sparse_unproven", sink, sink_q))
+            continue
+        state = _pool_entry(patch, (index, seq_len, uuids), pool_specs[index])
+        if state[0] == "missing":
+            route = "h3_chunked_sparse_cold"
+        elif state[0] == "present":
+            route = "h3_chunked_sparse_primed"
+        else:
+            safe = False
+            route = "h3_sparse_unproven"
+        specs.append((route, sink, sink_q))
+    return tuple(specs), safe
+
+
+def probe(
+    options: dict[str, Any], layout: Any, model: Any
+) -> tuple[CoreBSAAudit | None, str | None]:
+    """Recognize current core BSA and derive the next-call numerical identity."""
+    try:
+        module, source_blob = _load_audited_module()
+        if module is None or source_blob is None:
+            return None, source_blob or "module_unavailable"
+
+        ownership = _replacement_ownership(module, model, options)
+        if ownership is None:
+            return None, "ownership_unproven"
+        patch, ownership_identity = ownership
+        patch_generation = _lifetime_generation(patch)
+
+        normalized_layout = _normalize_layout(layout)
+        if normalized_layout is None:
+            return None, "layout_unproven"
+        seq_len, layout_identity = normalized_layout
+        uuids = _normalize_uuids(options)
+        if uuids is None:
+            return None, "uuids_unproven"
+        settings_identity = _settings_identity(patch)
+        execution_identity = _runtime_execution_identity(model)
+        if settings_identity is None or execution_identity is None:
+            return None, "execution_shape_unproven"
+        if settings_identity[0]:
+            return None, "vsa_unsupported"
+
+        try:
+            pool_specs = tuple(
+                (
+                    int(block.attn.heads),
+                    int(block.attn.head_dim),
+                    (
+                        str(block.attn.qkv_proj.weight.device)
+                        if torch.device(block.attn.qkv_proj.weight.device).type == "cuda"
+                        else None
+                    ),
+                )
+                for block in model.blocks
+            )
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            return None, "pool_shape_unproven"
+
+        sparse_runtime_ok = _sparse_runtime_eligible(model, module)
+        routed = _route_specs(
+            patch,
+            len(model.blocks),
+            seq_len,
+            uuids,
+            layout_identity,
+            options,
+            sparse_runtime_ok,
+            pool_specs,
+        )
+        if routed is None:
+            return None, "route_unproven"
+        route_specs, safe = routed
+        pool_ownership = _pool_ownership_identity(
+            patch, len(model.blocks), seq_len, uuids, pool_specs
+        )
+        expected_receipts = tuple(
+            (
+                ADAPTER_KEY,
+                ADAPTER_VERSION,
+                patch_generation,
+                index,
+                route,
+                seq_len,
+                sink,
+                sink_q,
+            )
+            for index, (route, sink, sink_q) in enumerate(route_specs)
+        )
+        mode = "sol-attn" if settings_identity[2] == 0.0 else "sla"
+        identity = (
+            ADAPTER_KEY,
+            ADAPTER_VERSION,
+            source_blob,
+            patch_generation,
+            ("mode", mode),
+            ("settings", settings_identity),
+            ("layout", layout_identity),
+            ("uuids", _freeze(uuids)),
+            ("routes", route_specs),
+            ("pool_ownership", pool_ownership),
+            ("ownership", ownership_identity),
+            ("execution", execution_identity),
+        )
+        return CoreBSAAudit(
+            identity=identity,
+            safe=bool(safe),
+            patch=patch,
+            patch_generation=patch_generation,
+            block_count=len(model.blocks),
+            seq_len=seq_len,
+            uuids=uuids,
+            layout_identity=layout_identity,
+            settings_identity=settings_identity,
+            route_specs=route_specs,
+            pool_specs=pool_specs,
+            expected_receipts=expected_receipts,
+            source_blob=source_blob,
+            current_override=options.get("optimized_attention_override"),
+        ), None
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - all adapter introspection is fail closed
+        return None, "adapter_introspection_failed"
+
+
+def _current_route_matches(
+    audit: CoreBSAAudit,
+    index: int,
+    args: dict[str, Any],
+) -> bool:
+    try:
+        hidden = args["img"]
+        call_options = args["transformer_options"]
+    except (KeyError, TypeError):
+        return False
+    if not torch.is_tensor(hidden) or hidden.ndim < 1 or int(hidden.shape[0]) != audit.seq_len:
+        return False
+
+    metadata_ok = True
+    if _normalize_uuids(call_options) != audit.uuids:
+        metadata_ok = False
+    if _settings_identity(audit.patch) != audit.settings_identity:
+        metadata_ok = False
+    if call_options.get("optimized_attention_override") is not audit.current_override:
+        metadata_ok = False
+    actual_layout = _normalize_layout(call_options.get("minimax_h3_layout"))
+    if (
+        actual_layout is None
+        or actual_layout[1] != audit.layout_identity
+        or actual_layout[0] != audit.seq_len
+    ):
+        metadata_ok = False
+    sigma = _sigma_value(call_options)
+    if sigma is None:
+        metadata_ok = False
+        inside_window = False
+    else:
+        sigma_start = audit.settings_identity[4]
+        sigma_end = audit.settings_identity[5]
+        inside_window = sigma_end <= sigma <= sigma_start
+
+    min_tokens = audit.settings_identity[6]
+    dense_blocks = audit.settings_identity[7]
+    dense = not inside_window or audit.seq_len < min_tokens or index in dense_blocks
+    expected_route = audit.route_specs[index][0]
+    if expected_route != "h3_dense" and (
+        hidden.dtype is not torch.bfloat16 or hidden.device.type != "cuda"
+    ):
+        metadata_ok = False
+    if not metadata_ok:
+        return False
+    if expected_route == "h3_dense":
+        return dense
+    return not dense
+
+
+def _make_actual_wrapper(
+    audit: CoreBSAAudit,
+    index: int,
+    replacement: Any,
+    receipts: list[Any],
+):
+    key = (index, audit.seq_len, audit.uuids)
+    replacement_closure = _closure_values(replacement)
+    expected_attention = (
+        replacement_closure.get("attention")
+        if replacement_closure is not None
+        else None
+    )
+
+    def audited_replacement(args, replacement_context):
+        try:
+            metadata_ok = _current_route_matches(audit, index, args)
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except Exception:  # noqa: BLE001 - observation must not abort the actual block
+            metadata_ok = False
+            audit.failure = "actual_metadata_failed"
+        try:
+            before = _pool_entry(audit.patch, key, audit.pool_specs[index])
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except Exception:  # noqa: BLE001
+            before = ("invalid",)
+            metadata_ok = False
+
+        sparse_selected = False
+        original_block_calls = 0
+        original_block = replacement_context.get("original_block")
+        if expected_attention is None or not callable(original_block):
+            metadata_ok = False
+            output = replacement(args, replacement_context)
+        else:
+            def audited_original_block(call_args):
+                nonlocal sparse_selected, original_block_calls
+                original_block_calls += 1
+                sparse_selected = call_args.get("attention") is expected_attention
+                if sparse_selected:
+                    from .bsa_transition_probe import attention
+                    call_args = {**call_args, "attention": attention(expected_attention, audit, index)}
+                return original_block(call_args)
+
+            observed_context = dict(replacement_context)
+            observed_context["original_block"] = audited_original_block
+            output = replacement(args, observed_context)
+            if original_block_calls != 1:
+                metadata_ok = False
+
+        try:
+            after = _pool_entry(audit.patch, key, audit.pool_specs[index])
+            observed = _classify_pool_transition(
+                before,
+                after,
+                sparse_selected=sparse_selected,
+            )
+            expected_route, expected_sink, expected_sink_q = audit.route_specs[index]
+            if not metadata_ok or observed != expected_route:
+                audit.failure = "actual_route_mismatch"
+            receipt = (
+                ADAPTER_KEY,
+                ADAPTER_VERSION,
+                audit.patch_generation,
+                index,
+                observed,
+                audit.seq_len,
+                expected_sink,
+                expected_sink_q,
+            )
+            receipts.append(receipt)
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except Exception:  # noqa: BLE001 - observation failure must not abort sampling
+            audit.failure = "actual_observation_failed"
+        return output
+
+    return audited_replacement
+
+
+def instrument_actual_options(
+    options: dict[str, Any], audit: CoreBSAAudit, receipts_key: str
+) -> dict[str, Any]:
+    """Wrap copied main-H3 replacements so an actual call proves its route."""
+    prepared = dict(options)
+    receipts = prepared.get(receipts_key)
+    if not isinstance(receipts, list):
+        audit.failure = "receipt_buffer_missing"
+        return prepared
+    patches_replace = prepared.get("patches_replace")
+    if not isinstance(patches_replace, dict):
+        audit.failure = "replacement_table_missing"
+        return prepared
+    dit = patches_replace.get("dit")
+    if not isinstance(dit, dict):
+        audit.failure = "dit_replacement_table_missing"
+        return prepared
+
+    local_patches = dict(patches_replace)
+    local_dit = dict(dit)
+    for index in range(audit.block_count):
+        key = ("double_block", index)
+        replacement = local_dit.get(key)
+        if replacement is None:
+            audit.failure = "main_h3_replacement_missing"
+            return prepared
+        local_dit[key] = _make_actual_wrapper(audit, index, replacement, receipts)
+    local_patches["dit"] = local_dit
+    prepared["patches_replace"] = local_patches
+    prepared[PRIVATE_AUDIT_KEY] = audit
+    return prepared
+
+
+def accepts_actual(audit: CoreBSAAudit, receipts: tuple[Any, ...]) -> bool:
+    if audit.failure is not None or not audit.safe:
+        return False
+    if len(receipts) != audit.block_count:
+        return False
+    seen = set()
+    for receipt in receipts:
+        if not isinstance(receipt, tuple) or len(receipt) != 8:
+            return False
+        if receipt[0] != ADAPTER_KEY or receipt[1] != ADAPTER_VERSION:
+            return False
+        if receipt[2] != audit.patch_generation:
+            return False
+        block = receipt[3]
+        if type(block) is not int or block < 0 or block >= audit.block_count or block in seen:
+            return False
+        seen.add(block)
+        if receipt != audit.expected_receipts[block]:
+            return False
+    return seen == set(range(audit.block_count))

--- a/comfyui_spectrum_h3/core_bsa_diagnostics.py
+++ b/comfyui_spectrum_h3/core_bsa_diagnostics.py
@@ -1,0 +1,314 @@
+"""Debug-only ownership diagnostics for the source-gated core BSA adapter.
+
+This module does not participate in acceptance. It mirrors the strict ownership
+checks closely enough to report which proof boundary rejected a real runtime
+stack. All failures remain actual-only in the real adapter.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+from . import core_bsa_compat, core_bsa_flow_compat
+
+
+def _callable_label(value: Any) -> str:
+    if value is None:
+        return "None"
+    base = getattr(value, "__func__", value)
+    module = getattr(base, "__module__", type(base).__module__)
+    qualname = getattr(base, "__qualname__", type(base).__qualname__)
+    return f"{module}.{qualname}"
+
+
+def _callable_source_diagnostic(value: Any) -> str:
+    """Describe a rejected callable without changing any acceptance decision."""
+    if value is None:
+        return "callable=None"
+    base = getattr(value, "__func__", value)
+    module_name = getattr(base, "__module__", None)
+    qualname = getattr(base, "__qualname__", None)
+    defaults = getattr(base, "__defaults__", None)
+    kwdefaults = getattr(base, "__kwdefaults__", None)
+    code = getattr(base, "__code__", None)
+    code_name = getattr(code, "co_filename", None)
+    module = sys.modules.get(module_name) if isinstance(module_name, str) else None
+    source = getattr(module, "__file__", None) if module is not None else None
+    try:
+        source_path = str(Path(source).resolve()) if isinstance(source, str) else None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        source_path = f"<unresolvable:{source!r}>"
+    try:
+        code_path = str(Path(code_name).resolve()) if isinstance(code_name, str) else None
+    except (OSError, RuntimeError, TypeError, ValueError):
+        code_path = f"<unresolvable:{code_name!r}>"
+    blob = core_bsa_compat._module_blob_sha(module) if module is not None else None
+    closure = core_bsa_compat._closure_values(base)
+    closure_keys = (
+        tuple(sorted(str(key) for key in closure)) if isinstance(closure, dict) else None
+    )
+    return (
+        f"module={module_name!r} qualname={qualname!r} registered={module is not None} "
+        f"source={source_path!r} code={code_path!r} blob={blob!r} "
+        f"defaults={defaults!r} kwdefaults={kwdefaults!r} closure_keys={closure_keys!r}"
+    )
+
+
+def _flow_layout_review_diagnostic(wrapper: Any, index: int) -> str:
+    """Mirror every reviewed Flow layout-wrapper gate and report the first miss."""
+    base = getattr(wrapper, "__func__", wrapper)
+    if getattr(base, "__qualname__", None) != core_bsa_flow_compat._LAYOUT_QUALNAME:
+        return f"layout:qualname={getattr(base, '__qualname__', None)!r}"
+
+    module_name = getattr(base, "__module__", None)
+    if not isinstance(module_name, str):
+        return f"layout:module_name_type={type(module_name).__name__}"
+    if (
+        module_name != core_bsa_flow_compat._FLOW_ATTENTION_TOPLEVEL
+        and not module_name.endswith(core_bsa_flow_compat._FLOW_ATTENTION_SUFFIX)
+    ):
+        return f"layout:module_name_unreviewed={module_name!r}"
+
+    module = sys.modules.get(module_name)
+    if module is None:
+        return f"layout:module_not_registered={module_name!r}"
+    source = getattr(module, "__file__", None)
+    code = getattr(base, "__code__", None)
+    if not isinstance(source, str) or code is None:
+        return (
+            "layout:source_or_code_missing "
+            f"source_type={type(source).__name__} code_type={type(code).__name__}"
+        )
+    try:
+        source_path = Path(source).resolve()
+        code_path = Path(code.co_filename).resolve()
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        return f"layout:path_resolution={type(exc).__name__}:{exc}"
+    if source_path != code_path:
+        return f"layout:path_mismatch source={source_path} code={code_path}"
+    if source_path.name != "attention.py":
+        return f"layout:filename={source_path.name!r}"
+    if source_path.parent.name != "h3_flow_regenerate":
+        return f"layout:parent={source_path.parent.name!r}"
+
+    blob = core_bsa_compat._module_blob_sha(module)
+    if blob not in core_bsa_flow_compat.AUDITED_FLOW_ATTENTION_GIT_BLOBS:
+        return f"layout:source_blob_unreviewed={blob!r} path={source_path}"
+    if not core_bsa_flow_compat._source_matches(
+        base,
+        module,
+        ("make_layout_block_wrapper", "wrapper"),
+    ):
+        return f"layout:source_code_mismatch blob={blob} path={source_path}"
+    if getattr(base, "__defaults__", None) is not None:
+        return f"layout:defaults={getattr(base, '__defaults__', None)!r}"
+    if getattr(base, "__kwdefaults__", None):
+        return f"layout:kwdefaults={getattr(base, '__kwdefaults__', None)!r}"
+
+    closure = core_bsa_compat._closure_values(base)
+    if closure is None:
+        return "layout:closure_unreadable"
+    keys = frozenset(closure)
+    if keys != core_bsa_flow_compat._LAYOUT_CLOSURE_SCHEMA:
+        return f"layout:closure_schema={tuple(sorted(keys))!r}"
+    if type(closure["layer"]) is not int or closure["layer"] != index:
+        return f"layout:layer={closure['layer']!r} expected={index}"
+    if type(closure["record_layout"]) is not bool:
+        return f"layout:record_layout_type={type(closure['record_layout']).__name__}"
+
+    previous = closure["previous"]
+    marker = getattr(wrapper, "_h3_flow_layout_wrapper", None)
+    if marker is not True:
+        return f"layout:marker={marker!r}"
+    marker_previous = getattr(wrapper, "_h3_flow_previous", None)
+    if marker_previous is not previous:
+        return (
+            "layout:previous_marker_mismatch "
+            f"closure={_callable_label(previous)} marker={_callable_label(marker_previous)}"
+        )
+    scope = getattr(wrapper, "_h3_flow_layout_scope", None)
+    if scope not in {"layout", "attention"}:
+        return f"layout:scope={scope!r}"
+    metrics = closure["metrics"]
+    marker_metrics = getattr(wrapper, "_h3_flow_metrics", None)
+    if marker_metrics is not metrics:
+        return (
+            "layout:metrics_marker_mismatch "
+            f"closure_id={id(metrics)} marker_id={id(marker_metrics)}"
+        )
+    if not callable(getattr(metrics, "increment", None)):
+        return f"layout:metrics_increment={type(getattr(metrics, 'increment', None)).__name__}"
+    if not callable(getattr(metrics, "event", None)):
+        return f"layout:metrics_event={type(getattr(metrics, 'event', None)).__name__}"
+    return (
+        "layout:all_review_checks_passed "
+        f"blob={blob} scope={scope!r} module={module_name!r} "
+        f"previous={_callable_label(previous)} "
+        f"previous_detail=({_callable_source_diagnostic(previous)})"
+    )
+
+
+def _flow_wrapper_review_diagnostic(wrapper: Any, index: int) -> str:
+    base = getattr(wrapper, "__func__", wrapper)
+    qualname = getattr(base, "__qualname__", None)
+    if qualname == core_bsa_flow_compat._LAYOUT_QUALNAME:
+        return _flow_layout_review_diagnostic(wrapper, index)
+    if qualname == core_bsa_flow_compat._MIXED_QUALNAME:
+        return "mixed:review_failed_before_detailed_diagnostic"
+    return f"unknown:qualname={qualname!r} detail=({_callable_source_diagnostic(wrapper)})"
+
+
+def _effective_override(options: dict[str, Any]) -> tuple[Any, str]:
+    current = options.get("optimized_attention_override")
+    if core_bsa_compat._looks_like_core_bsa_callable(
+        current, "make_attention_override", "override"
+    ):
+        return current, "direct_bsa"
+    contract = getattr(current, "attention_preprocess_v1", None)
+    if isinstance(contract, tuple) and len(contract) == 2:
+        transform, previous = contract
+        return previous, f"preprocess:{_callable_label(transform)}"
+    return current, f"unrecognized_outer:{_callable_label(current)}"
+
+
+def ownership_diagnostic(
+    options: dict[str, Any], layout: Any, model: Any
+) -> str:
+    """Return one compact first-failure description without changing acceptance."""
+    try:
+        module, source = core_bsa_compat._load_audited_module()
+        if module is None:
+            return f"module:{source or 'unavailable'}"
+        block_patch_code = core_bsa_compat._nested_code(module.make_h3_block_patch, "block_patch")
+        attention_code = core_bsa_compat._nested_code(module.make_h3_block_patch, "attention")
+        override_code = core_bsa_compat._nested_code(module.make_attention_override, "override")
+        if block_patch_code is None or attention_code is None or override_code is None:
+            return "source:nested_code_missing"
+
+        blocks = getattr(model, "blocks", None)
+        if blocks is None:
+            return "model:blocks_missing"
+        patches = options.get("patches_replace")
+        if not isinstance(patches, dict):
+            return f"patches_replace:{type(patches).__name__}"
+        dit = patches.get("dit")
+        if not isinstance(dit, dict):
+            return f"dit:{type(dit).__name__}"
+
+        patch = None
+        flow_wrapped = 0
+        direct = 0
+        for index, block in enumerate(blocks):
+            replacement = dit.get(("double_block", index))
+            if replacement is None:
+                return f"block[{index}]:replacement_missing"
+            if core_bsa_compat._looks_like_core_bsa_callable(
+                replacement, "make_h3_block_patch", "block_patch"
+            ):
+                underlying = replacement
+                direct += 1
+            else:
+                underlying, identities, _mixed, reason = core_bsa_flow_compat._unwrap_replacement(
+                    replacement, index, layout, model
+                )
+                if underlying is None:
+                    review = _flow_wrapper_review_diagnostic(replacement, index)
+                    return (
+                        f"block[{index}]:flow_unwrap={reason or 'unknown'} "
+                        f"review={review} outer={_callable_label(replacement)}"
+                    )
+                flow_wrapped += 1
+                if not identities:
+                    return f"block[{index}]:flow_unwrap_without_identity"
+
+            if getattr(underlying, "__code__", None) is not block_patch_code:
+                return (
+                    f"block[{index}]:block_patch_code_mismatch "
+                    f"underlying={_callable_label(underlying)} source={source} "
+                    f"underlying_detail=({_callable_source_diagnostic(underlying)})"
+                )
+            closure = core_bsa_compat._closure_values(underlying)
+            if closure is None:
+                return f"block[{index}]:block_closure_unreadable"
+            owner = closure.get("patch")
+            if type(owner) is not module.SparseAttnPatch:
+                return (
+                    f"block[{index}]:patch_type_mismatch "
+                    f"actual={type(owner).__module__}.{type(owner).__qualname__}"
+                )
+            if patch is None:
+                patch = owner
+            elif owner is not patch:
+                return f"block[{index}]:patch_owner_changed"
+            if closure.get("block") is not block:
+                return (
+                    f"block[{index}]:block_identity_mismatch "
+                    f"captured={id(closure.get('block'))} runtime={id(block)}"
+                )
+            if closure.get("block_index") != index:
+                return f"block[{index}]:block_index={closure.get('block_index')!r}"
+            attention = closure.get("attention")
+            if getattr(attention, "__code__", None) is not attention_code:
+                return (
+                    f"block[{index}]:attention_code_mismatch "
+                    f"attention={_callable_label(attention)}"
+                )
+            attention_closure = core_bsa_compat._closure_values(attention)
+            if attention_closure is None:
+                return f"block[{index}]:attention_closure_unreadable"
+            if attention_closure.get("patch") is not patch:
+                return f"block[{index}]:attention_patch_owner_mismatch"
+            if attention_closure.get("block") is not block:
+                return f"block[{index}]:attention_block_identity_mismatch"
+            if attention_closure.get("block_index") != index:
+                return f"block[{index}]:attention_block_index_mismatch"
+
+        if patch is None:
+            return "patch:none"
+
+        current = options.get("optimized_attention_override")
+        effective, outer_mode = _effective_override(options)
+        if getattr(effective, "__code__", None) is not override_code:
+            contract = getattr(current, "attention_preprocess_v1", None)
+            contract_shape = "none"
+            if isinstance(contract, tuple):
+                contract_shape = f"tuple[{len(contract)}]"
+            elif contract is not None:
+                contract_shape = type(contract).__name__
+            return (
+                "override:code_mismatch "
+                f"mode={outer_mode} current={_callable_label(current)} "
+                f"effective={_callable_label(effective)} contract={contract_shape} "
+                f"blocks=direct:{direct}/flow:{flow_wrapped} "
+                f"effective_detail=({_callable_source_diagnostic(effective)})"
+            )
+        closure = core_bsa_compat._closure_values(effective)
+        if closure is None:
+            return f"override:closure_unreadable mode={outer_mode}"
+        if closure.get("patch") is not patch:
+            return f"override:patch_owner_mismatch mode={outer_mode}"
+        installed = getattr(patch, "installed", None)
+        if not isinstance(installed, set):
+            return f"override:installed_type={type(installed).__name__}"
+        if effective not in installed:
+            return f"override:not_in_installed mode={outer_mode} installed={len(installed)}"
+        previous = closure.get("previous")
+        if getattr(previous, "__code__", None) is override_code:
+            return f"override:stacked_bsa_previous mode={outer_mode}"
+        previous_closure = (
+            core_bsa_compat._closure_values(previous) if previous is not None else None
+        )
+        if (
+            previous_closure is not None
+            and type(previous_closure.get("patch")) is module.SparseAttnPatch
+        ):
+            return f"override:previous_owns_bsa_patch mode={outer_mode}"
+
+        return (
+            "ownership_checks_passed_unexpectedly "
+            f"mode={outer_mode} blocks=direct:{direct}/flow:{flow_wrapped} "
+            f"current={_callable_label(current)}"
+        )
+    except Exception as exc:  # noqa: BLE001 - diagnostics must never alter sampling
+        return f"diagnostic_exception:{type(exc).__name__}:{exc}"

--- a/comfyui_spectrum_h3/core_bsa_flow_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_flow_compat.py
@@ -1,0 +1,817 @@
+"""Source-gated Flow wrapper composition around ComfyUI core H3 BSA.
+
+Flow-Aligned Regenerate legitimately wraps MiniMax-H3 ``double_block`` replacements.
+Core BSA can therefore be numerically active without remaining the top-level block
+replacement. This module recognizes only reviewed Flow wrapper code, unwraps it
+for BSA preflight, and verifies the actual route around the real outer wrapper
+chain without depending on inference-tensor version counters.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from . import core_bsa_compat, source_code_audit
+
+AUDITED_FLOW_ATTENTION_GIT_BLOBS = frozenset(
+    {"c58c652f7b7d6030a2311f4805c3443615e432eb"}
+)
+AUDITED_FLOW_MIXED_GRID_GIT_BLOBS = frozenset(
+    {
+        "8fc0f753ff2cd21fae898a4dd3c9ab1025f98443",  # released v0.3.3
+        "66c59f26ad41154fcce7e1ce5250fa233a96dc3b",  # PR #26 canonical layout propagation
+    }
+)
+_FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS = frozenset(
+    {"66c59f26ad41154fcce7e1ce5250fa233a96dc3b"}
+)
+_FLOW_ATTENTION_TOPLEVEL = "h3_flow_regenerate.attention"
+_FLOW_ATTENTION_SUFFIX = ".h3_flow_regenerate.attention"
+_FLOW_MIXED_TOPLEVEL = "h3_flow_regenerate.mixed_grid"
+_FLOW_MIXED_SUFFIX = ".h3_flow_regenerate.mixed_grid"
+_LAYOUT_QUALNAME = "make_layout_block_wrapper.<locals>.wrapper"
+_MIXED_QUALNAME = "mixed_diffusion_wrapper.<locals>.wrap.<locals>.call"
+_LAYOUT_CLOSURE_SCHEMA = frozenset({"layer", "metrics", "previous", "record_layout"})
+_MIXED_CLOSURE_SCHEMA = frozenset(
+    {
+        "cached",
+        "inner",
+        "layer",
+        "layout",
+        "measure_contract",
+        "metrics",
+        "mixed_layout",
+        "native",
+        "old_prefix",
+        "plan",
+        "positions",
+        "previous",
+        "va",
+        "vb",
+    }
+)
+
+
+def _loaded_source_module(
+    base: Any,
+    *,
+    top_level: str,
+    suffix: str,
+    parent: str,
+    filename: str,
+    blobs: frozenset[str],
+) -> tuple[Any, str] | None:
+    module_name = getattr(base, "__module__", None)
+    if not isinstance(module_name, str):
+        return None
+    if module_name != top_level and not module_name.endswith(suffix):
+        return None
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None
+    source = getattr(module, "__file__", None)
+    code = getattr(base, "__code__", None)
+    if not isinstance(source, str) or code is None:
+        return None
+    try:
+        source_path = Path(source).resolve()
+        code_path = Path(code.co_filename).resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    if (
+        source_path != code_path
+        or source_path.name != filename
+        or source_path.parent.name != parent
+    ):
+        return None
+    blob = core_bsa_compat._module_blob_sha(module)
+    if blob not in blobs:
+        return None
+    return module, blob
+
+
+def _source_matches(base: Any, module: Any, lexical_path: tuple[str, ...]) -> bool:
+    source = getattr(module, "__file__", None)
+    return isinstance(source, str) and source_code_audit.matches_nested_source_code(
+        base,
+        Path(source),
+        lexical_path,
+    )
+
+
+def _audited_layout_wrapper(
+    wrapper: Any, index: int
+) -> tuple[Any, tuple[Any, ...]] | None:
+    base = getattr(wrapper, "__func__", wrapper)
+    if getattr(base, "__qualname__", None) != _LAYOUT_QUALNAME:
+        return None
+    loaded = _loaded_source_module(
+        base,
+        top_level=_FLOW_ATTENTION_TOPLEVEL,
+        suffix=_FLOW_ATTENTION_SUFFIX,
+        parent="h3_flow_regenerate",
+        filename="attention.py",
+        blobs=AUDITED_FLOW_ATTENTION_GIT_BLOBS,
+    )
+    if loaded is None:
+        return None
+    module, blob = loaded
+    if not _source_matches(base, module, ("make_layout_block_wrapper", "wrapper")):
+        return None
+    if getattr(base, "__defaults__", None) is not None or getattr(base, "__kwdefaults__", None):
+        return None
+    closure = core_bsa_compat._closure_values(base)
+    if closure is None or frozenset(closure) != _LAYOUT_CLOSURE_SCHEMA:
+        return None
+    if type(closure["layer"]) is not int or closure["layer"] != index:
+        return None
+    if type(closure["record_layout"]) is not bool:
+        return None
+    previous = closure["previous"]
+    if getattr(wrapper, "_h3_flow_layout_wrapper", False) is not True:
+        return None
+    if getattr(wrapper, "_h3_flow_previous", None) is not previous:
+        return None
+    scope = getattr(wrapper, "_h3_flow_layout_scope", None)
+    if scope not in {"layout", "attention"}:
+        return None
+    metrics = closure["metrics"]
+    if getattr(wrapper, "_h3_flow_metrics", None) is not metrics:
+        return None
+    if not callable(getattr(metrics, "increment", None)) or not callable(
+        getattr(metrics, "event", None)
+    ):
+        return None
+    return previous, (
+        "flow_layout_wrapper",
+        blob,
+        scope,
+        index,
+        core_bsa_compat._callable_identity(wrapper),
+        core_bsa_compat._lifetime_generation(metrics),
+    )
+
+
+def _plan_geometry(plan: Any) -> dict[str, Any] | None:
+    try:
+        prefix = plan.prefix
+        prefix_noise = plan.prefix_noise
+        temporal = plan.temporal
+        source_h = plan.source_h
+        source_w = plan.source_w
+        attention_measure = plan.attention_measure
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+    if not torch.is_tensor(prefix) or prefix.ndim != 5:
+        return None
+    if not torch.is_tensor(prefix_noise) or tuple(prefix_noise.shape) != tuple(prefix.shape):
+        return None
+    if (
+        type(temporal) is not int
+        or type(source_h) is not int
+        or type(source_w) is not int
+        or type(attention_measure) is not bool
+    ):
+        return None
+    prefix_t = int(prefix.shape[2])
+    target_h, target_w = map(int, prefix.shape[-2:])
+    if (
+        temporal <= prefix_t
+        or prefix_t <= 0
+        or min(source_h, source_w, target_h, target_w) < 2
+        or any(value % 2 for value in (source_h, source_w, target_h, target_w))
+    ):
+        return None
+    source_rows = source_h * source_w // 4
+    target_rows = target_h * target_w // 4
+    if source_rows <= 0 or target_rows <= source_rows:
+        return None
+    mixed_rows = prefix_t * target_rows + (temporal - prefix_t) * source_rows
+    return {
+        "temporal": temporal,
+        "prefix_t": prefix_t,
+        "source_h": source_h,
+        "source_w": source_w,
+        "target_h": target_h,
+        "target_w": target_w,
+        "source_rows": source_rows,
+        "target_rows": target_rows,
+        "mixed_rows": mixed_rows,
+        "attention_measure": attention_measure,
+    }
+
+
+def _expected_measure_contract(
+    geometry: dict[str, Any], *, video_start: int, sequence_rows: int
+) -> dict[str, Any] | None:
+    if not geometry["attention_measure"]:
+        return None
+    return {
+        "api": 1,
+        "mode": "prefix_kv_stratified_subsample",
+        "video_start": video_start,
+        "sequence_rows": sequence_rows,
+        "temporal": geometry["temporal"],
+        "prefix_t": geometry["prefix_t"],
+        "source_grid_h": geometry["source_h"] // 2,
+        "source_grid_w": geometry["source_w"] // 2,
+        "prefix_grid_h": geometry["target_h"] // 2,
+        "prefix_grid_w": geometry["target_w"] // 2,
+        "source_rows_per_frame": geometry["source_rows"],
+        "prefix_rows_per_frame": geometry["target_rows"],
+        "expected_kv_rows": video_start
+        + geometry["temporal"] * geometry["source_rows"],
+        "exact_prefix_queries_preserved": True,
+        "suffix_kv_unchanged": True,
+    }
+
+
+def _audited_mixed_wrapper(
+    wrapper: Any,
+    index: int,
+    carrier_layout: Any,
+    model: Any,
+) -> tuple[Any, tuple[Any, ...], dict[str, Any]] | None:
+    base = getattr(wrapper, "__func__", wrapper)
+    if getattr(base, "__qualname__", None) != _MIXED_QUALNAME:
+        return None
+    loaded = _loaded_source_module(
+        base,
+        top_level=_FLOW_MIXED_TOPLEVEL,
+        suffix=_FLOW_MIXED_SUFFIX,
+        parent="h3_flow_regenerate",
+        filename="mixed_grid.py",
+        blobs=AUDITED_FLOW_MIXED_GRID_GIT_BLOBS,
+    )
+    if loaded is None:
+        return None
+    module, blob = loaded
+    if not _source_matches(
+        base,
+        module,
+        ("mixed_diffusion_wrapper", "wrap", "call"),
+    ):
+        return None
+    if getattr(base, "__defaults__", None) is not None or getattr(base, "__kwdefaults__", None):
+        return None
+    closure = core_bsa_compat._closure_values(base)
+    if closure is None or frozenset(closure) != _MIXED_CLOSURE_SCHEMA:
+        return None
+    if type(closure["layer"]) is not int or closure["layer"] != index:
+        return None
+    if closure["inner"] is not model:
+        return None
+    native = closure["native"]
+    if (
+        getattr(native, "__name__", None) != "comfy.ldm.minimax.model"
+        or sys.modules.get("comfy.ldm.minimax.model") is not native
+    ):
+        return None
+    cached = closure["cached"]
+    if type(cached) is not dict or cached:
+        return None
+    previous = closure["previous"]
+    mixed_layout = closure["mixed_layout"]
+    plan = closure["plan"]
+    closed_carrier = closure["layout"]
+    if type(plan) is not getattr(module, "MixedGridPlan", object):
+        return None
+    geometry = _plan_geometry(plan)
+    if geometry is None:
+        return None
+    normalized_carrier = core_bsa_compat._normalize_layout(carrier_layout)
+    normalized_closed_carrier = core_bsa_compat._normalize_layout(closed_carrier)
+    normalized_mixed = core_bsa_compat._normalize_layout(mixed_layout)
+    if (
+        normalized_carrier is None
+        or normalized_closed_carrier != normalized_carrier
+        or normalized_mixed is None
+    ):
+        return None
+    carrier_seq, carrier_identity = normalized_carrier
+    mixed_seq, mixed_identity = normalized_mixed
+    if mixed_seq <= carrier_seq:
+        return None
+    carrier_segments = dict(carrier_identity).get("segments")
+    mixed_segments = dict(mixed_identity).get("segments")
+    if not isinstance(carrier_segments, tuple) or not isinstance(mixed_segments, tuple):
+        return None
+    carrier_video = [item for item in carrier_segments if item[2] == "video"]
+    mixed_video = [item for item in mixed_segments if item[2] == "video"]
+    if len(carrier_video) != 1 or len(mixed_video) != 1:
+        return None
+    va, vb, _kind = carrier_video[0]
+    mixed_va, mixed_vb, _mixed_kind = mixed_video[0]
+    if (
+        va != mixed_va
+        or vb != carrier_seq
+        or mixed_vb != mixed_seq
+        or mixed_seq != va + geometry["mixed_rows"]
+    ):
+        return None
+    if tuple(item for item in carrier_segments if item[2] != "video") != tuple(
+        item for item in mixed_segments if item[2] != "video"
+    ):
+        return None
+    if closure["va"] != va or closure["vb"] != vb:
+        return None
+    if closure["old_prefix"] != geometry["prefix_t"] * geometry["source_rows"]:
+        return None
+    positions = closure["positions"]
+    if not torch.is_tensor(positions) or getattr(mixed_layout, "position_ids", None) is not positions:
+        return None
+    if int(positions.shape[0]) != mixed_seq:
+        return None
+    expected_measure = _expected_measure_contract(
+        geometry,
+        video_start=va,
+        sequence_rows=mixed_seq,
+    )
+    if closure["measure_contract"] != expected_measure:
+        return None
+    metrics = closure["metrics"]
+    if not callable(getattr(metrics, "increment", None)) or not callable(
+        getattr(metrics, "event", None)
+    ):
+        return None
+    plan_generation = core_bsa_compat._lifetime_generation(plan)
+    mixed_generation = core_bsa_compat._lifetime_generation(mixed_layout)
+    identity = (
+        "flow_mixed_grid_wrapper",
+        blob,
+        index,
+        core_bsa_compat._callable_identity(wrapper),
+        plan_generation,
+        mixed_generation,
+        carrier_identity,
+        mixed_identity,
+    )
+    return previous, identity, {
+        "source_blob": blob,
+        "plan": plan,
+        "plan_generation": plan_generation,
+        "mixed_layout": mixed_layout,
+        "mixed_generation": mixed_generation,
+        "mixed_seq": mixed_seq,
+        "mixed_identity": mixed_identity,
+        "carrier_seq": carrier_seq,
+        "carrier_identity": carrier_identity,
+        "cached": cached,
+        "metrics": metrics,
+        "positions": positions,
+        "native": native,
+        "inner": model,
+        "measure_contract": expected_measure,
+        "old_prefix": closure["old_prefix"],
+        "va": va,
+        "vb": vb,
+    }
+
+
+def _unwrap_replacement(
+    replacement: Any,
+    index: int,
+    carrier_layout: Any,
+    model: Any,
+) -> tuple[Any | None, tuple[Any, ...], dict[str, Any] | None, str | None]:
+    current = replacement
+    identities: list[Any] = []
+    mixed: dict[str, Any] | None = None
+    seen: set[int] = set()
+    for _depth in range(8):
+        if core_bsa_compat._looks_like_core_bsa_callable(
+            current, "make_h3_block_patch", "block_patch"
+        ):
+            return current, tuple(identities), mixed, None
+        if current is None or id(current) in seen:
+            return None, tuple(identities), mixed, "flow_wrapper_chain_invalid"
+        seen.add(id(current))
+
+        layout = _audited_layout_wrapper(current, index)
+        if layout is not None:
+            current, identity = layout
+            identities.append(identity)
+            continue
+
+        mixed_result = _audited_mixed_wrapper(current, index, carrier_layout, model)
+        if mixed_result is not None:
+            if mixed is not None:
+                return None, tuple(identities), mixed, "flow_mixed_wrapper_stacked"
+            current, identity, mixed = mixed_result
+            identities.append(identity)
+            continue
+
+        return None, tuple(identities), mixed, "flow_wrapper_unreviewed"
+    return None, tuple(identities), mixed, "flow_wrapper_chain_too_deep"
+
+
+def has_core_bsa_evidence(options: dict[str, Any]) -> bool:
+    if core_bsa_compat.has_core_bsa_evidence(options):
+        return True
+    patches = options.get("patches_replace")
+    if not isinstance(patches, dict):
+        return False
+    dit = patches.get("dit")
+    if not isinstance(dit, dict):
+        return False
+    for replacement in dit.values():
+        current = replacement
+        seen: set[int] = set()
+        for _depth in range(8):
+            if core_bsa_compat._looks_like_core_bsa_callable(
+                current, "make_h3_block_patch", "block_patch"
+            ):
+                return True
+            if current is None or id(current) in seen:
+                break
+            seen.add(id(current))
+            if getattr(current, "_h3_flow_layout_wrapper", False) is True:
+                current = getattr(current, "_h3_flow_previous", None)
+                continue
+            closure = core_bsa_compat._closure_values(current)
+            if (
+                getattr(current, "__qualname__", None) == _MIXED_QUALNAME
+                and isinstance(closure, dict)
+            ):
+                current = closure.get("previous")
+                continue
+            break
+    return False
+
+
+def _effective_mixed_layout(mixed: dict[str, Any], carrier_layout: Any) -> Any:
+    """Return the exact layout core BSA sees for the reviewed Flow source.
+
+    Released Flow v0.3.3 passes ``mixed_layout`` as the direct block argument but
+    leaves ``transformer_options['minimax_h3_layout']`` on the carrier layout.
+    Core BSA therefore sees a token/layout mismatch and uses zero conditioning
+    sinks. PR #26 fixes the producer-side contract and publishes ``mixed_layout``
+    through the canonical transformer metadata as well. The audit preserves both
+    numerical semantics instead of pretending the released and fixed sources are
+    equivalent.
+    """
+    source_blob = mixed.get("source_blob")
+    if source_blob in _FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS:
+        layout = mixed.get("mixed_layout")
+        normalized = core_bsa_compat._normalize_layout(layout)
+        if normalized is None or normalized[0] != int(mixed["mixed_seq"]):
+            raise ValueError("propagated mixed layout is invalid")
+        return layout
+
+    carrier = core_bsa_compat._normalize_layout(carrier_layout)
+    if carrier is None:
+        raise ValueError("carrier layout is invalid")
+    mixed_seq = int(mixed["mixed_seq"])
+    return SimpleNamespace(
+        seq_len=mixed_seq,
+        signature=("flow_mixed_bsa_effective_v1", carrier[1], mixed["mixed_identity"]),
+        segments=[(0, mixed_seq, "flow_mixed_effective")],
+    )
+
+
+def probe(options: dict[str, Any], layout: Any, model: Any):
+    """Prove reviewed Flow wrappers and then delegate the underlying BSA audit."""
+    try:
+        blocks = getattr(model, "blocks", None)
+        if not isinstance(blocks, (tuple, list, torch.nn.ModuleList)) or not blocks:
+            return None, "flow_model_shape_unproven"
+        patches = options.get("patches_replace")
+        if not isinstance(patches, dict):
+            return core_bsa_compat.probe(options, layout, model)
+        dit = patches.get("dit")
+        if not isinstance(dit, dict):
+            return core_bsa_compat.probe(options, layout, model)
+
+        normalized_dit = dict(dit)
+        wrapper_specs: list[Any] = []
+        mixed_specs: list[dict[str, Any] | None] = []
+        saw_flow = False
+        for index in range(len(blocks)):
+            replacement = dit.get(("double_block", index))
+            if replacement is None:
+                return None, "main_h3_replacement_missing"
+            if core_bsa_compat._looks_like_core_bsa_callable(
+                replacement, "make_h3_block_patch", "block_patch"
+            ):
+                normalized_dit[("double_block", index)] = replacement
+                wrapper_specs.append(tuple())
+                mixed_specs.append(None)
+                continue
+            underlying, identities, mixed, reason = _unwrap_replacement(
+                replacement, index, layout, model
+            )
+            if underlying is None:
+                return None, reason or "flow_wrapper_unreviewed"
+            saw_flow = True
+            normalized_dit[("double_block", index)] = underlying
+            wrapper_specs.append(identities)
+            mixed_specs.append(mixed)
+
+        if not saw_flow:
+            return core_bsa_compat.probe(options, layout, model)
+
+        mixed_present = [item is not None for item in mixed_specs]
+        if any(mixed_present) and not all(mixed_present):
+            return None, "flow_mixed_wrapper_incomplete"
+        mixed = mixed_specs[0] if all(mixed_present) else None
+        if mixed is not None:
+            for item in mixed_specs[1:]:
+                if (
+                    item is None
+                    or item["plan"] is not mixed["plan"]
+                    or item["mixed_layout"] is not mixed["mixed_layout"]
+                    or item["source_blob"] != mixed["source_blob"]
+                    or item["carrier_identity"] != mixed["carrier_identity"]
+                    or item["cached"] is not mixed["cached"]
+                    or item["metrics"] is not mixed["metrics"]
+                    or item["positions"] is not mixed["positions"]
+                    or item["native"] is not mixed["native"]
+                    or item["inner"] is not mixed["inner"]
+                    or item["measure_contract"] != mixed["measure_contract"]
+                    or item["old_prefix"] != mixed["old_prefix"]
+                    or item["va"] != mixed["va"]
+                    or item["vb"] != mixed["vb"]
+                ):
+                    return None, "flow_mixed_wrapper_inconsistent"
+
+        normalized = dict(options)
+        normalized_patches = dict(patches)
+        normalized_patches["dit"] = normalized_dit
+        normalized["patches_replace"] = normalized_patches
+        audit_layout = _effective_mixed_layout(mixed, layout) if mixed is not None else layout
+        audit, reason = core_bsa_compat.probe(normalized, audit_layout, model)
+        if audit is None:
+            return None, reason
+
+        carrier = core_bsa_compat._normalize_layout(layout)
+        if carrier is None:
+            return None, "flow_carrier_layout_unproven"
+        carrier_seq, carrier_identity = carrier
+        if mixed is None:
+            outer_seq_lens = tuple(carrier_seq for _ in blocks)
+            flow_mode = "layout_wrapped"
+        else:
+            outer_seq_lens = (carrier_seq, *(mixed["mixed_seq"] for _ in blocks[1:]))
+            flow_mode = (
+                "mixed_grid_layout_propagated_v1"
+                if mixed["source_blob"] in _FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS
+                else "mixed_grid_v0.3.3"
+            )
+
+        flow_identity = (
+            "reviewed_flow_h3_wrapper_chain_v1",
+            flow_mode,
+            tuple(wrapper_specs),
+            ("carrier_layout", carrier_identity),
+            (
+                "mixed_layout",
+                None
+                if mixed is None
+                else (
+                    mixed["plan_generation"],
+                    mixed["mixed_generation"],
+                    mixed["mixed_identity"],
+                ),
+            ),
+        )
+        audit.identity = (*audit.identity, ("outer_block_wrappers", flow_identity))
+        audit.flow_wrapper_specs = tuple(wrapper_specs)
+        audit.flow_outer_replacements = tuple(
+            dit[("double_block", index)] for index in range(len(blocks))
+        )
+        audit.flow_bsa_replacements = tuple(
+            normalized_dit[("double_block", index)] for index in range(len(blocks))
+        )
+        audit.flow_outer_seq_lens = outer_seq_lens
+        audit.flow_carrier_seq_len = carrier_seq
+        audit.flow_carrier_layout_identity = carrier_identity
+        audit.flow_mixed = mixed is not None
+        audit.flow_mixed_layout_propagated = bool(
+            mixed is not None
+            and mixed["source_blob"] in _FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS
+        )
+        audit.flow_identity = flow_identity
+        audit.flow_model = model
+        return audit, None
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - optional Flow introspection remains actual-only
+        return None, "flow_introspection_failed"
+
+
+def _pool_entry(
+    audit: core_bsa_compat.CoreBSAAudit, index: int
+) -> tuple[Any, ...]:
+    return core_bsa_compat._pool_entry(
+        audit.patch,
+        (index, audit.seq_len, audit.uuids),
+        audit.pool_specs[index],
+    )
+
+
+def _current_metadata_matches(
+    audit: core_bsa_compat.CoreBSAAudit,
+    index: int,
+    args: dict[str, Any],
+) -> bool:
+    try:
+        hidden = args["img"]
+        call_options = args["transformer_options"]
+    except (KeyError, TypeError):
+        return False
+    if (
+        not torch.is_tensor(hidden)
+        or hidden.ndim < 1
+        or int(hidden.shape[0]) != int(audit.flow_outer_seq_lens[index])
+    ):
+        return False
+    if core_bsa_compat._normalize_uuids(call_options) != audit.uuids:
+        return False
+    if core_bsa_compat._settings_identity(audit.patch) != audit.settings_identity:
+        return False
+    if call_options.get("optimized_attention_override") is not audit.current_override:
+        return False
+    actual_layout = core_bsa_compat._normalize_layout(
+        call_options.get("minimax_h3_layout")
+    )
+    if (
+        actual_layout is None
+        or actual_layout[0] != audit.flow_carrier_seq_len
+        or actual_layout[1] != audit.flow_carrier_layout_identity
+    ):
+        return False
+    sigma = core_bsa_compat._sigma_value(call_options)
+    if sigma is None:
+        return False
+    sigma_start = audit.settings_identity[4]
+    sigma_end = audit.settings_identity[5]
+    min_tokens = audit.settings_identity[6]
+    dense_blocks = audit.settings_identity[7]
+    dense = (
+        not (sigma_end <= sigma <= sigma_start)
+        or audit.seq_len < min_tokens
+        or index in dense_blocks
+    )
+    expected = audit.route_specs[index][0]
+    if expected == "h3_dense":
+        return dense
+    if expected not in {"h3_chunked_sparse_cold", "h3_chunked_sparse_primed"}:
+        return False
+    return not dense
+
+
+def _make_actual_wrapper(
+    audit: core_bsa_compat.CoreBSAAudit,
+    index: int,
+    replacement: Any,
+    bsa_replacement: Any,
+    receipts: list[Any],
+):
+    bsa_closure = core_bsa_compat._closure_values(bsa_replacement)
+    expected_attention = (
+        bsa_closure.get("attention") if isinstance(bsa_closure, dict) else None
+    )
+
+    def audited_replacement(args, replacement_context):
+        try:
+            metadata_ok = _current_metadata_matches(audit, index, args)
+            before = _pool_entry(audit, index)
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except Exception:  # noqa: BLE001 - observation remains fail-closed
+            metadata_ok = False
+            before = ("invalid",)
+            audit.failure = "actual_metadata_failed"
+
+        sparse_selected = False
+        original_block_calls = 0
+        try:
+            original_block = replacement_context.get("original_block")
+        except Exception:  # noqa: BLE001 - malformed observation context fails closed
+            original_block = None
+        if not callable(expected_attention) or not callable(original_block):
+            metadata_ok = False
+            output = replacement(args, replacement_context)
+        else:
+            def audited_original_block(call_args):
+                nonlocal sparse_selected, original_block_calls
+                original_block_calls += 1
+                sparse_selected = call_args.get("attention") is expected_attention
+                if sparse_selected:
+                    from .bsa_transition_probe import attention
+                    call_args = {**call_args, "attention": attention(expected_attention, audit, index)}
+                return original_block(call_args)
+
+            observed_context = dict(replacement_context)
+            observed_context["original_block"] = audited_original_block
+            output = replacement(args, observed_context)
+            if original_block_calls != 1:
+                metadata_ok = False
+
+        try:
+            after = _pool_entry(audit, index)
+            observed = core_bsa_compat._classify_pool_transition(
+                before,
+                after,
+                sparse_selected=sparse_selected,
+            )
+            expected_route, expected_sink, expected_sink_q = audit.route_specs[index]
+            if not metadata_ok or observed != expected_route:
+                audit.failure = "actual_route_mismatch"
+            receipts.append(
+                (
+                    core_bsa_compat.ADAPTER_KEY,
+                    core_bsa_compat.ADAPTER_VERSION,
+                    audit.patch_generation,
+                    index,
+                    observed,
+                    audit.seq_len,
+                    expected_sink,
+                    expected_sink_q,
+                )
+            )
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except Exception:  # noqa: BLE001 - observation failure must not abort sampling
+            audit.failure = "actual_observation_failed"
+        return output
+
+    return audited_replacement
+
+
+def instrument_actual_options(
+    options: dict[str, Any],
+    audit: core_bsa_compat.CoreBSAAudit,
+    receipts_key: str,
+) -> dict[str, Any]:
+    if not hasattr(audit, "flow_wrapper_specs"):
+        return core_bsa_compat.instrument_actual_options(options, audit, receipts_key)
+    prepared = dict(options)
+    receipts = prepared.get(receipts_key)
+    patches = prepared.get("patches_replace")
+    if not isinstance(receipts, list) or not isinstance(patches, dict):
+        audit.failure = "flow_receipt_or_replacement_table_missing"
+        return prepared
+    dit = patches.get("dit")
+    if not isinstance(dit, dict):
+        audit.failure = "dit_replacement_table_missing"
+        return prepared
+    bsa_replacements = getattr(audit, "flow_bsa_replacements", None)
+    if not isinstance(bsa_replacements, tuple) or len(bsa_replacements) != audit.block_count:
+        audit.failure = "flow_bsa_replacement_evidence_missing"
+        return prepared
+    flow_model = getattr(audit, "flow_model", None)
+    if flow_model is None:
+        audit.failure = "flow_model_evidence_missing"
+        return prepared
+
+    local_patches = dict(patches)
+    local_dit = dict(dit)
+    for index in range(audit.block_count):
+        key = ("double_block", index)
+        replacement = local_dit.get(key)
+        if replacement is None or replacement is not audit.flow_outer_replacements[index]:
+            audit.failure = "flow_outer_replacement_changed"
+            return prepared
+        underlying, identities, mixed, reason = _unwrap_replacement(
+            replacement,
+            index,
+            SimpleNamespace(
+                seq_len=audit.flow_carrier_seq_len,
+                signature=dict(audit.flow_carrier_layout_identity).get("signature"),
+                segments=list(dict(audit.flow_carrier_layout_identity).get("segments", ())),
+            ),
+            flow_model,
+        )
+        if (
+            underlying is None
+            or underlying is not bsa_replacements[index]
+            or identities != audit.flow_wrapper_specs[index]
+        ):
+            audit.failure = reason or "flow_wrapper_chain_changed"
+            return prepared
+        if bool(mixed is not None) != bool(audit.flow_mixed):
+            audit.failure = "flow_wrapper_mode_changed"
+            return prepared
+        if (
+            mixed is not None
+            and bool(mixed["source_blob"] in _FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS)
+            != bool(getattr(audit, "flow_mixed_layout_propagated", False))
+        ):
+            audit.failure = "flow_mixed_layout_mode_changed"
+            return prepared
+        local_dit[key] = _make_actual_wrapper(
+            audit,
+            index,
+            replacement,
+            underlying,
+            receipts,
+        )
+    local_patches["dit"] = local_dit
+    prepared["patches_replace"] = local_patches
+    prepared[core_bsa_compat.PRIVATE_AUDIT_KEY] = audit
+    return prepared

--- a/comfyui_spectrum_h3/core_bsa_forecast_recovery.py
+++ b/comfyui_spectrum_h3/core_bsa_forecast_recovery.py
@@ -1,0 +1,378 @@
+"""Source-gated recovery of Spectrum forecasts across core-BSA cold->primed transitions.
+
+CUDA diagnostics proved that ComfyUI core BlockSparseAttention's cold sparse call
+creates the exact calibration tensor owners consumed by the adjacent primed call.
+This module preserves Spectrum history only for that one-way, structurally proven
+transition when the current Spectrum step was already selected as a forecast.
+Dense->sparse and every unproven/foreign transition keep the normal hard reset.
+
+The same integration promotes the previously test-only deferred one-point
+bootstrap entitlement.  The entitlement belongs to one Spectrum run and is
+consumed only by a successfully finalized forecast.  It is not a target-NFE
+special case; it only lets an ordinary degree-1 bootstrap move past exact-prefix
+or backend-veto steps until the immediately preceding retained actual anchor can
+support it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import wraps
+import logging
+from typing import Any
+
+from .backend_history import BackendHistory
+
+LOG = logging.getLogger(__name__)
+
+_INSTALLED = False
+_ORIGINAL_PREPARE = None
+_ORIGINAL_OBSERVE = None
+
+
+@dataclass(slots=True)
+class _ColdSuccessorProof:
+    run_id: int
+    step_id: int
+    semantic_identity: tuple[Any, ...]
+    patch: Any
+    patch_generation: int
+    source_blob: str
+    seq_len: int
+    uuids: tuple[Any, ...]
+    sparse_blocks: tuple[int, ...]
+    owners: tuple[tuple[Any, Any], ...]
+
+
+def _semantic_identity(identity: Any) -> Any:
+    """Drop only route/pool state; all other numerical identity remains binding."""
+    if isinstance(identity, tuple):
+        return tuple(
+            _semantic_identity(item)
+            for item in identity
+            if not (
+                isinstance(item, tuple)
+                and item
+                and item[0] in ("routes", "pool_ownership")
+            )
+        )
+    return identity
+
+
+def _clear_transition_proof(runtime) -> None:
+    runtime._core_bsa_cold_successor_proof = None
+
+
+def _capture_transition_proof(runtime, run_id: int, step_id: int, audit, receipts) -> None:
+    """Capture exact post-cold calibration owners after an accepted actual call."""
+    from . import core_bsa_compat
+
+    _clear_transition_proof(runtime)
+    if (
+        audit is None
+        or not audit.safe
+        or not core_bsa_compat.accepts_actual(audit, receipts)
+        or runtime._backend_history.policy != audit.identity
+        or not runtime._backend_history.forecast_safe
+    ):
+        return
+
+    sparse = tuple(
+        index
+        for index, spec in enumerate(audit.route_specs)
+        if spec[0] != "h3_dense"
+    )
+    if not sparse or any(
+        audit.route_specs[index][0] != "h3_chunked_sparse_cold"
+        for index in sparse
+    ):
+        return
+
+    owners = []
+    for index in sparse:
+        entry = core_bsa_compat._pool_entry(
+            audit.patch,
+            (index, audit.seq_len, audit.uuids),
+            audit.pool_specs[index],
+        )
+        if entry[0] != "present":
+            return
+        owners.append((entry[1], entry[2]))
+
+    runtime._core_bsa_cold_successor_proof = _ColdSuccessorProof(
+        run_id=int(run_id),
+        step_id=int(step_id),
+        semantic_identity=_semantic_identity(audit.identity),
+        patch=audit.patch,
+        patch_generation=int(audit.patch_generation),
+        source_blob=str(audit.source_blob),
+        seq_len=int(audit.seq_len),
+        uuids=tuple(audit.uuids),
+        sparse_blocks=sparse,
+        owners=tuple(owners),
+    )
+
+
+def _prove_forecast_carry(runtime, run_id: int, step_id: int, audit, identity, safe: bool) -> bool:
+    """Prove the exact adjacent cold->primed transition needed by a forecast step."""
+    from . import core_bsa_compat
+
+    proof = getattr(runtime, "_core_bsa_cold_successor_proof", None)
+    if proof is None:
+        return False
+    if proof.run_id != int(run_id) or proof.step_id + 1 != int(step_id):
+        _clear_transition_proof(runtime)
+        return False
+    step = runtime._step
+    if step is None or step.mode != "forecast" or not safe:
+        _clear_transition_proof(runtime)
+        return False
+    if (
+        audit is None
+        or not audit.safe
+        or audit.patch is not proof.patch
+        or int(audit.patch_generation) != proof.patch_generation
+        or str(audit.source_blob) != proof.source_blob
+        or int(audit.seq_len) != proof.seq_len
+        or tuple(audit.uuids) != proof.uuids
+        or _semantic_identity(identity) != proof.semantic_identity
+    ):
+        _clear_transition_proof(runtime)
+        return False
+
+    sparse = tuple(
+        index
+        for index, spec in enumerate(audit.route_specs)
+        if spec[0] != "h3_dense"
+    )
+    if sparse != proof.sparse_blocks or any(
+        audit.route_specs[index][0] != "h3_chunked_sparse_primed"
+        for index in sparse
+    ):
+        _clear_transition_proof(runtime)
+        return False
+
+    for index, owners in zip(sparse, proof.owners):
+        entry = core_bsa_compat._pool_entry(
+            audit.patch,
+            (index, audit.seq_len, audit.uuids),
+            audit.pool_specs[index],
+        )
+        if (
+            entry[0] != "present"
+            or entry[1] is not owners[0]
+            or entry[2] is not owners[1]
+        ):
+            _clear_transition_proof(runtime)
+            return False
+
+    old = runtime._backend_history
+    if old.policy is None or old.receipt is None or not old.forecast_safe:
+        _clear_transition_proof(runtime)
+        return False
+
+    # Rebind only the policy identity.  The old accepted cold receipt remains as
+    # provenance until the next actual call supplies a real primed receipt.  BSA
+    # calibration itself is intentionally not modified or pretended refreshed.
+    runtime._backend_history = BackendHistory(
+        policy=identity,
+        receipt=old.receipt,
+        forecast_safe=True,
+    )
+    runtime._core_bsa_carry_step = int(step_id)
+    _clear_transition_proof(runtime)
+    if runtime.config.debug:
+        LOG.warning(
+            "Spectrum H3 core-BSA history carry run_id=%s step=%s "
+            "transition=cold->primed proof=adjacent_exact_calibration_tensor_owners",
+            run_id,
+            step_id,
+        )
+    return True
+
+
+def _prepare(runtime, run_id, step_id, options, layout, model):
+    """Backend-history prepare with one narrow cold->primed carry exception."""
+    from . import backend_history as history
+    from . import core_bsa_flow_compat
+
+    identity, safe, audit = history._preflight(options, layout, model)
+    history._debug_core_bsa_preflight(
+        runtime,
+        run_id,
+        step_id,
+        identity,
+        safe,
+        audit,
+        options=options,
+        layout=layout,
+        model=model,
+    )
+    if identity is None:
+        if runtime._backend_history.policy is None:
+            return options, None
+        identity, safe = ("provider_removed",), False
+
+    if runtime._backend_history.policy is None and not history._runtime_has_backend_evidence(runtime):
+        runtime._backend_history = BackendHistory(policy=identity)
+
+    _prove_forecast_carry(runtime, run_id, step_id, audit, identity, safe)
+    runtime.prepare_backend_history(run_id, step_id, identity, safe)
+
+    prepared = {**options, history.RECEIPTS: []}
+    if audit is not None:
+        prepared = core_bsa_flow_compat.instrument_actual_options(
+            prepared,
+            audit,
+            history.RECEIPTS,
+        )
+    return prepared, (identity, safe)
+
+
+def _observe(runtime, run_id, step_id, options, policy):
+    """Run normal receipt observation, then retain exact post-cold owners if valid."""
+    assert _ORIGINAL_OBSERVE is not None
+    _ORIGINAL_OBSERVE(runtime, run_id, step_id, options, policy)
+    if policy is None:
+        _clear_transition_proof(runtime)
+        return
+    from . import backend_history as history
+    from . import core_bsa_compat
+
+    audit = options.get(core_bsa_compat.PRIVATE_AUDIT_KEY)
+    receipts = tuple(options.get(history.RECEIPTS, ()))
+    _capture_transition_proof(runtime, run_id, step_id, audit, receipts)
+
+
+def _entitlement_available(runtime) -> bool:
+    return bool(getattr(runtime, "_core_bsa_bootstrap_entitlement_unused", False))
+
+
+def _can_defer_bootstrap(runtime, decision) -> bool:
+    step = runtime._step
+    run = runtime._run
+    if (
+        step is None
+        or run is None
+        or not decision.get("actual", True)
+        or decision.get("reason") != "insufficient actual history"
+        or not _entitlement_available(runtime)
+        or not runtime.config.bootstrap_first_forecast
+        or runtime.config.degree != 1
+        or run.state_conditioned_residual
+        or run.separate_stage_histories
+        or runtime.offline_phase is not None
+        or runtime.forecaster.history_length != 1
+        or runtime._last_completed_mode != "actual"
+        or runtime._last_completed_step_id != step.step_id - 1
+    ):
+        return False
+    return runtime.forecaster.latest_anchor_ids(1) == (runtime._last_completed_step_id,)
+
+
+def install_core_bsa_forecast_recovery() -> None:
+    """Install the CUDA-evidence-backed production candidate exactly once."""
+    global _INSTALLED, _ORIGINAL_PREPARE, _ORIGINAL_OBSERVE
+    if _INSTALLED:
+        return
+
+    from . import backend_history as history
+    from .runtime import SpectrumH3Runtime
+
+    _ORIGINAL_PREPARE = history.prepare
+    _ORIGINAL_OBSERVE = history.observe
+    history.prepare = _prepare
+    history.observe = _observe
+
+    original_start = SpectrumH3Runtime.start_run
+    original_begin = SpectrumH3Runtime.begin_step
+    original_finalize = SpectrumH3Runtime.finalize_step
+    original_abort = SpectrumH3Runtime.abort_step
+    original_snapshot = SpectrumH3Runtime.create_rollback_snapshot
+    original_restore = SpectrumH3Runtime.restore_rollback_snapshot
+    original_end = SpectrumH3Runtime.end_run
+
+    @wraps(original_start)
+    def start_run(self, *args, **kwargs):
+        run_id = original_start(self, *args, **kwargs)
+        self._core_bsa_bootstrap_entitlement_unused = bool(
+            self.config.bootstrap_first_forecast
+        )
+        self._core_bsa_cold_successor_proof = None
+        self._core_bsa_carry_step = None
+        self._core_bsa_recovery_snapshots = {}
+        return run_id
+
+    @wraps(original_begin)
+    def begin_step(self, timestep):
+        decision = original_begin(self, timestep)
+        if _can_defer_bootstrap(self, decision):
+            step = self._step
+            step.mode = "forecast"
+            step.reason = "deferred one-point bootstrap forecast"
+            step.bootstrap_forecast = True
+            decision["actual"] = False
+            decision["reason"] = step.reason
+            if self.config.debug:
+                LOG.warning(
+                    "Spectrum H3 deferred bootstrap entitlement run_id=%s step=%s "
+                    "anchor_step=%s action=forecast",
+                    decision["run_id"],
+                    decision["step_id"],
+                    self._last_completed_step_id,
+                )
+        return decision
+
+    @wraps(original_finalize)
+    def finalize_step(self, run_id, step_id):
+        original_finalize(self, run_id, step_id)
+        if (
+            self._last_completed_step_id == int(step_id)
+            and self._last_completed_mode == "forecast"
+        ):
+            self._core_bsa_bootstrap_entitlement_unused = False
+
+    @wraps(original_abort)
+    def abort_step(self, run_id, step_id):
+        # No forecast has committed, so entitlement is intentionally untouched.
+        return original_abort(self, run_id, step_id)
+
+    @wraps(original_snapshot)
+    def create_rollback_snapshot(self):
+        snapshot = original_snapshot(self)
+        state = (
+            bool(getattr(self, "_core_bsa_bootstrap_entitlement_unused", False)),
+            getattr(self, "_core_bsa_cold_successor_proof", None),
+            getattr(self, "_core_bsa_carry_step", None),
+        )
+        self._core_bsa_recovery_snapshots[id(snapshot)] = state
+        return snapshot
+
+    @wraps(original_restore)
+    def restore_rollback_snapshot(self, snapshot):
+        state = self._core_bsa_recovery_snapshots.get(id(snapshot))
+        original_restore(self, snapshot)
+        if state is not None:
+            (
+                self._core_bsa_bootstrap_entitlement_unused,
+                self._core_bsa_cold_successor_proof,
+                self._core_bsa_carry_step,
+            ) = state
+
+    @wraps(original_end)
+    def end_run(self, *args, **kwargs):
+        try:
+            return original_end(self, *args, **kwargs)
+        finally:
+            self._core_bsa_cold_successor_proof = None
+            self._core_bsa_carry_step = None
+            self._core_bsa_recovery_snapshots = {}
+
+    SpectrumH3Runtime.start_run = start_run
+    SpectrumH3Runtime.begin_step = begin_step
+    SpectrumH3Runtime.finalize_step = finalize_step
+    SpectrumH3Runtime.abort_step = abort_step
+    SpectrumH3Runtime.create_rollback_snapshot = create_rollback_snapshot
+    SpectrumH3Runtime.restore_rollback_snapshot = restore_rollback_snapshot
+    SpectrumH3Runtime.end_run = end_run
+
+    _INSTALLED = True

--- a/comfyui_spectrum_h3/core_bsa_loader_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_loader_compat.py
@@ -1,0 +1,320 @@
+"""Resolve reviewed core BSA callables under ComfyUI's real builtin-node loader.
+
+ComfyUI loads builtin ``comfy_extras/nodes_*.py`` files through ``load_custom_node``
+using the file path stem as ``sys.modules`` key. Therefore the live core-BSA
+closures can belong to an absolute-path module instead of the canonical dotted
+``comfy_extras.nodes_sparse_attention`` import. Importing the canonical module
+then creates a second module instance whose function/class identities cannot prove
+the already-installed live patch.
+
+This compatibility layer preserves the existing canonical audit and adds one
+strict fallback for that real loader alias. The fallback accepts only the current
+ComfyUI checkout's reviewed ``comfy_extras/nodes_sparse_attention.py`` source,
+independently proves nested callable semantics from that on-disk source, and then
+runs the existing ownership/route audit against the exact live module instance.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from typing import Any
+
+import torch
+
+from . import core_bsa_compat, source_code_audit
+
+_BSA_FILE = "nodes_sparse_attention.py"
+_BSA_PARENT = "comfy_extras"
+_REQUIRED = (
+    "SparseAttnPatch",
+    "make_attention_override",
+    "make_h3_block_patch",
+    "HEAD_DIM",
+    "BLOCK_SIZE",
+    "PRODUCER_CHUNK",
+    "ck",
+)
+_ORIGINAL_LOOKS_LIKE = core_bsa_compat._looks_like_core_bsa_callable
+_ORIGINAL_PROBE = core_bsa_compat.probe
+_INSTALLED = False
+
+
+def _comfy_extras_dir() -> Path | None:
+    """Resolve the active ComfyUI root through a concrete ``comfy`` submodule.
+
+    ``comfy`` itself is a namespace package in current ComfyUI and therefore has
+    no reliable ``__file__``. ``comfy.model_management`` is an ordinary module
+    from the active checkout and gives us an unambiguous root without importing
+    the BSA file under a second name.
+    """
+    try:
+        import comfy.model_management as model_management
+
+        source = getattr(model_management, "__file__", None)
+        if not isinstance(source, str):
+            return None
+        root = Path(source).resolve().parent.parent
+        extras = (root / _BSA_PARENT).resolve()
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        return None
+    return extras
+
+
+def _reviewed_defaults(base: Any, owner: str, local_name: str) -> bool:
+    """Prove defaults that live outside a Python function's code object."""
+    defaults = getattr(base, "__defaults__", None)
+    kwdefaults = getattr(base, "__kwdefaults__", None)
+    if kwdefaults:
+        return False
+    if (owner, local_name) == ("make_attention_override", "override"):
+        return defaults == (None, None, False, False)
+    if (owner, local_name) == ("make_h3_block_patch", "block_patch"):
+        return defaults is None
+    return False
+
+
+def _runtime_module_from_callable(
+    function: Any,
+    owner: str,
+    local_name: str,
+) -> tuple[Any, str] | None:
+    base = getattr(function, "__func__", function)
+    if getattr(base, "__qualname__", None) != f"{owner}.<locals>.{local_name}":
+        return None
+    code = getattr(base, "__code__", None)
+    module_name = getattr(base, "__module__", None)
+    if not isinstance(code, types.CodeType) or not isinstance(module_name, str):
+        return None
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None
+    source = getattr(module, "__file__", None)
+    if not isinstance(source, str):
+        return None
+    try:
+        source_path = Path(source).resolve()
+        code_path = Path(code.co_filename).resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    extras = _comfy_extras_dir()
+    if (
+        extras is None
+        or source_path != code_path
+        or source_path.name != _BSA_FILE
+        or source_path.parent != extras
+    ):
+        return None
+    blob = core_bsa_compat._module_blob_sha(module)
+    if blob not in core_bsa_compat.AUDITED_BSA_GIT_BLOBS:
+        return None
+    if any(not hasattr(module, name) for name in _REQUIRED):
+        return None
+    try:
+        constants_ok = (
+            int(module.HEAD_DIM) == 128
+            and int(module.BLOCK_SIZE) == 64
+            and int(module.PRODUCER_CHUNK) == 4096
+        )
+    except (TypeError, ValueError):
+        return None
+    if not constants_ok:
+        return None
+    if not source_code_audit.matches_nested_source_code(
+        base,
+        source_path,
+        (owner, local_name),
+    ):
+        return None
+    if not _reviewed_defaults(base, owner, local_name):
+        return None
+    return module, blob
+
+
+def _looks_like_runtime_core_bsa_callable(function: Any, owner: str, local_name: str) -> bool:
+    # Preserve the canonical test/import path exactly. The loader-aware proof is
+    # an additive fallback, not a replacement for the already-reviewed contract.
+    if _ORIGINAL_LOOKS_LIKE(function, owner, local_name):
+        return True
+    return _runtime_module_from_callable(function, owner, local_name) is not None
+
+
+def _runtime_module_for_options(
+    options: dict[str, Any], model: Any
+) -> tuple[Any, str] | None:
+    blocks = getattr(model, "blocks", None)
+    if not isinstance(blocks, (tuple, list, torch.nn.ModuleList)) or not blocks:
+        return None
+    patches = options.get("patches_replace")
+    if not isinstance(patches, dict):
+        return None
+    dit = patches.get("dit")
+    if not isinstance(dit, dict):
+        return None
+
+    runtime_module = None
+    runtime_blob = None
+    for index in range(len(blocks)):
+        replacement = dit.get(("double_block", index))
+        resolved = _runtime_module_from_callable(
+            replacement,
+            "make_h3_block_patch",
+            "block_patch",
+        )
+        if resolved is None:
+            return None
+        module, blob = resolved
+        if runtime_module is None:
+            runtime_module, runtime_blob = module, blob
+        elif module is not runtime_module or blob != runtime_blob:
+            return None
+
+    override = options.get("optimized_attention_override")
+    resolved_override = _runtime_module_from_callable(
+        override,
+        "make_attention_override",
+        "override",
+    )
+    if resolved_override is None:
+        return None
+    module, blob = resolved_override
+    if module is not runtime_module or blob != runtime_blob:
+        return None
+    return runtime_module, runtime_blob
+
+
+def _runtime_alias_probe(
+    options: dict[str, Any], layout: Any, model: Any
+) -> tuple[core_bsa_compat.CoreBSAAudit | None, str | None]:
+    """Run the existing BSA audit against the actual path-loaded module instance."""
+    try:
+        resolved = _runtime_module_for_options(options, model)
+        if resolved is None:
+            return None, "ownership_unproven"
+        module, source_blob = resolved
+
+        ownership = core_bsa_compat._replacement_ownership(module, model, options)
+        if ownership is None:
+            return None, "ownership_unproven"
+        patch, ownership_identity = ownership
+        patch_generation = core_bsa_compat._lifetime_generation(patch)
+
+        normalized_layout = core_bsa_compat._normalize_layout(layout)
+        if normalized_layout is None:
+            return None, "layout_unproven"
+        seq_len, layout_identity = normalized_layout
+        uuids = core_bsa_compat._normalize_uuids(options)
+        if uuids is None:
+            return None, "uuids_unproven"
+        settings_identity = core_bsa_compat._settings_identity(patch)
+        execution_identity = core_bsa_compat._runtime_execution_identity(model)
+        if settings_identity is None or execution_identity is None:
+            return None, "execution_shape_unproven"
+        if settings_identity[0]:
+            return None, "vsa_unsupported"
+
+        try:
+            pool_specs = tuple(
+                (
+                    int(block.attn.heads),
+                    int(block.attn.head_dim),
+                    (
+                        str(block.attn.qkv_proj.weight.device)
+                        if torch.device(block.attn.qkv_proj.weight.device).type == "cuda"
+                        else None
+                    ),
+                )
+                for block in model.blocks
+            )
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            return None, "pool_shape_unproven"
+
+        sparse_runtime_ok = core_bsa_compat._sparse_runtime_eligible(model, module)
+        routed = core_bsa_compat._route_specs(
+            patch,
+            len(model.blocks),
+            seq_len,
+            uuids,
+            layout_identity,
+            options,
+            sparse_runtime_ok,
+            pool_specs,
+        )
+        if routed is None:
+            return None, "route_unproven"
+        route_specs, safe = routed
+        pool_ownership = core_bsa_compat._pool_ownership_identity(
+            patch,
+            len(model.blocks),
+            seq_len,
+            uuids,
+            pool_specs,
+        )
+        expected_receipts = tuple(
+            (
+                core_bsa_compat.ADAPTER_KEY,
+                core_bsa_compat.ADAPTER_VERSION,
+                patch_generation,
+                index,
+                route,
+                seq_len,
+                sink,
+                sink_q,
+            )
+            for index, (route, sink, sink_q) in enumerate(route_specs)
+        )
+        mode = "sol-attn" if settings_identity[2] == 0.0 else "sla"
+        identity = (
+            core_bsa_compat.ADAPTER_KEY,
+            core_bsa_compat.ADAPTER_VERSION,
+            source_blob,
+            patch_generation,
+            ("mode", mode),
+            ("settings", settings_identity),
+            ("layout", layout_identity),
+            ("uuids", core_bsa_compat._freeze(uuids)),
+            ("routes", route_specs),
+            ("pool_ownership", pool_ownership),
+            ("ownership", ownership_identity),
+            ("execution", execution_identity),
+        )
+        return core_bsa_compat.CoreBSAAudit(
+            identity=identity,
+            safe=bool(safe),
+            patch=patch,
+            patch_generation=patch_generation,
+            block_count=len(model.blocks),
+            seq_len=seq_len,
+            uuids=uuids,
+            layout_identity=layout_identity,
+            settings_identity=settings_identity,
+            route_specs=route_specs,
+            pool_specs=pool_specs,
+            expected_receipts=expected_receipts,
+            source_blob=source_blob,
+            current_override=options.get("optimized_attention_override"),
+        ), None
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - source/ownership introspection stays fail closed
+        return None, "adapter_introspection_failed"
+
+
+def _runtime_probe(
+    options: dict[str, Any], layout: Any, model: Any
+) -> tuple[core_bsa_compat.CoreBSAAudit | None, str | None]:
+    """Prefer the canonical audit; use the loader alias only for its ownership miss."""
+    audit, reason = _ORIGINAL_PROBE(options, layout, model)
+    if audit is not None or reason != "ownership_unproven":
+        return audit, reason
+    return _runtime_alias_probe(options, layout, model)
+
+
+def install_core_bsa_loader_compat() -> None:
+    """Install loader-aware BSA callable/module resolution once per process."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    core_bsa_compat._looks_like_core_bsa_callable = _looks_like_runtime_core_bsa_callable
+    core_bsa_compat.probe = _runtime_probe
+    _INSTALLED = True

--- a/comfyui_spectrum_h3/core_bsa_preprocess_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_preprocess_compat.py
@@ -1,0 +1,268 @@
+"""Bridge the reviewed Untwist attention preprocessor around core H3 BSA.
+
+Untwist v0.2.4 deliberately composes with an existing MiniMax-H3 attention
+provider through ``attention_preprocess_v1``. In the production stack this puts
+Untwist above core BlockSparseAttention at model-call time while BSA can itself
+sit below reviewed Flow block wrappers. The auditor therefore proves both
+wrapper layers before accepting backend history.
+
+This module does not accept arbitrary preprocess contracts. It recognizes only
+the reviewed Untwist source and requires Untwist's Spectrum runtime descriptor,
+then temporarily exposes the underlying BSA override to the source-gated
+BSA/Flow audit. Unknown preprocessors remain actual-only.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import torch
+
+from . import core_bsa_compat, core_bsa_flow_compat, source_code_audit
+
+AUDITED_UNTWIST_GIT_BLOBS = frozenset(
+    {"49a6eeda841a9dffe52974dceb3bce78bf02f25d"}
+)
+_UNTWIST_TOPLEVEL_MODULE = "flux_untwist.patches"
+_UNTWIST_MODULE_SUFFIX = ".flux_untwist.patches"
+_UNTWIST_FACTORY = "make_minimax_h3_attention_override"
+_UNTWIST_PREPROCESS_QUALNAME = (
+    "make_minimax_h3_attention_override.<locals>.preprocess"
+)
+_UNTWIST_PROVIDER = "comfyui-flux2-untwisting-rope"
+_UNTWIST_RUNTIME_KEY = "spectrum_h3_visual_reference_patch_runtime"
+_UNTWIST_CONFIG_KEY = "minimax_h3_untwist_rope"
+_MISSING = object()
+
+
+def _loaded_untwist_module(base: Any) -> Any | None:
+    """Resolve the reviewed source module under either test or ComfyUI package naming."""
+    module_name = getattr(base, "__module__", None)
+    if not isinstance(module_name, str):
+        return None
+    if module_name != _UNTWIST_TOPLEVEL_MODULE and not module_name.endswith(
+        _UNTWIST_MODULE_SUFFIX
+    ):
+        return None
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None
+    source = getattr(module, "__file__", None)
+    code = getattr(base, "__code__", None)
+    if not isinstance(source, str) or code is None:
+        return None
+    try:
+        source_path = Path(source).resolve()
+        code_path = Path(code.co_filename).resolve()
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    if (
+        source_path != code_path
+        or source_path.name != "patches.py"
+        or source_path.parent.name != "flux_untwist"
+    ):
+        return None
+    return module
+
+
+def _audited_untwist_preprocess(transform: Any) -> tuple[Any, ...] | None:
+    """Return a stable identity only for the exact reviewed Untwist preprocessor."""
+    base = getattr(transform, "__func__", transform)
+    if getattr(base, "__qualname__", None) != _UNTWIST_PREPROCESS_QUALNAME:
+        return None
+    module = _loaded_untwist_module(base)
+    if module is None:
+        return None
+    blob = core_bsa_compat._module_blob_sha(module)
+    if blob not in AUDITED_UNTWIST_GIT_BLOBS:
+        return None
+    source = getattr(module, "__file__", None)
+    if not isinstance(source, str) or not source_code_audit.matches_nested_source_code(
+        base,
+        Path(source),
+        (_UNTWIST_FACTORY, "preprocess"),
+    ):
+        return None
+    if getattr(base, "__defaults__", None) is not None:
+        return None
+    if getattr(base, "__kwdefaults__", None):
+        return None
+    closure = core_bsa_compat._closure_values(base)
+    if closure != {}:
+        return None
+    return ("untwist_h3_attention_preprocess_v1", blob)
+
+
+def _untwist_runtime_identity(options: dict[str, Any]) -> tuple[Any, ...] | None:
+    """Require the runtime descriptor Spectrum already uses to track Untwist."""
+    raw = options.get(_UNTWIST_RUNTIME_KEY)
+    if not isinstance(raw, (tuple, list)):
+        return None
+    active = []
+    for value in raw:
+        if not isinstance(value, dict) or value.get("provider") != _UNTWIST_PROVIDER:
+            continue
+        if value.get("active") is not True:
+            continue
+        schema = value.get("schema_version")
+        instance_id = value.get("instance_id")
+        progress = value.get("schedule_progress")
+        if (
+            isinstance(schema, bool)
+            or not isinstance(schema, int)
+            or schema not in {1, 2}
+            or not isinstance(instance_id, str)
+            or not instance_id
+            or isinstance(progress, bool)
+            or not isinstance(progress, (int, float))
+            or not 0.0 <= float(progress) <= 1.0
+        ):
+            return None
+        active.append((schema, instance_id))
+    if len(active) != 1:
+        return None
+
+    cfg = options.get(_UNTWIST_CONFIG_KEY)
+    if not isinstance(cfg, dict) or cfg.get("enabled") is not True:
+        return None
+    # Progress-dependent scaling is already represented by Spectrum's dedicated
+    # external-patch runtime contract. Keeping only the stable instance here avoids
+    # turning every smooth schedule point into a backend-history discontinuity.
+    return (_UNTWIST_PROVIDER, active[0][0], active[0][1])
+
+
+def _unwrap_reviewed_untwist(
+    options: dict[str, Any],
+) -> tuple[Any | None, tuple[Any, ...] | None, str | None]:
+    current = options.get("optimized_attention_override")
+    if core_bsa_compat._looks_like_core_bsa_callable(
+        current, "make_attention_override", "override"
+    ):
+        return current, None, None
+    if current is None:
+        return None, None, "ownership_unproven"
+
+    contract = getattr(current, "attention_preprocess_v1", _MISSING)
+    if not isinstance(contract, tuple) or len(contract) != 2:
+        return None, None, "ownership_unproven"
+    transform, previous = contract
+    preprocess_identity = _audited_untwist_preprocess(transform)
+    if preprocess_identity is None:
+        return None, None, "untwist_preprocess_unreviewed"
+    runtime_identity = _untwist_runtime_identity(options)
+    if runtime_identity is None:
+        return None, None, "untwist_runtime_unproven"
+    if not core_bsa_compat._looks_like_core_bsa_callable(
+        previous, "make_attention_override", "override"
+    ):
+        return None, None, "ownership_unproven"
+    return previous, (preprocess_identity, runtime_identity), None
+
+
+def _stabilize_flow_audit_identity(audit: Any) -> bool:
+    """Remove per-call object generations from reviewed dynamic Flow wrappers.
+
+    Mixed-Grid creates fresh wrapper functions, layout objects and plan objects on
+    each actual model invocation. Those addresses/generations prove the current
+    call's ownership but are not numerical backend semantics. Retaining them in
+    backend history would force a reset on every model call and suppress every
+    forecast. Exact source/code/closure proof remains in ``flow_wrapper_specs``
+    for the immediate receipt instrumentation; the retained policy uses only the
+    reviewed source, wrapper role/layer and structural carrier/mixed layouts.
+    """
+    raw = getattr(audit, "flow_identity", None)
+    if raw is None:
+        return True
+    if not isinstance(raw, tuple) or len(raw) != 5:
+        return False
+    if raw[0] != "reviewed_flow_h3_wrapper_chain_v1":
+        return False
+    mode, wrapper_specs, carrier_entry, mixed_entry = raw[1:]
+    if not isinstance(wrapper_specs, tuple):
+        return False
+
+    stable_blocks = []
+    for block in wrapper_specs:
+        if not isinstance(block, tuple):
+            return False
+        stable_chain = []
+        for item in block:
+            if not isinstance(item, tuple) or not item:
+                return False
+            if item[0] == "flow_layout_wrapper" and len(item) == 6:
+                stable_chain.append(item[:4])
+            elif item[0] == "flow_mixed_grid_wrapper" and len(item) == 8:
+                stable_chain.append((item[0], item[1], item[2], item[6], item[7]))
+            else:
+                return False
+        stable_blocks.append(tuple(stable_chain))
+
+    if (
+        not isinstance(carrier_entry, tuple)
+        or len(carrier_entry) != 2
+        or carrier_entry[0] != "carrier_layout"
+        or not isinstance(mixed_entry, tuple)
+        or len(mixed_entry) != 2
+        or mixed_entry[0] != "mixed_layout"
+    ):
+        return False
+    if mixed_entry[1] is None:
+        stable_mixed = mixed_entry
+    else:
+        payload = mixed_entry[1]
+        if not isinstance(payload, tuple) or len(payload) != 3:
+            return False
+        stable_mixed = ("mixed_layout", payload[2])
+
+    stable = (
+        raw[0],
+        mode,
+        tuple(stable_blocks),
+        carrier_entry,
+        stable_mixed,
+    )
+    expected_tail = ("outer_block_wrappers", raw)
+    identity = getattr(audit, "identity", None)
+    if not isinstance(identity, tuple) or not identity or identity[-1] != expected_tail:
+        return False
+    audit.identity = (*identity[:-1], ("outer_block_wrappers", stable))
+    audit.flow_identity = stable
+    return True
+
+
+def _probe_flow(options: dict[str, Any], layout: Any, model: Any):
+    audit, reason = core_bsa_flow_compat.probe(options, layout, model)
+    if audit is None:
+        return None, reason
+    if not _stabilize_flow_audit_identity(audit):
+        return None, "flow_identity_unproven"
+    return audit, None
+
+
+def probe(options: dict[str, Any], layout: Any, model: Any):
+    """Prove core BSA through reviewed Untwist and Flow composition."""
+    try:
+        real_override = options.get("optimized_attention_override")
+        bsa_override, preprocess_identity, reason = _unwrap_reviewed_untwist(options)
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - optional-provider introspection fails closed
+        return None, "untwist_introspection_failed"
+    if bsa_override is None:
+        return None, reason
+    if preprocess_identity is None:
+        return _probe_flow(options, layout, model)
+
+    normalized = dict(options)
+    normalized["optimized_attention_override"] = bsa_override
+    audit, reason = _probe_flow(normalized, layout, model)
+    if audit is None:
+        return None, reason
+
+    # Underlying BSA/Flow ownership and numerical route are now proven. Add only
+    # the stable reviewed Untwist owner, then restore the real call-time provider
+    # so receipt instrumentation still rejects a mid-forward owner change.
+    audit.identity = (*audit.identity, ("outer_preprocess", preprocess_identity))
+    audit.current_override = real_override
+    return audit, None

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -468,6 +468,8 @@ def _execute_actual(
         # second full target tensor on the GPU before the required CPU archive.
         target = hidden[aa:vb].unsqueeze(0)
         actual_target = target
+        from .bsa_transition_probe import hidden
+        hidden(target, target_segments(layout)[0][1] - aa)
         from .backend_history import observe
         resets_before = runtime.stats.backend_history_resets
         observe(runtime, run_id, step_id, local_options,
@@ -517,14 +519,21 @@ def _execute_actual(
         return output
 
     dit_replacements[("double_block", last_index)] = capture_replacement
-    result = executor(
-        x,
-        timestep,
-        context,
-        local_options,
-        minimax_payload=minimax_payload,
-        **kwargs,
-    )
+    from .bsa_transition_probe import actual_scope
+    with actual_scope(runtime, run_id, step_id, call_id, local_options) as diagnostic:
+        result = executor(
+            x,
+            timestep,
+            context,
+            local_options,
+            minimax_payload=minimax_payload,
+            **kwargs,
+        )
+        if diagnostic is not None:
+            from .core_bsa_compat import accepts_actual
+            diagnostic.complete(accepts_actual(
+                diagnostic.audit, tuple(local_options.get("attention_backend_receipts_v1", ()))
+            ))
     if not observed:
         raise RuntimeError("native MiniMax H3 final transformer block was not executed")
     if residual_probe is not None and actual_target is not None:

--- a/comfyui_spectrum_h3/runtime.py
+++ b/comfyui_spectrum_h3/runtime.py
@@ -1163,6 +1163,8 @@ class SpectrumH3Runtime:
             return
         if self._run.run_id != int(run_id):
             raise RuntimeError("attempted to end a stale Spectrum H3 run")
+        from .bsa_transition_probe import finish
+        finish(self)
         self._step = None
         self._run = None
         for forecaster in self._stage_forecasters.values():

--- a/comfyui_spectrum_h3/source_code_audit.py
+++ b/comfyui_spectrum_h3/source_code_audit.py
@@ -1,0 +1,117 @@
+"""Stable code fingerprints derived from reviewed on-disk Python source.
+
+Compatibility bridges already gate accepted modules by exact Git blob. This helper
+adds a second, independent proof for nested callables: compile the audited file
+without executing it, locate the expected lexical code path, and compare its
+behavioral code structure with the live callable. The comparison does not trust
+mutable bindings in ``sys.modules``.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+import sys
+import types
+from typing import Any
+
+
+def _constant_semantics(value: Any) -> Any:
+    if isinstance(value, types.CodeType):
+        return ("code", _code_semantics(value))
+    if isinstance(value, tuple):
+        return ("tuple", tuple(_constant_semantics(item) for item in value))
+    if isinstance(value, frozenset):
+        frozen = tuple(sorted((_constant_semantics(item) for item in value), key=repr))
+        return ("frozenset", frozen)
+    if value is None or isinstance(value, (bool, int, float, complex, str, bytes)):
+        return (type(value).__name__, value)
+    if value is Ellipsis:
+        return ("ellipsis",)
+    return (type(value).__module__, type(value).__qualname__, repr(value))
+
+
+def _code_semantics(code: types.CodeType) -> tuple[Any, ...]:
+    return (
+        code.co_name,
+        code.co_qualname,
+        code.co_argcount,
+        getattr(code, "co_posonlyargcount", 0),
+        code.co_kwonlyargcount,
+        code.co_nlocals,
+        code.co_stacksize,
+        code.co_flags,
+        code.co_code,
+        tuple(_constant_semantics(value) for value in code.co_consts),
+        code.co_names,
+        code.co_varnames,
+        code.co_freevars,
+        code.co_cellvars,
+        getattr(code, "co_exceptiontable", b""),
+    )
+
+
+def _direct_nested_code(parent: types.CodeType, name: str) -> types.CodeType | None:
+    matches = [
+        value
+        for value in parent.co_consts
+        if isinstance(value, types.CodeType) and value.co_name == name
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+@lru_cache(maxsize=32)
+def _reference_semantics(
+    path: str,
+    mtime_ns: int,
+    size: int,
+    lexical_path: tuple[str, ...],
+    optimize: int,
+) -> tuple[Any, ...] | None:
+    try:
+        data = Path(path).read_bytes()
+    except OSError:
+        return None
+    if len(data) != size:
+        return None
+    try:
+        current = compile(
+            data,
+            path,
+            "exec",
+            dont_inherit=True,
+            optimize=optimize,
+        )
+    except (SyntaxError, ValueError, TypeError):
+        return None
+    for name in lexical_path:
+        current = _direct_nested_code(current, name)
+        if current is None:
+            return None
+    return _code_semantics(current)
+
+
+def matches_nested_source_code(
+    function: Any,
+    source_path: Path,
+    lexical_path: tuple[str, ...],
+) -> bool:
+    """Compare a live callable with the nested code compiled from audited source."""
+    base = getattr(function, "__func__", function)
+    live_code = getattr(base, "__code__", None)
+    if not isinstance(live_code, types.CodeType) or not lexical_path:
+        return False
+    try:
+        resolved = source_path.resolve()
+        stat = resolved.stat()
+    except (OSError, RuntimeError):
+        return False
+    reference = _reference_semantics(
+        str(resolved),
+        int(stat.st_mtime_ns),
+        int(stat.st_size),
+        tuple(lexical_path),
+        int(sys.flags.optimize),
+    )
+    return reference is not None and _code_semantics(live_code) == reference

--- a/investigation/core-bsa-pool-transition.md
+++ b/investigation/core-bsa-pool-transition.md
@@ -1,0 +1,83 @@
+# Core-BSA pool transition investigation
+
+Status: investigation checkpoint only; no production implementation change. This file belongs to the development mirror and must not be consolidated into the implementation PR.
+
+## Revisions and evidence
+
+Spectrum PR #106 was re-fetched at 041b1de91779e59f9997d0b5ff5091c6929e37dc, one commit over be95adecec0b85c80d0c9fc5dd8d07386d50aaee. Its original head is preserved on checkpoint/core-bsa-before-pool-transition-20260910. Flow PR #26 remains unchanged at 860f308cc4f84f920d0c1facd4ece028584a02a0.
+
+Read the complete downloaded metrics_00343_.json, metrics_00317_.json and the relevant lines of Pasted text(20260910-030334).txt. Pasted text(20260910-025048).txt is downloaded but not used for conclusions.
+
+The metrics confirm:
+- 00343: 18 logical, 17 actual, 1 forecast; low 9A/1F, high 6A/0F, probe 2A.
+- 00317: 18 logical, 14 actual, 4 forecasts; low 8A/2F, high 4A/2F, probe 2A.
+
+The completed production log confirms 16 audited safe preflights and 15 accepted actual calls with receipts=50 expected=50. Five preflights have flow_mixed=True and seq_len=43557. Sparse stages retain two dense blocks and use 48 chunked sparse blocks. Do not summarize the first route entry alone: it is dense even during sparse stages.
+
+The counters establish the NFE difference; they do not by themselves establish identical seeds, settings, or decoded quality.
+
+## Pool semantics from exact comfy-kitchen v0.2.33
+
+Tag commit: e9ea99cf2f0af1d0c49c04690d4153a91c2b8668.
+
+Primary sources:
+- https://github.com/Comfy-Org/comfy-kitchen/blob/e9ea99cf2f0af1d0c49c04690d4153a91c2b8668/comfy_kitchen/backends/cuda/__init__.py
+- https://github.com/Comfy-Org/comfy-kitchen/blob/e9ea99cf2f0af1d0c49c04690d4153a91c2b8668/comfy_kitchen/backends/cuda/sage_attention/sol_attn_producer.cu
+- https://github.com/Comfy-Org/comfy-kitchen/blob/e9ea99cf2f0af1d0c49c04690d4153a91c2b8668/comfy_kitchen/backends/cuda/sage_attention/sol_layout.cuh
+- https://github.com/Comfy-Org/comfy-kitchen/blob/e9ea99cf2f0af1d0c49c04690d4153a91c2b8668/comfy_kitchen/backends/cuda/sage_attention/sol_attn_preprocess.cu
+- https://github.com/Comfy-Org/comfy-kitchen/blob/e9ea99cf2f0af1d0c49c04690d4153a91c2b8668/comfy_kitchen/backends/cuda/sage_attention/sol_attn.cu
+
+sol_attn_chunked cold execution traverses the QKV producer twice. The first traversal collects uncentered post-RoPE K sums and V absolute maxima; the second quantizes using those current-input statistics. Primed execution traverses once and uses the supplied statistics from the previous actual call.
+
+K centering changes the quantized carrier. In exact arithmetic subtracting one shared key vector leaves softmax unchanged, but this identity does not eliminate INT8 rounding error or prove equality of the sparse implementation.
+
+V scaling is directly numerical:
+    s = max(1e-8, 1.1 * previous_absmax / 127)
+    q = clamp(round_to_nearest_even(v / s), -127, 127)
+The core consumes the same supplied scale when using the quantized carriers. Values beyond the previous maximum's 10% headroom can clip. The next statistics are collected from current unquantized inputs, independently of the previous scales.
+
+These are calibration statistics, not an output cache and not merely an allocation optimization. Their continuous updates already occur within the primed identity. Consequently numerical dependence alone neither proves a hard cold/primed boundary necessary nor proves history carry safe.
+
+An accepted cold call initializes a plausible successor calibration state from its own input. That supports investigating a narrowly validated successor transition. It does not prove the accuracy of forecasting a different timestep. Even matched-input cold/reused-stat comparisons can differ slightly because Python and CUDA reduction orders for K means differ.
+
+Skipping a transformer also skips its statistics refresh. The subsequent actual then uses older calibration data. Validation must measure the subsequent actual as well as the proposed forecast. A same-input cold/primed comparison alone cannot establish this multi-step effect.
+
+The cold producer's second QKV traversal is real existing work but is not a second complete H3 transformer NFE.
+
+## Spectrum source trace and additional scheduler blocker
+
+core_bsa_compat.probe retains BOTH route_specs and pool_ownership in its identity. Cold to primed changes route names and replaces missing entries with tensor lifetime generations. Renaming the routes alone does not remove this boundary.
+
+runtime.prepare_backend_history clears history on identity change. runtime.observe_backend_history separately clears history on receipt change. A transition design must address both deliberately while continuing to verify original raw receipts.
+
+In runtime.py's existing decision chain, bootstrap_first_forecast requires:
+- non-state-conditioned residual mode;
+- degree == 1;
+- policy_step_id == 1;
+- exactly one history entry.
+
+The solver-owned bootstrap also requires policy_step_id == 1.
+
+Dense to sparse remains a required hard boundary under the task's safety constraints. Low step 2 therefore leaves only one sparse anchor. At low step 3, retaining that anchor across cold to primed still cannot satisfy either bootstrap clause. Normal fitting requires additional history.
+
+Executed the actual AST-extracted scheduler if/elif chain from the unmodified runtime.py with one retained history entry:
+- three-step stage, prefix 1, step 1: forecast, one-point bootstrap forecast;
+- five-step stage, prefix 0, step 3: actual, insufficient actual history;
+- five-step stage, prefix 2, step 3: actual, insufficient actual history.
+
+This is targeted execution of the existing decision code with scalar fixtures, not a full runtime or CUDA test.
+
+Conditional on an otherwise successful cold/primed carry implementation, unchanged scheduling can recover the two high-stage forecasts but cannot recover the missing low-stage forecast. The resulting upper bound from this change alone is 15A/3F, not 14A/4F.
+
+A generic bootstrap-after-every-backend-reset rule would expose step 3 in BOTH low stages, potentially producing 13A/5F. The requested 14A/4F therefore also requires a defensible scheduling rule that explains the different low-stage choices. Do not encode arbitrary stage/count exceptions to match the target.
+
+## Next bounded diagnostic and remaining gate
+
+Before changing production:
+1. At the candidate transition, retain cold-call calibration and capture actual primed execution on matched inputs. Compare cold versus supplied calibration to separate quantization differences from timestep differences.
+2. Measure the proposed hidden forecast against the actual next-timestep hidden output.
+3. Measure clipping/range headroom at the following actual when the intervening pool refresh is skipped. Preserve and restore owner pool state around diagnostic alternatives; diagnostics must not alter the control trajectory.
+4. Resolve low-stage scheduling explicitly, preserving dense-to-sparse boundaries, Continuum prefixes, final tails, and existing quality settings.
+5. Only then implement a narrowly source-gated transition with raw receipt validation and owner/layout/UUID/settings invalidation tests, and run the controlled production gate.
+
+No NVIDIA runtime is exposed in this workspace (nvidia-smi unavailable); default Python also lacks torch. No CUDA experiment or decoded quality comparison was performed. No claim of recovered NFEs or completed fix is supported. Neither PR was changed or merged.

--- a/investigation/scheduler-bootstrap-entitlement.md
+++ b/investigation/scheduler-bootstrap-entitlement.md
@@ -1,0 +1,82 @@
+# Deferred first-forecast bootstrap investigation
+
+Status: proposed scheduling rule for a development mirror. No production scheduler changes or numerical safety claim. This note addresses single-stage, non-state-conditioned runtime paths; solver-owned bootstrap and independent multistage histories require separate analysis.
+
+## Existing behavior
+
+`SpectrumH3Runtime.begin_step` orders forced execution, feedback refresh, Continuum prefix, sampler prefix, warmup, final tail, sampler exact steps/stages and stage refresh before bootstrap. Configured bootstrap requires degree one, non-state-conditioned residuals, exactly one retained actual anchor and `policy_step_id == 1`. Normal fitting follows bootstrap and requires `min_fit_points`.
+
+`sampling._continuum_actual_prefix` parses the explicit interop contract. `sampling._continuum_prefix_for_phase` preserves that prefix for sampling and first-pass execution; only offline replay receives zero. The prefix is an execution requirement, not scheduler credit.
+
+`SpectrumH3Runtime._reset_backend_history` clears feature histories, model-aware controllers, branch topology, consecutive forecasts and feedback state. It forces the current step actual. `prepare_backend_history` applies policy identity transitions; `observe_backend_history` independently applies receipt transitions. Consequently a cold-to-primed carry design must address both transitions while preserving raw receipt checks.
+
+`finalize_step` advances the adaptive window only for an eligible `adaptive_recompute` actual. Prefix and insufficient-history actuals do not advance it. Resetting feature history does not reset the adaptive window. Changing the window cannot make a one-anchor normal fit ready: the insufficient-history branch is evaluated first.
+
+After a required dense-to-sparse boundary, the first sparse actual supplies one sparse anchor. At the next step, preserving that anchor across a validated cold-to-primed successor would still fail the current bootstrap check whenever the policy step is greater than one.
+
+## Candidate rule
+
+Treat configured one-point bootstrap as permission to initialize the **first forecasting episode of a run**, deferred while actual execution is mandatory:
+
+1. Initialize one unused bootstrap entitlement at run start, only when the existing bootstrap configuration is valid.
+2. Keep all existing forced-execution, prefix, tail, sampler and feedback precedence checks.
+3. After those checks, allow a one-point hold when the entitlement is unused, exactly one compatible actual anchor exists, and the current path is the supported single-stage non-state-conditioned path. Require that anchor to belong to the current numerical backend segment and immediately preceding completed logical step. A current backend transition can still override the proposed forecast to actual.
+4. Retire the entitlement when **any forecast successfully commits**, including a normal fitted forecast. A later history reset never replenishes it.
+5. Keep post-forecast refresh and model-aware rejection rules effective. The entitlement is not a waiver for unsafe backend state, failed branch validation or incompatible layouts.
+
+This replaces the global step-one restriction for the scoped path with a lifecycle condition. It does not use desired NFE totals, resolution, native/mixed flags, stage length or chunk index. The current solver-owned bootstrap remains unchanged.
+
+The rule deliberately extends the existing scheduling policy. Permission for one-point hold at the start of a run does not prove equal accuracy later in denoising. The proposed forecast must be evaluated against the actual hidden output, with subsequent stale-calibration execution measured separately.
+
+## Conditional schedule derivation
+
+For the observed five-call low-stage structure, assume a hard dense-to-sparse boundary at logical step 2, a protected final step 4, no additional forced work, and numerically accepted sparse cold-to-primed carry:
+
+| Path | Step 0 | Step 1 | Step 2 | Step 3 | Step 4 |
+| --- | --- | --- | --- | --- | --- |
+| No two-step Continuum prefix | Actual anchor | Existing bootstrap; retire entitlement | Actual sparse boundary; clear dense history | Actual; entitlement already retired and only one sparse anchor | Actual tail |
+| Two-step Continuum prefix | Required actual | Required actual; entitlement unused | Actual sparse boundary; clear dense history | Deferred bootstrap from sparse anchor; retire entitlement | Actual tail |
+
+Thus exactly one additional low-stage forecast becomes eligible in this pair of paths. The two paths differ because only one has already executed its first forecast. This is a conditional source-level derivation, not a measured production schedule or guarantee of 14 actual / 4 forecast calls. Additional model-aware, interop or backend decisions can still require actual execution.
+
+The corresponding three-call high-stage sequence can retain its existing step-one bootstrap if the first anchor's cold-to-primed successor is accepted. Its final tail stays actual. This is separate from the low-stage scheduler extension.
+
+## Rejected shortcuts and counterexamples
+
+- Bootstrap after every history reset would add a second bootstrap to the first low path, changing more than the missing forecast and allowing repeated history resets to repeatedly authorize one-point holds.
+- Granting entitlement based on a Continuum flag hardcodes the motivating caller. The first-forecast lifecycle also explains an equivalent mandatory prefix supplied through another supported contract.
+- Retiring only after bootstrap leaves permission available after an ordinary fitted forecast. A later reset could then introduce an unrelated one-point forecast; retiring on any committed forecast prevents this.
+- Consuming permission at `begin_step` loses it on backend veto, incomplete conditional branches, retry or aborted execution. Consumption must occur after `finalize_step` validates the complete forecast transaction.
+- Reusing dense history to fit the first sparse forecast violates the numerical-backend boundary. Deferred bootstrap uses only the sparse anchor.
+- Increasing adaptive window credit cannot overcome the earlier history-readiness check and changes unrelated schedule decisions.
+- A long prefix that supplies two compatible anchors does not need one-point bootstrap. Normal fitting proceeds; its first committed forecast retires the entitlement.
+- A prefix extending into the tail produces no deferred bootstrap. An entitlement can expire unused.
+
+## Implementation and transaction constraints
+
+Store explicit run-local lifecycle state rather than deriving it from cumulative telemetry. `RuntimeRollbackSnapshot`, `create_rollback_snapshot` and `restore_rollback_snapshot` must preserve that state so discarded speculative forecasts do not permanently consume permission. `abort_step` and `prepare_actual_retry` must not consume it. `start_run` resets it; backend resets do not. Offline replay must not create new online bootstrap opportunities.
+
+If independent stage histories are later supported, define ownership per history lane and snapshot all lane state explicitly. Do not silently grant a global entitlement separately to every solver stage. Maintain current solver-owned state-conditioned bootstrap until its residual contract is independently extended and tested.
+
+## Focused test matrix
+
+Use the full runtime with actual branch transactions and backend prepare/receipt observation. Initial `begin_step` decisions alone are insufficient because backend checks can change the effective mode.
+
+| Case | Required result |
+| --- | --- |
+| Five-call low path, no prefix, hard boundary at 2 | Only existing bootstrap at 1; no new bootstrap at 3 |
+| Same path, explicit two-step prefix | Prefix 0 and 1 actual; boundary 2 actual; deferred bootstrap at 3; tail 4 actual |
+| Same paths with cold-to-primed carry unavailable | Backend veto remains actual; no unsafe forecast |
+| Repeated backend transitions after first committed forecast | No renewed entitlement |
+| Two-anchor prefix without backend transition | Ordinary fit; first fitted forecast retires entitlement |
+| Prefix/tail overlap, force-actual, warmup, sampler exact steps and refresh | Existing precedence preserved; permission can remain unused |
+| Bootstrap disabled or incompatible degree/configuration | Existing behavior preserved |
+| Missing, stale, wrong-layout or wrong-backend anchor | No deferred bootstrap |
+| Model-aware veto and unsafe receipt | Actual execution; entitlement not spent |
+| Incomplete branch set, retry and abort | No entitlement consumption before successful forecast commit |
+| Rollback before first forecast | Restore unused entitlement and original schedule |
+| Rollback after first forecast | Restore retired entitlement |
+| New run and offline replay | New online run initializes permission; replay does not consume or grant online permission |
+| Existing state-conditioned and multistage suites | Unchanged behavior for paths outside the initial scope |
+
+CPU transaction tests can establish these structural properties. Matched production shadow measurements and decoded output comparison are still needed to judge the numerical and perceptual consequences of the newly eligible hold.

--- a/tests/test_bsa_transition_probe.py
+++ b/tests/test_bsa_transition_probe.py
@@ -1,0 +1,217 @@
+from types import SimpleNamespace as N
+import json
+import random
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import bsa_transition_probe as probe
+
+
+def test_pool_transaction_restores_contents_keys_and_all_identities_in_inference_mode():
+    with torch.inference_mode():
+        entry = (torch.ones(2, 3), torch.full((2, 3), 2.0))
+        mapping = {("block",): entry}
+        patch = N(pooled=mapping)
+        with probe.isolated_pool(patch, torch.device("cpu")) as status:
+            entry[0].zero_()
+            patch.pooled = {"foreign": (torch.zeros(1, 1), torch.zeros(1, 1))}
+        assert status.pool_restored and status.rng_restored
+        assert patch.pooled is mapping
+        assert patch.pooled[("block",)] is entry
+        assert torch.equal(entry[0], torch.ones(2, 3))
+        assert torch.equal(entry[1], torch.full((2, 3), 2.0))
+
+
+@pytest.mark.parametrize("error", [RuntimeError, torch.cuda.OutOfMemoryError])
+def test_transaction_restores_rng_and_pool_when_shadow_raises(error):
+    patch = N(pooled={0: [torch.ones(1, 1), torch.ones(1, 1)]})
+    tensor = patch.pooled[0][0]
+    rng = torch.get_rng_state().clone()
+    python_rng = random.getstate()
+    with pytest.raises(error), probe.isolated_pool(patch, torch.device("cpu")):
+        tensor.zero_()
+        torch.rand(5)
+        random.random()
+        patch.pooled[1] = (tensor, tensor)
+        raise error("shadow failed")
+    assert torch.equal(torch.get_rng_state(), rng)
+    assert random.getstate() == python_rng
+    assert list(patch.pooled) == [0]
+    assert patch.pooled[0][0] is tensor and tensor.item() == 1
+
+
+def test_primary_oom_is_not_masked_by_restore_failure(monkeypatch):
+    patch = N(pooled={0: (torch.ones(1, 1), torch.ones(1, 1))})
+    original = probe.PoolSnapshot.restore
+
+    def broken_restore(self):
+        original(self)
+        raise RuntimeError("synthetic restore failure")
+
+    monkeypatch.setattr(probe.PoolSnapshot, "restore", broken_restore)
+    with (
+        pytest.raises(torch.cuda.OutOfMemoryError, match="primary oom") as caught,
+        probe.isolated_pool(patch, torch.device("cpu")),
+    ):
+        raise torch.cuda.OutOfMemoryError("primary oom")
+    assert any("synthetic restore failure" in note for note in getattr(caught.value, "__notes__", ()))
+
+
+def test_malformed_pool_fails_before_diagnostic_mutation():
+    patch = N(pooled={0: (None, torch.zeros(1, 1))})
+    with pytest.raises(ValueError, match="malformed"), probe.isolated_pool(patch, torch.device("cpu")):
+        pytest.fail("should never enter")
+
+
+def test_chunked_error_metrics_and_nonfinite():
+    ref = torch.arange(262150, dtype=torch.float64).reshape(2, -1)
+    report = probe.delta(ref, ref + 2)
+    assert report["rmse"] == 2
+    assert report["max_abs"] == 2
+    assert report["mae"] == 2
+    assert probe.delta(torch.ones(1), torch.tensor([float("nan")]))["finite"] is False
+    empty = probe.delta(torch.empty(0), torch.empty(0))
+    assert empty["finite"] and empty["elements"] == 0
+
+
+def _fixture(tmp_path):
+    config = N(bootstrap_first_forecast=True, degree=1)
+    p = probe.Probe(tmp_path, 1, config)
+    rt = N(config=config, stats=N(forecast_model_calls=0, actual_transformer_calls=0),
+           _run=N(min_actual_prefix_steps=2, state_conditioned_residual=False),
+           _step=N(policy_step_id=0))
+    patch = N(pooled={})
+
+    def audit(route, seq=4):
+        return N(identity=("source", ("layout", seq), ("routes", route),
+                           ("pool_ownership", "cold" if route.endswith("cold") else "live")),
+                 route_specs=((route, (0, 0), (0, 0)),), patch=patch,
+                 seq_len=seq, uuids=("positive",), block_count=1, flow_mixed=True,
+                 source_blob="reviewed-core-blob", patch_generation=7)
+    return p, rt, patch, audit
+
+
+def _complete_cold_anchor(p, rt, patch, audit, *, step=2):
+    key = (0, 4, ("positive",))
+    cold = probe.Actual(p, rt, step, 0, audit("h3_chunked_sparse_cold"))
+    patch.pooled[key] = (torch.ones(1, 2), torch.ones(1, 2))
+    cold.capture_hidden(torch.ones(1, 4, 2), 1)
+    cold.complete(True)
+    return key, patch.pooled[key]
+
+
+def test_candidate_and_next_actual_measurements_preserve_control(tmp_path):
+    p, rt, patch, audit = _fixture(tmp_path)
+    key, entry = _complete_cold_anchor(p, rt, patch, audit)
+    calls = []
+
+    def attention(h):
+        existing = patch.pooled.get(key)
+        scale = existing[1][0, 0].item() if existing is not None else 4.0
+        calls.append(scale)
+        if existing is None:
+            patch.pooled[key] = (torch.zeros(1, 2), torch.zeros(1, 2))
+        for tensor in patch.pooled[key]:
+            tensor.add_(1)
+        return h * scale
+
+    candidate = probe.Actual(p, rt, 3, 0, audit("h3_chunked_sparse_primed"))
+    assert candidate.candidate
+    assert candidate.predecessor_pool_continuity is True
+    candidate_wrapper = candidate.wrap_attention(attention, 0)
+    control = candidate_wrapper(torch.ones(4, 2))
+    assert calls == [1.0, 4.0]
+    assert torch.equal(control, torch.ones(4, 2))
+    assert patch.pooled[key] is entry and entry[1][0, 0] == 2
+    assert candidate.measurements[0]["pool_restored"] is True
+    assert candidate.measurements[0]["rng_restored"] is True
+    assert candidate.measurements[0]["diagnostic_transformer_nfe_delta"] == 0
+    assert candidate.measurements[0]["alternative_output_discarded"] is True
+    assert candidate.measurements[0]["alternative_supplied_calibration"] is None
+    candidate.capture_hidden(torch.full((1, 4, 2), 2.0), 1)
+    rt._step.policy_step_id = 3
+    candidate.complete(True)
+    next_call = probe.Actual(p, rt, 4, 0, audit("h3_chunked_sparse_primed"))
+    assert next_call.next_actual and not next_call.candidate
+    control = next_call.wrap_attention(attention, 0)(torch.ones(4, 2))
+    assert calls == [1, 4, 2, 1]
+    assert torch.equal(control, torch.full((4, 2), 2.0))
+    assert patch.pooled[key] is entry and entry[1][0, 0] == 3
+    assert next_call.measurements[0]["alternative_scale_headroom_exceeded_channels"] == 2
+    assert next_call.measurements[0]["alternative_supplied_calibration"] is not None
+    next_call.complete(True)
+    p.close()
+    events = [json.loads(line) for line in p.path.read_text().splitlines()]
+    assert len([e for e in events if e["event"] == "forecast_vs_actual"]) == 1
+    kinds = [m["measurement"] for e in events if e["event"] == "actual" for m in e["measurements"]]
+    assert kinds == ["cold_vs_primed", "skipped_refresh_next_actual"]
+    actual_events = [e for e in events if e["event"] == "actual"]
+    assert actual_events[0]["captured_cold_successor_blocks"] == 1
+    assert actual_events[1]["predecessor_pool_continuity"] is True
+    assert actual_events[0]["core_bsa_source_blob"] == "reviewed-core-blob"
+    assert actual_events[0]["patch_generation"] == 7
+    forecast_event = next(e for e in events if e["event"] == "forecast_vs_actual")
+    assert forecast_event["predecessor_pool_continuity"] is True
+    assert events[-1]["diagnostic_attention_calls_completed"] == 2
+    assert events[-1]["diagnostic_transformer_nfe"] == 0
+
+
+@pytest.mark.parametrize("change", ["layout", "nonadjacent", "owner", "dense"])
+def test_candidate_requires_adjacent_matching_cold_anchor(tmp_path, change):
+    p, rt, patch, audit = _fixture(tmp_path)
+    _complete_cold_anchor(p, rt, patch, audit)
+    a = audit("h3_dense" if change == "dense" else "h3_chunked_sparse_primed",
+              seq=5 if change == "layout" else 4)
+    if change == "owner":
+        a.identity += (("owner", "new"),)
+    next_call = probe.Actual(p, rt, 4 if change == "nonadjacent" else 3, 0, a)
+    assert not next_call.candidate
+    p.close()
+
+
+def test_candidate_rejects_replaced_pool_tensor_owners(tmp_path):
+    p, rt, patch, audit = _fixture(tmp_path)
+    key, entry = _complete_cold_anchor(p, rt, patch, audit)
+    patch.pooled[key] = tuple(tensor.clone() for tensor in entry)
+    candidate = probe.Actual(p, rt, 3, 0, audit("h3_chunked_sparse_primed"))
+    assert not candidate.candidate
+    assert candidate.predecessor_pool_continuity is False
+    assert candidate.predecessor_pool_mismatch_block == 0
+    assert candidate.predecessor_pool_mismatch_reason == "pool_tensor_owner_changed"
+    p.close()
+    events = [json.loads(line) for line in p.path.read_text().splitlines()]
+    skipped = [e for e in events if e["event"] == "skipped"]
+    assert skipped[-1]["reason"] == "cold_to_primed_pool_successor_discontinuity"
+    assert skipped[-1]["mismatch"] == "pool_tensor_owner_changed"
+
+
+def test_candidate_rejects_mutated_pool_tensor_contents(tmp_path):
+    p, rt, patch, audit = _fixture(tmp_path)
+    key, entry = _complete_cold_anchor(p, rt, patch, audit)
+    entry[0].add_(0.25)
+    assert patch.pooled[key] is entry
+    candidate = probe.Actual(p, rt, 3, 0, audit("h3_chunked_sparse_primed"))
+    assert not candidate.candidate
+    assert candidate.predecessor_pool_continuity is False
+    assert candidate.predecessor_pool_mismatch_block == 0
+    assert candidate.predecessor_pool_mismatch_reason == "pool_tensor_contents_changed"
+    p.close()
+
+
+def test_candidate_allows_new_container_with_same_pool_tensor_owners_and_bytes(tmp_path):
+    p, rt, patch, audit = _fixture(tmp_path)
+    key, entry = _complete_cold_anchor(p, rt, patch, audit)
+    patch.pooled[key] = [entry[0], entry[1]]
+    candidate = probe.Actual(p, rt, 3, 0, audit("h3_chunked_sparse_primed"))
+    assert candidate.candidate
+    assert candidate.predecessor_pool_continuity is True
+    p.close()
+
+
+def test_disabled_scope_and_attention_are_noops(monkeypatch):
+    monkeypatch.delenv(probe.ENV, raising=False)
+    function = lambda h: h
+    with probe.actual_scope(N(), 1, 0, 0, {}) as scope:
+        assert scope is None
+        assert probe.attention(function, N(), 0) is function

--- a/tests/test_bsa_transition_probe_activation.py
+++ b/tests/test_bsa_transition_probe_activation.py
@@ -1,0 +1,27 @@
+from comfyui_spectrum_h3 import bsa_transition_probe as probe
+
+
+def test_diagnostic_does_not_auto_enable_without_cuda(monkeypatch):
+    monkeypatch.delenv(probe.ENV, raising=False)
+    monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: False)
+    assert probe._diagnostic_directory(automatic=True) is None
+
+
+def test_diagnostic_no_longer_auto_enables_on_cuda_after_evidence(monkeypatch):
+    monkeypatch.delenv(probe.ENV, raising=False)
+    monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: True)
+    assert probe._diagnostic_directory(automatic=True) is None
+
+
+def test_explicit_directory_overrides_automatic_location(monkeypatch, tmp_path):
+    target = tmp_path / "custom-diagnostics"
+    monkeypatch.setenv(probe.ENV, str(target))
+    monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: False)
+    assert probe._diagnostic_directory(automatic=False) == target
+    assert probe._diagnostic_directory(automatic=True) == target
+
+
+def test_explicit_disable_beats_automatic_cuda_activation(monkeypatch):
+    monkeypatch.setenv(probe.ENV, "off")
+    monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: True)
+    assert probe._diagnostic_directory(automatic=True) is None

--- a/tests/test_bsa_transition_probe_kitchen_compat.py
+++ b/tests/test_bsa_transition_probe_kitchen_compat.py
@@ -1,0 +1,158 @@
+from types import ModuleType, SimpleNamespace as N
+import json
+
+import torch
+
+from comfyui_spectrum_h3 import bsa_transition_probe as probe
+from comfyui_spectrum_h3 import bsa_transition_probe_compat as compat
+
+
+def test_source_built_comfy_kitchen_is_not_rejected_by_version_or_blob(monkeypatch, tmp_path):
+    source = tmp_path / "cuda.py"
+    source.write_text("# locally built current comfy-kitchen source\n")
+    cuda = ModuleType("comfy_kitchen.backends.cuda")
+    cuda.__file__ = str(source)
+
+    def sol_attn_chunked(qkv_chunks, t, h, rope_freqs, qk_norm_weights, *, kmean=None, vscale=None):
+        return qkv_chunks, kmean, vscale
+
+    cuda.sol_attn_chunked = sol_attn_chunked
+    monkeypatch.setattr(compat.importlib.metadata, "version", lambda _name: "999.0.dev-current")
+    monkeypatch.setattr(compat.importlib, "import_module", lambda _name: cuda)
+
+    version, blob, signature = compat._source_provenance()
+    assert version == "999.0.dev-current"
+    assert blob is not None
+    assert "kmean" in signature and "vscale" in signature
+
+
+def test_missing_sol_attn_chunked_is_a_type_contract_error(monkeypatch):
+    cuda = ModuleType("comfy_kitchen.backends.cuda")
+    monkeypatch.setattr(compat.importlib.metadata, "version", lambda _name: "0.2.33")
+    monkeypatch.setattr(compat.importlib, "import_module", lambda _name: cuda)
+
+    try:
+        compat._source_provenance()
+    except TypeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("missing sol_attn_chunked must be rejected")
+    assert "sol_attn_chunked" in message
+
+
+def test_only_required_sol_attn_chunked_api_contract_is_enforced(monkeypatch):
+    cuda = ModuleType("comfy_kitchen.backends.cuda")
+
+    def sol_attn_chunked(qkv_chunks, t, h):
+        return qkv_chunks
+
+    cuda.sol_attn_chunked = sol_attn_chunked
+    monkeypatch.setattr(compat.importlib.metadata, "version", lambda _name: "0.2.33")
+    monkeypatch.setattr(compat.importlib, "import_module", lambda _name: cuda)
+
+    try:
+        compat._source_provenance()
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("missing calibration parameters must be rejected")
+    assert "kmean" in message and "vscale" in message
+
+
+def test_installed_probe_uses_compatibility_provenance_without_exact_build_pin(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(probe, "_diagnostic_directory", lambda **_kwargs: tmp_path)
+    monkeypatch.setattr(
+        compat,
+        "_source_provenance",
+        lambda: ("0.2.33+source", "different-current-source-blob", "(..., kmean=None, vscale=None)"),
+    )
+    runtime = N(_run=object(), config=N())
+
+    current = probe.get_probe(runtime, 17, automatic=True)
+    try:
+        assert current is not None
+        assert runtime._bsa_transition_probe[1] is current
+        record = current.path.read_text().splitlines()[1]
+        assert "different-current-source-blob" in record
+        assert "runtime_api_contract_not_exact_build_pin" in record
+    finally:
+        current.close()
+        runtime._bsa_transition_probe = None
+
+
+def test_one_jsonl_is_shared_by_all_runtime_segments_of_one_generation(monkeypatch, tmp_path):
+    compat._close_sinks()
+    monkeypatch.setattr(compat, "_execution_generation_id", lambda: "prompt-generation-123")
+    config = N()
+
+    first = probe.Probe(tmp_path, 1, config)
+    first.write("marker", segment="low")
+    first.close()
+    second = probe.Probe(tmp_path, 3, config)
+    second.write("marker", segment="high")
+    second.close()
+
+    try:
+        assert first.path == second.path
+        assert len(list(tmp_path.glob("bsa-*.jsonl"))) == 1
+        events = [json.loads(line) for line in first.path.read_text().splitlines()]
+        starts = [event for event in events if event["event"] == "start"]
+        assert len(starts) == 2
+        assert {event["run_id"] for event in starts} == {1, 3}
+        assert len({event["run_instance"] for event in starts}) == 2
+        assert all(event["schema_version"] == 4 for event in starts)
+        markers = [event["segment"] for event in events if event["event"] == "marker"]
+        assert markers == ["low", "high"]
+    finally:
+        compat._close_sinks()
+
+
+def test_new_prompt_generation_gets_a_new_jsonl(monkeypatch, tmp_path):
+    compat._close_sinks()
+    generation = ["prompt-a"]
+    monkeypatch.setattr(compat, "_execution_generation_id", lambda: generation[0])
+
+    first = probe.Probe(tmp_path, 1, N())
+    first.close()
+    generation[0] = "prompt-b"
+    second = probe.Probe(tmp_path, 1, N())
+    second.close()
+
+    try:
+        assert first.path != second.path
+        assert len(list(tmp_path.glob("bsa-*.jsonl"))) == 2
+    finally:
+        compat._close_sinks()
+
+
+def test_next_actual_measurement_can_cross_settings_identity_with_same_pool_owners(
+    monkeypatch, tmp_path
+):
+    compat._close_sinks()
+    monkeypatch.setattr(compat, "_execution_generation_id", lambda: None)
+    diagnostic = probe.Probe(tmp_path, 3, N())
+    entry = (torch.ones(1, 2), torch.ones(1, 2))
+    patch = N(pooled={(0, 4, ("positive",)): entry})
+    diagnostic.pending = {
+        "identity": ("settings", "previous"),
+        "step": 1,
+        "stale": {0: (entry, tuple(tensor.clone() for tensor in entry))},
+    }
+    runtime = N()
+    audit = N(
+        identity=("settings", "current"),
+        route_specs=(("h3_chunked_sparse_primed", (0, 0), (0, 0)),),
+        patch=patch,
+        seq_len=4,
+        uuids=("positive",),
+    )
+
+    try:
+        current = probe.Actual(diagnostic, runtime, 2, 0, audit)
+        assert current.next_actual is True
+        assert current.next_actual_identity_changed is True
+    finally:
+        diagnostic.close()
+        compat._close_sinks()

--- a/tests/test_bsa_transition_probe_manual.py
+++ b/tests/test_bsa_transition_probe_manual.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from comfyui_spectrum_h3 import bsa_transition_probe as probe
+
+
+def test_transition_probe_is_not_automatic_after_cuda_evidence(monkeypatch):
+    monkeypatch.delenv(probe.ENV, raising=False)
+    monkeypatch.setattr(probe.torch.cuda, "is_available", lambda: True)
+    assert probe._diagnostic_directory(automatic=True) is None
+
+
+def test_transition_probe_explicit_environment_override_still_works(monkeypatch, tmp_path):
+    monkeypatch.setenv(probe.ENV, str(tmp_path))
+    assert probe._diagnostic_directory(automatic=True) == Path(tmp_path)
+    assert probe._diagnostic_directory(automatic=False) == Path(tmp_path)
+
+
+def test_transition_probe_explicit_disable_still_wins(monkeypatch):
+    monkeypatch.setenv(probe.ENV, "off")
+    assert probe._diagnostic_directory(automatic=True) is None

--- a/tests/test_core_bsa_compat.py
+++ b/tests/test_core_bsa_compat.py
@@ -1,0 +1,554 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import core_bsa_compat
+from comfyui_spectrum_h3.backend_history import POLICIES, RECEIPTS, preflight
+
+
+class _FakeAttention:
+    def __init__(self, heads=2):
+        self.heads = heads
+        self.head_dim = 128
+        self.qkv_proj = SimpleNamespace(
+            weight=torch.empty(1, dtype=torch.bfloat16, device="cpu")
+        )
+
+    def forward(self, x, rope_freqs=None, transformer_options=None):
+        return x
+
+
+class _FakeBlock:
+    def __init__(self):
+        self.attn = _FakeAttention()
+
+
+class _FakeModel:
+    def __init__(self, count=2):
+        self.blocks = [_FakeBlock() for _ in range(count)]
+        self.dtype = torch.bfloat16
+
+
+def _audited_nodes():
+    try:
+        import comfy_extras.nodes_sparse_attention as nodes
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"core BSA is unavailable in this reviewed ComfyUI fixture: {exc}")
+    if core_bsa_compat._module_blob_sha(nodes) not in core_bsa_compat.AUDITED_BSA_GIT_BLOBS:
+        pytest.skip("this ComfyUI fixture is not the reviewed core BSA source")
+    return nodes
+
+
+def _layout(seq_len=128):
+    return SimpleNamespace(
+        seq_len=seq_len,
+        signature=(64, 1, 8, 8, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, seq_len, "video"),
+        ],
+    )
+
+
+def _installation(*, count=2, previous=None, sigma=1.0, uuids=("positive",)):
+    nodes = _audited_nodes()
+    model = _FakeModel(count)
+    patch = nodes.SparseAttnPatch(
+        tau=1.0,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=0,
+        verbose=False,
+    )
+    override = nodes.make_attention_override(patch, previous)
+    patch.installed.add(override)
+    dit = {
+        ("double_block", index): nodes.make_h3_block_patch(block, index, patch)
+        for index, block in enumerate(model.blocks)
+    }
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {"dit": dit},
+        "sigmas": torch.tensor([sigma]),
+        "uuids": uuids,
+    }
+    return nodes, model, patch, options
+
+
+def _actual_args(options, layout, seq_len):
+    call_options = dict(options)
+    call_options["minimax_h3_layout"] = layout
+    return {
+        "img": torch.zeros(seq_len, 4, dtype=torch.bfloat16),
+        "rope_freqs": torch.zeros(seq_len, 1),
+        "transformer_options": call_options,
+    }
+
+
+def test_reviewed_core_bsa_dense_route_is_structurally_recognized():
+    _nodes, model, _patch, options = _installation(sigma=1.0)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None
+    assert audit is not None
+    assert audit.safe
+    assert {spec[0] for spec in audit.route_specs} == {"h3_dense"}
+
+
+def test_structural_bsa_evidence_survives_missing_callback():
+    _nodes, model, _patch, options = _installation(sigma=1.0)
+    options["callbacks"] = {}
+    assert core_bsa_compat.has_core_bsa_evidence(options)
+    identity, safe = preflight(options, _layout(), model)
+    assert identity[0] == core_bsa_compat.ADAPTER_KEY
+    assert safe
+
+
+def test_structural_bsa_evidence_fails_closed_after_override_replacement():
+    _nodes, model, _patch, options = _installation(sigma=1.0)
+    options["callbacks"] = {}
+    options["optimized_attention_override"] = lambda *args, **kwargs: None
+    assert core_bsa_compat.has_core_bsa_evidence(options)
+    identity, safe = preflight(options, _layout(), model)
+    assert identity == ("core_bsa_unreported", "ownership_unproven")
+    assert not safe
+
+
+def test_explicit_provider_contract_keeps_precedence(monkeypatch):
+    class Provider:
+        def __call__(self, **_kwargs):
+            return ("explicit",)
+
+    def forbidden_probe(*_args, **_kwargs):
+        raise AssertionError("core BSA adapter must not run with an explicit provider")
+
+    monkeypatch.setattr(core_bsa_compat, "probe", forbidden_probe)
+    identity, safe = preflight({POLICIES: {"explicit": Provider()}}, None, None)
+    assert identity == (("explicit", ("explicit",)),)
+    assert safe
+
+
+def test_unreviewed_core_bsa_source_fails_closed(monkeypatch):
+    _nodes, model, _patch, options = _installation()
+    monkeypatch.setattr(core_bsa_compat, "_module_blob_sha", lambda _module: "unreviewed")
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "source_unreviewed"
+    identity, safe = preflight(options, _layout(), model)
+    assert identity == ("core_bsa_unreported", "source_unreviewed")
+    assert not safe
+
+
+def test_missing_or_foreign_h3_replacement_fails_closed():
+    _nodes, model, _patch, options = _installation()
+    options["patches_replace"]["dit"][("double_block", 1)] = lambda args, extra: extra[
+        "original_block"
+    ](args)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "ownership_unproven"
+
+
+def test_stacked_bsa_ownership_fails_closed():
+    nodes, model, first_patch, first_options = _installation()
+    first_override = first_options["optimized_attention_override"]
+    second_patch = nodes.SparseAttnPatch(
+        tau=1.0,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=0,
+        verbose=False,
+    )
+    second_override = nodes.make_attention_override(second_patch, first_override)
+    second_patch.installed.add(second_override)
+    options = dict(first_options)
+    options["optimized_attention_override"] = second_override
+    options["patches_replace"] = {
+        "dit": {
+            ("double_block", index): nodes.make_h3_block_patch(
+                block, index, second_patch
+            )
+            for index, block in enumerate(model.blocks)
+        }
+    }
+    assert first_patch is not second_patch
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "ownership_unproven"
+
+
+def test_inherited_attention_owner_change_changes_policy_identity():
+    nodes, model, patch, options = _installation(previous=lambda *args, **kwargs: None)
+    first, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and first is not None
+
+    def replacement_previous(*args, **kwargs):
+        return None
+
+    override = nodes.make_attention_override(patch, replacement_previous)
+    patch.installed.add(override)
+    options["optimized_attention_override"] = override
+    second, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and second is not None
+    assert first.identity != second.identity
+
+
+def test_lifetime_generation_and_callable_identity_are_stable_and_unique():
+    class Owner:
+        pass
+
+    first_owner = Owner()
+    second_owner = Owner()
+    first_generation = core_bsa_compat._lifetime_generation(first_owner)
+    assert first_generation == core_bsa_compat._lifetime_generation(first_owner)
+    assert first_generation != core_bsa_compat._lifetime_generation(second_owner)
+
+    def first_callable():
+        return None
+
+    def second_callable():
+        return None
+
+    first_identity = core_bsa_compat._callable_identity(first_callable)
+    assert first_identity == core_bsa_compat._callable_identity(first_callable)
+    assert first_identity != core_bsa_compat._callable_identity(second_callable)
+
+
+def test_execution_identity_ignores_transient_weight_residency():
+    model = _FakeModel(1)
+    first = core_bsa_compat._runtime_execution_identity(model)
+    model.blocks[0].attn.qkv_proj.weight = torch.empty(
+        1, dtype=torch.bfloat16, device="meta"
+    )
+    second = core_bsa_compat._runtime_execution_identity(model)
+    assert first == second
+
+
+def test_dense_sparse_and_cold_primed_transitions_change_identity(monkeypatch):
+    _nodes, model, patch, options = _installation(sigma=1.0)
+    dense, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and dense is not None
+
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    options["sigmas"] = torch.tensor([0.5])
+    cold, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and cold is not None and cold.safe
+    assert {spec[0] for spec in cold.route_specs} == {"h3_chunked_sparse_cold"}
+
+    for index, block in enumerate(model.blocks):
+        shape = (block.attn.heads, block.attn.head_dim)
+        patch.pooled[(index, 128, ("positive",))] = (
+            torch.zeros(shape, dtype=torch.float32),
+            torch.zeros(shape, dtype=torch.float32),
+        )
+    primed, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and primed is not None and primed.safe
+    assert {spec[0] for spec in primed.route_specs} == {
+        "h3_chunked_sparse_primed"
+    }
+    assert primed.expected_receipts[0][2] == primed.patch_generation
+    assert dense.identity != cold.identity
+    assert cold.identity != primed.identity
+
+
+def test_pool_tensor_replacement_changes_policy_identity(monkeypatch):
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    _nodes, model, patch, options = _installation(sigma=0.5, count=1)
+    shape = (model.blocks[0].attn.heads, model.blocks[0].attn.head_dim)
+    key = (0, 128, ("positive",))
+    patch.pooled[key] = (
+        torch.zeros(shape, dtype=torch.float32),
+        torch.zeros(shape, dtype=torch.float32),
+    )
+    first, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and first is not None and first.safe
+
+    patch.pooled[key] = (
+        torch.zeros(shape, dtype=torch.float32),
+        torch.zeros(shape, dtype=torch.float32),
+    )
+    second, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and second is not None and second.safe
+    assert first.identity != second.identity
+
+
+def test_layout_and_uuid_changes_change_policy_identity(monkeypatch):
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    _nodes, model, _patch, options = _installation(sigma=0.5)
+    first, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and first is not None
+
+    options["uuids"] = ("other",)
+    uuid_changed, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and uuid_changed is not None
+    assert first.identity != uuid_changed.identity
+
+    layout_changed = SimpleNamespace(
+        seq_len=192,
+        signature=(64, 1, 8, 16, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, 192, "video"),
+        ],
+    )
+    layout_identity, reason = core_bsa_compat.probe(options, layout_changed, model)
+    assert reason is None and layout_identity is not None
+    assert uuid_changed.identity != layout_identity.identity
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+def test_nonfinite_sigma_is_unproven(value):
+    assert core_bsa_compat._sigma_value({"sigmas": [value]}) is None
+
+
+def test_pool_transition_classifier_rejects_ambiguous_state():
+    patch = SimpleNamespace(pooled={})
+    key = (0, 128, ("positive",))
+    assert core_bsa_compat._classify_pool_transition(
+        core_bsa_compat._pool_entry(patch, key),
+        core_bsa_compat._pool_entry(patch, key),
+        sparse_selected=False,
+    ) == "h3_dense"
+
+    first = torch.zeros((2, 128), dtype=torch.float32)
+    second = torch.zeros((2, 128), dtype=torch.float32)
+    before = core_bsa_compat._pool_entry(patch, key)
+    patch.pooled[key] = (first, second)
+    after = core_bsa_compat._pool_entry(patch, key)
+    assert core_bsa_compat._classify_pool_transition(
+        before, after, sparse_selected=True
+    ) == "h3_chunked_sparse_cold"
+
+    before = core_bsa_compat._pool_entry(patch, key)
+    first.copy_(torch.ones_like(first))
+    second.copy_(torch.ones_like(second))
+    after = core_bsa_compat._pool_entry(patch, key)
+    assert core_bsa_compat._classify_pool_transition(
+        before, after, sparse_selected=True
+    ) == "h3_chunked_sparse_primed"
+    assert core_bsa_compat._classify_pool_transition(
+        before, after, sparse_selected=False
+    ) == "h3_dense"
+
+    before = after
+    patch.pooled[key] = (
+        torch.zeros_like(first),
+        torch.zeros_like(second),
+    )
+    replacement = core_bsa_compat._pool_entry(patch, key)
+    assert core_bsa_compat._classify_pool_transition(
+        before, replacement, sparse_selected=True
+    ) == "unknown"
+
+
+def test_pool_entry_accepts_inference_mode_tensors():
+    key = (0, 128, ("positive",))
+    with torch.inference_mode():
+        first = torch.zeros((2, 128), dtype=torch.float32)
+        second = torch.zeros((2, 128), dtype=torch.float32)
+    patch = SimpleNamespace(pooled={key: (first, second)})
+
+    with pytest.raises(RuntimeError, match="version counter"):
+        _ = first._version
+
+    state = core_bsa_compat._pool_entry(patch, key, (2, 128, None))
+    assert state[0] == "present"
+    assert state[1] is first
+    assert state[2] is second
+
+
+def test_actual_wrapper_observes_sparse_selection_without_version_counter(monkeypatch):
+    key = (0, 128, ("positive",))
+    with torch.inference_mode():
+        first = torch.zeros((2, 128), dtype=torch.float32)
+        second = torch.zeros((2, 128), dtype=torch.float32)
+    patch = SimpleNamespace(pooled={key: (first, second)})
+
+    def attention(*_args, **_kwargs):
+        return None
+
+    def replacement(args, extra):
+        return extra["original_block"]({**args, "attention": attention})
+
+    audit = SimpleNamespace(
+        seq_len=128,
+        uuids=("positive",),
+        patch=patch,
+        pool_specs=((2, 128, None),),
+        route_specs=(("h3_chunked_sparse_primed", (0, 0), (0, 0)),),
+        patch_generation=11,
+        failure=None,
+    )
+    monkeypatch.setattr(core_bsa_compat, "_current_route_matches", lambda *_args: True)
+    receipts = []
+    wrapped = core_bsa_compat._make_actual_wrapper(audit, 0, replacement, receipts)
+    output = wrapped(
+        {"img": torch.zeros(128, 4)},
+        {"original_block": lambda call_args: {"img": call_args["img"]}},
+    )
+
+    assert "img" in output
+    assert audit.failure is None
+    assert receipts == [
+        (
+            core_bsa_compat.ADAPTER_KEY,
+            core_bsa_compat.ADAPTER_VERSION,
+            11,
+            0,
+            "h3_chunked_sparse_primed",
+            128,
+            (0, 0),
+            (0, 0),
+        )
+    ]
+
+
+def test_main_block_audit_does_not_count_unrelated_attention():
+    _nodes, model, _patch, options = _installation(sigma=1.0, count=1)
+    layout = _layout()
+    audit, reason = core_bsa_compat.probe(options, layout, model)
+    assert reason is None and audit is not None
+
+    prepared = {**options, RECEIPTS: []}
+    prepared = core_bsa_compat.instrument_actual_options(prepared, audit, RECEIPTS)
+    receipts = prepared[RECEIPTS]
+
+    override = prepared["optimized_attention_override"]
+    q = torch.zeros(1, 4, 256, dtype=torch.bfloat16)
+    override(
+        lambda q, _k, _v, _heads, **_kwargs: q,
+        q,
+        q,
+        q,
+        2,
+        mask=torch.ones(1),
+        transformer_options={},
+    )
+    assert receipts == []
+
+    args = _actual_args(prepared, layout, 128)
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+    output = wrapped(args, {"original_block": lambda call_args: {"img": call_args["img"]}})
+    assert "img" in output
+    assert len(receipts) == 1
+    assert core_bsa_compat.accepts_actual(audit, tuple(receipts))
+
+
+def test_actual_route_mismatch_fails_receipt_acceptance(monkeypatch):
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    _nodes, model, _patch, options = _installation(sigma=0.5, count=1)
+    layout = _layout()
+    audit, reason = core_bsa_compat.probe(options, layout, model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.route_specs[0][0] == "h3_chunked_sparse_cold"
+
+    prepared = {**options, RECEIPTS: []}
+    prepared = core_bsa_compat.instrument_actual_options(prepared, audit, RECEIPTS)
+    args = _actual_args(prepared, layout, 128)
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+
+    # The fake H3 activation is on CPU, so the real reviewed BSA replacement
+    # declines its sparse producer. The Spectrum audit must observe dense rather
+    # than trusting the preflight prediction.
+    wrapped(args, {"original_block": lambda call_args: {"img": call_args["img"]}})
+    receipts = tuple(prepared[RECEIPTS])
+    assert receipts[0][4] == "h3_dense"
+    assert audit.failure == "actual_route_mismatch"
+    assert not core_bsa_compat.accepts_actual(audit, receipts)
+
+
+def test_adapter_propagates_cuda_oom_from_sigma_introspection():
+    class OOMSigmas:
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, _index):
+            raise torch.cuda.OutOfMemoryError("synthetic metadata OOM")
+
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        core_bsa_compat._sigma_value({"sigmas": OOMSigmas()})
+
+
+def test_invalid_pooled_shape_is_not_forecast_safe(monkeypatch):
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    _nodes, model, patch, options = _installation(sigma=0.5)
+    patch.pooled[(0, 128, ("positive",))] = (
+        torch.zeros((1, 128), dtype=torch.float32),
+        torch.zeros((1, 128), dtype=torch.float32),
+    )
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None
+    assert audit is not None
+    assert not audit.safe
+    assert audit.route_specs[0][0] == "h3_sparse_unproven"
+
+
+def test_vsa_remains_fail_closed():
+    _nodes, model, patch, options = _installation()
+    patch.vsa = True
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "vsa_unsupported"
+
+
+def test_actual_attention_owner_change_invalidates_receipt():
+    _nodes, model, _patch, options = _installation(sigma=1.0, count=1)
+    layout = _layout()
+    audit, reason = core_bsa_compat.probe(options, layout, model)
+    assert reason is None and audit is not None
+
+    prepared = {**options, RECEIPTS: []}
+    prepared = core_bsa_compat.instrument_actual_options(prepared, audit, RECEIPTS)
+    args = _actual_args(prepared, layout, 128)
+    args["transformer_options"]["optimized_attention_override"] = lambda *args, **kwargs: None
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+    wrapped(args, {"original_block": lambda call_args: {"img": call_args["img"]}})
+
+    assert audit.failure == "actual_route_mismatch"
+    assert not core_bsa_compat.accepts_actual(audit, tuple(prepared[RECEIPTS]))
+
+
+def test_midforward_attention_owner_change_is_revalidated_per_block():
+    _nodes, model, _patch, options = _installation(sigma=1.0, count=2)
+    layout = _layout()
+    audit, reason = core_bsa_compat.probe(options, layout, model)
+    assert reason is None and audit is not None
+
+    prepared = {**options, RECEIPTS: []}
+    prepared = core_bsa_compat.instrument_actual_options(prepared, audit, RECEIPTS)
+    args = _actual_args(prepared, layout, 128)
+    context = {"original_block": lambda call_args: {"img": call_args["img"]}}
+
+    first = prepared["patches_replace"]["dit"][("double_block", 0)]
+    first(args, context)
+    assert audit.failure is None
+
+    args["transformer_options"]["optimized_attention_override"] = lambda *args, **kwargs: None
+    second = prepared["patches_replace"]["dit"][("double_block", 1)]
+    second(args, context)
+
+    assert audit.failure == "actual_route_mismatch"
+    assert not core_bsa_compat.accepts_actual(audit, tuple(prepared[RECEIPTS]))

--- a/tests/test_core_bsa_flow_compat.py
+++ b/tests/test_core_bsa_flow_compat.py
@@ -1,0 +1,457 @@
+from types import SimpleNamespace
+import types
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import (
+    core_bsa_compat,
+    core_bsa_flow_compat,
+    core_bsa_preprocess_compat,
+)
+from comfyui_spectrum_h3.backend_history import BackendHistory, prepare, observe
+
+
+class _FakeAttention:
+    def __init__(self):
+        self.heads = 2
+        self.head_dim = 128
+        self.qkv_proj = SimpleNamespace(
+            weight=torch.empty(1, dtype=torch.bfloat16, device="cpu")
+        )
+
+    def forward(self, x, rope_freqs=None, transformer_options=None):
+        return x
+
+
+class _FakeBlock:
+    def __init__(self):
+        self.attn = _FakeAttention()
+
+
+class _FakeModel:
+    def __init__(self, count=2):
+        self.blocks = [_FakeBlock() for _ in range(count)]
+        self.dtype = torch.bfloat16
+
+
+class _EmptyForecaster:
+    history_length = 0
+
+
+class _BackendRuntime:
+    def __init__(self):
+        self.config = SimpleNamespace(debug=False)
+        self._backend_history = BackendHistory()
+        self._history_topology = None
+        self._history_labels = None
+        self._primary_forecaster = _EmptyForecaster()
+        self._stage_forecasters = {}
+        self._step = None
+        self._offline_archive = None
+        self._offline_smoother = None
+        self.prepared = None
+        self.observed = None
+
+    def prepare_backend_history(self, run_id, step_id, identity, safe):
+        self.prepared = (run_id, step_id, identity, bool(safe))
+
+    def observe_backend_history(self, run_id, step_id, identity, receipts, safe):
+        self.observed = (run_id, step_id, identity, receipts, bool(safe))
+
+
+def _audited_nodes():
+    try:
+        import comfy_extras.nodes_sparse_attention as nodes
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"core BSA fixture unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(nodes)
+        not in core_bsa_compat.AUDITED_BSA_GIT_BLOBS
+    ):
+        pytest.skip("ComfyUI fixture is not the reviewed core BSA source")
+    return nodes
+
+
+def _flow_modules():
+    try:
+        from h3_flow_regenerate import attention, mixed_grid
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"reviewed Flow fixture unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(attention)
+        not in core_bsa_flow_compat.AUDITED_FLOW_ATTENTION_GIT_BLOBS
+    ):
+        pytest.skip("Flow attention fixture is not the reviewed source")
+    if (
+        core_bsa_compat._module_blob_sha(mixed_grid)
+        not in core_bsa_flow_compat.AUDITED_FLOW_MIXED_GRID_GIT_BLOBS
+    ):
+        pytest.skip("Flow mixed-grid fixture is not the reviewed source")
+    return attention, mixed_grid
+
+
+def _layout(seq_len=128):
+    return SimpleNamespace(
+        seq_len=seq_len,
+        signature=(64, 8, 4, 4, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, seq_len, "video"),
+        ],
+    )
+
+
+def _mixed_layout():
+    positions = torch.zeros((140, 3), dtype=torch.float32)
+    return SimpleNamespace(
+        seq_len=140,
+        signature=("h3_flow_mixed_grid_v1", 64, 8, 4, 4, 16, 1, 8, 8),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, 140, "video"),
+        ],
+        position_ids=positions,
+    )
+
+
+def _installation(*, count=2, sigma=1.0):
+    nodes = _audited_nodes()
+    model = _FakeModel(count)
+    patch = nodes.SparseAttnPatch(
+        tau=1.3,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=64,
+        verbose=False,
+    )
+    override = nodes.make_attention_override(patch, None)
+    patch.installed.add(override)
+    replacements = {
+        ("double_block", index): nodes.make_h3_block_patch(block, index, patch)
+        for index, block in enumerate(model.blocks)
+    }
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {"dit": replacements},
+        "sigmas": torch.tensor([sigma]),
+        "uuids": ("positive",),
+    }
+    return model, patch, override, options
+
+
+def _wrap_layout(options, *, index=0):
+    attention, _mixed = _flow_modules()
+    from h3_flow_regenerate.metrics import H3FlowMetrics
+
+    out = dict(options)
+    patches = dict(options["patches_replace"])
+    dit = dict(patches["dit"])
+    previous = dit[("double_block", index)]
+    metrics = H3FlowMetrics()
+    wrapper = attention.make_layout_block_wrapper(index, metrics, previous)
+    wrapper = attention.mark_layout_wrapper(
+        wrapper,
+        metrics=metrics,
+        previous=previous,
+        scope="layout",
+    )
+    dit[("double_block", index)] = wrapper
+    patches["dit"] = dit
+    out["patches_replace"] = patches
+    return out, wrapper
+
+
+def _cell(value):
+    def close():
+        return value
+
+    return close.__closure__[0]
+
+
+def _rebind(wrapper, **changes):
+    values = core_bsa_compat._closure_values(wrapper)
+    assert isinstance(values, dict)
+    values.update(changes)
+    return types.FunctionType(
+        wrapper.__code__,
+        wrapper.__globals__,
+        name=wrapper.__name__,
+        closure=tuple(_cell(values[name]) for name in wrapper.__code__.co_freevars),
+    )
+
+
+def _mixed_shared(model, mixed):
+    _attention, mixed_module = _flow_modules()
+    from h3_flow_regenerate.metrics import H3FlowMetrics
+    import comfy.ldm.minimax.model as native
+
+    plan = mixed_module.MixedGridPlan(
+        prefix=torch.zeros(1, 24, 1, 8, 8),
+        temporal=8,
+        source_h=4,
+        source_w=4,
+        prefix_noise=torch.zeros(1, 24, 1, 8, 8),
+        attention_measure=False,
+    )
+    return {
+        "cached": {},
+        "inner": model,
+        "layout": _layout(),
+        "measure_contract": None,
+        "metrics": H3FlowMetrics(),
+        "mixed_layout": mixed,
+        "native": native,
+        "old_prefix": 4,
+        "plan": plan,
+        "positions": mixed.position_ids,
+        "va": 96,
+        "vb": 128,
+    }
+
+
+def _mixed_wrapper(previous, index, carrier, mixed, model, shared):
+    _attention, mixed_module = _flow_modules()
+    code = core_bsa_compat._nested_code(mixed_module.mixed_diffusion_wrapper, "call")
+    assert code is not None
+    values = {name: None for name in code.co_freevars}
+    values.update(shared)
+    values.update(layer=index, layout=carrier, previous=previous)
+    wrapper = types.FunctionType(
+        code,
+        mixed_module.__dict__,
+        name=code.co_name,
+        closure=tuple(_cell(values[name]) for name in code.co_freevars),
+    )
+    return wrapper
+
+
+def _wrap_mixed(options, model, *, include_all=True):
+    carrier = _layout()
+    mixed = _mixed_layout()
+    shared = _mixed_shared(model, mixed)
+    out = dict(options)
+    patches = dict(options["patches_replace"])
+    dit = dict(patches["dit"])
+    limit = len(model.blocks) if include_all else len(model.blocks) - 1
+    for index in range(limit):
+        dit[("double_block", index)] = _mixed_wrapper(
+            dit[("double_block", index)],
+            index,
+            carrier,
+            mixed,
+            model,
+            shared,
+        )
+    patches["dit"] = dit
+    out["patches_replace"] = patches
+    return out, carrier, mixed
+
+
+def _actual_args(options, layout, seq_len=None):
+    if seq_len is None:
+        seq_len = layout.seq_len
+    call_options = dict(options)
+    call_options["minimax_h3_layout"] = layout
+    return {
+        "img": torch.zeros(seq_len, 4, dtype=torch.bfloat16),
+        "rope_freqs": torch.zeros(seq_len, 1),
+        "transformer_options": call_options,
+    }
+
+
+def test_reviewed_flow_layout_wrapper_is_unwrapped_to_bsa():
+    model, _patch, _override, options = _installation()
+    options, wrapper = _wrap_layout(options)
+    audit, reason = core_bsa_flow_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.flow_mixed is False
+    assert audit.flow_outer_replacements[0] is wrapper
+    assert audit.route_specs[0][0] == "h3_dense"
+
+
+def test_unknown_outer_block_wrapper_stays_fail_closed():
+    model, _patch, _override, options = _installation()
+    previous = options["patches_replace"]["dit"][("double_block", 0)]
+
+    def foreign(args, extra):
+        return previous(args, extra)
+
+    options["patches_replace"]["dit"][("double_block", 0)] = foreign
+    audit, reason = core_bsa_flow_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "flow_wrapper_unreviewed"
+
+
+def test_reviewed_mixed_grid_wrapper_uses_propagated_layout_and_exact_kv_sinks(monkeypatch):
+    _attention, mixed_module = _flow_modules()
+    mixed_blob = core_bsa_compat._module_blob_sha(mixed_module)
+    if mixed_blob not in core_bsa_flow_compat._FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS:
+        pytest.skip("Flow fixture predates canonical Mixed-Grid layout propagation")
+
+    model, _patch, _override, options = _installation(sigma=0.5)
+    monkeypatch.setattr(
+        core_bsa_compat,
+        "_sparse_runtime_eligible",
+        lambda _model, _module: True,
+    )
+    options, carrier, _mixed = _wrap_mixed(options, model)
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+
+    assert reason is None and audit is not None and audit.safe
+    assert audit.flow_mixed is True
+    assert audit.flow_mixed_layout_propagated is True
+    assert audit.seq_len == 140
+    assert audit.flow_carrier_seq_len == 128
+    assert audit.flow_outer_seq_lens == (128, 140)
+    assert all(
+        spec == ("h3_chunked_sparse_cold", (0, 2), (0, 0))
+        for spec in audit.route_specs
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("inner", object()),
+        ("native", object()),
+        ("old_prefix", 5),
+        ("positions", torch.zeros((140, 3))),
+        ("va", 95),
+        ("vb", 127),
+        ("measure_contract", {"api": 999}),
+        ("cached", {"rope": object()}),
+    ],
+)
+def test_mixed_grid_behavior_closure_mismatch_stays_fail_closed(field, bad_value):
+    model, _patch, _override, options = _installation(count=1)
+    options, carrier, _mixed = _wrap_mixed(options, model)
+    key = ("double_block", 0)
+    replacement = options["patches_replace"]["dit"][key]
+    options["patches_replace"]["dit"][key] = _rebind(
+        replacement,
+        **{field: bad_value},
+    )
+
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert audit is None
+    assert reason == "flow_wrapper_unreviewed"
+
+
+def test_released_v033_effective_layout_preserves_its_zero_sink_semantics():
+    carrier = _layout()
+    mixed = _mixed_layout()
+    normalized_mixed = core_bsa_compat._normalize_layout(mixed)
+    assert normalized_mixed is not None
+    effective = core_bsa_flow_compat._effective_mixed_layout(
+        {
+            "source_blob": "8fc0f753ff2cd21fae898a4dd3c9ab1025f98443",
+            "mixed_seq": 140,
+            "mixed_identity": normalized_mixed[1],
+            "mixed_layout": mixed,
+        },
+        carrier,
+    )
+    normalized = core_bsa_compat._normalize_layout(effective)
+    assert normalized is not None
+    assert normalized[0] == 140
+    assert all(kind != "video" for _a, _b, kind in dict(normalized[1])["segments"])
+
+
+def test_mixed_grid_wrapper_must_cover_every_main_block():
+    model, _patch, _override, options = _installation()
+    options, carrier, _mixed = _wrap_mixed(options, model, include_all=False)
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert audit is None
+    assert reason == "flow_mixed_wrapper_incomplete"
+
+
+def test_flow_prepare_observe_round_trip_accepts_dense_route():
+    model, _patch, _override, options = _installation(count=1)
+    options, _wrapper = _wrap_layout(options)
+    layout = _layout()
+    runtime = _BackendRuntime()
+
+    prepared, pending = prepare(runtime, 9, 0, options, layout, model)
+    assert pending is not None
+    args = _actual_args(prepared, layout)
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+    wrapped(
+        args,
+        {"original_block": lambda call_args: {"img": call_args["img"]}},
+    )
+    observe(runtime, 9, 0, prepared, pending)
+
+    assert runtime.observed is not None
+    assert runtime.observed[-1] is True
+    receipts = runtime.observed[-2]
+    assert len(receipts) == 1
+    assert receipts[0][4] == "h3_dense"
+
+
+def test_flow_receipts_accept_inference_mode_pool_without_version_counter():
+    model, patch, _override, options = _installation(count=1)
+    layout = _layout()
+    with torch.inference_mode():
+        kmean = torch.zeros((2, 128), dtype=torch.float32)
+        vscale = torch.zeros((2, 128), dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="Inference tensors do not track version counter"):
+        _ = kmean._version
+    patch.pooled[(0, layout.seq_len, ("positive",))] = (kmean, vscale)
+
+    options, _wrapper = _wrap_layout(options)
+    runtime = _BackendRuntime()
+    prepared, pending = prepare(runtime, 10, 0, options, layout, model)
+    assert pending is not None
+    args = _actual_args(prepared, layout)
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+    wrapped(
+        args,
+        {"original_block": lambda call_args: {"img": call_args["img"]}},
+    )
+    observe(runtime, 10, 0, prepared, pending)
+
+    assert runtime.observed is not None
+    assert runtime.observed[-1] is True
+    receipts = runtime.observed[-2]
+    assert len(receipts) == 1
+    assert receipts[0][4] == "h3_dense"
+
+
+def test_untwist_plus_flow_wrapper_reaches_core_bsa_audit():
+    model, _patch, bsa_override, options = _installation()
+    options, _wrapper = _wrap_layout(options)
+    try:
+        from flux_untwist import patches as untwist_patches
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"reviewed Untwist fixture unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(untwist_patches)
+        not in core_bsa_preprocess_compat.AUDITED_UNTWIST_GIT_BLOBS
+    ):
+        pytest.skip("Untwist fixture is not the reviewed source")
+    outer = untwist_patches.make_minimax_h3_attention_override(bsa_override)
+    options["optimized_attention_override"] = outer
+    options["minimax_h3_untwist_rope"] = {"enabled": True, "progress": 0.5}
+    options["spectrum_h3_visual_reference_patch_runtime"] = (
+        {
+            "schema_version": 2,
+            "provider": "comfyui-flux2-untwisting-rope",
+            "instance_id": "untwist-h3-1",
+            "schedule_progress": 0.5,
+            "active": True,
+        },
+    )
+
+    audit, reason = core_bsa_preprocess_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.current_override is outer
+    assert hasattr(audit, "flow_wrapper_specs")

--- a/tests/test_core_bsa_flow_identity.py
+++ b/tests/test_core_bsa_flow_identity.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+from comfyui_spectrum_h3 import core_bsa_preprocess_compat
+
+
+def _raw_flow_identity(generation: int, *, mixed_signature=("mixed", 160)):
+    carrier = (
+        ("signature", (64, 1, 8, 8, 16)),
+        ("segments", ((0, 96, "conditioning"), (96, 128, "video"))),
+    )
+    mixed = (
+        ("signature", mixed_signature),
+        ("segments", ((0, 96, "conditioning"), (96, 160, "video"))),
+    )
+    return (
+        "reviewed_flow_h3_wrapper_chain_v1",
+        "mixed_grid_v0.3.3",
+        (
+            (
+                (
+                    "flow_mixed_grid_wrapper",
+                    "mixed-blob",
+                    0,
+                    ("module", "qualname", generation),
+                    generation + 10,
+                    generation + 20,
+                    carrier,
+                    mixed,
+                ),
+                (
+                    "flow_layout_wrapper",
+                    "attention-blob",
+                    "layout",
+                    0,
+                    ("module", "qualname", generation + 30),
+                    generation + 40,
+                ),
+            ),
+        ),
+        ("carrier_layout", carrier),
+        ("mixed_layout", (generation + 10, generation + 20, mixed)),
+    )
+
+
+def _audit(raw):
+    return SimpleNamespace(
+        flow_identity=raw,
+        identity=(
+            ("core", "stable"),
+            ("outer_block_wrappers", raw),
+        ),
+    )
+
+
+def test_recreated_dynamic_flow_wrappers_keep_same_backend_identity():
+    first = _audit(_raw_flow_identity(100))
+    second = _audit(_raw_flow_identity(900))
+
+    assert core_bsa_preprocess_compat._stabilize_flow_audit_identity(first)
+    assert core_bsa_preprocess_compat._stabilize_flow_audit_identity(second)
+    assert first.identity == second.identity
+    assert first.flow_identity == second.flow_identity
+
+
+def test_structural_mixed_layout_change_still_changes_backend_identity():
+    first = _audit(_raw_flow_identity(100, mixed_signature=("mixed", 160)))
+    second = _audit(_raw_flow_identity(900, mixed_signature=("mixed", 192)))
+
+    assert core_bsa_preprocess_compat._stabilize_flow_audit_identity(first)
+    assert core_bsa_preprocess_compat._stabilize_flow_audit_identity(second)
+    assert first.identity != second.identity
+
+
+def test_malformed_flow_identity_fails_closed():
+    audit = SimpleNamespace(
+        flow_identity=("reviewed_flow_h3_wrapper_chain_v1", "broken"),
+        identity=(("outer_block_wrappers", "broken"),),
+    )
+    assert not core_bsa_preprocess_compat._stabilize_flow_audit_identity(audit)

--- a/tests/test_core_bsa_forecast_recovery.py
+++ b/tests/test_core_bsa_forecast_recovery.py
@@ -1,0 +1,256 @@
+from types import SimpleNamespace as N
+
+import torch
+
+from comfyui_spectrum_h3 import core_bsa_compat
+from comfyui_spectrum_h3.backend_history import BackendHistory
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.core_bsa_forecast_recovery import (
+    _capture_transition_proof,
+    _prove_forecast_carry,
+)
+from comfyui_spectrum_h3.runtime import SpectrumH3Runtime
+
+
+TOPOLOGY = (
+    ("video", (1, 24, 2, 4, 4)),
+    ("audio", (1, 32, 2, 8)),
+    ("hidden", 4),
+    ("target_audio_rows", 1),
+    ("target_video_rows", 2),
+)
+LABEL = ((0, "positive"),)
+
+
+def _runtime(**overrides):
+    values = {
+        "degree": 1,
+        "max_history": 4,
+        "warmup_steps": 0,
+        "tail_actual_steps": 0,
+        "window_size": 2.0,
+        "bootstrap_first_forecast": True,
+        "offline_smoothing_replay": False,
+    }
+    values.update(overrides)
+    return SpectrumH3Runtime(SpectrumH3Config(**values))
+
+
+def _start(runtime, steps, **kwargs):
+    return runtime.start_run(
+        torch.linspace(1.0, 0.0, steps + 1),
+        "sample_res_multistep",
+        supported_sampler=True,
+        min_actual_steps_after_forecast=0,
+        **kwargs,
+    )
+
+
+def _complete(runtime, timestep, *, policy=None):
+    decision = runtime.begin_step(torch.tensor([timestep]))
+    if policy is not None:
+        runtime.prepare_backend_history(
+            decision["run_id"], decision["step_id"], policy, True
+        )
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=TOPOLOGY,
+        labels=LABEL,
+        expected_shape=(1, 3, 4),
+    )
+    if actual:
+        runtime.observe_actual(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            torch.full((1, 3, 4), float(decision["step_id"])),
+        )
+        if policy is not None:
+            runtime.observe_backend_history(
+                decision["run_id"],
+                decision["step_id"],
+                policy,
+                ("receipt", policy),
+                True,
+            )
+    else:
+        assert runtime.predict(
+            decision["run_id"],
+            decision["step_id"],
+            call_id,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        ) is not None
+    final_mode = runtime._step.mode
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    return decision, final_mode
+
+
+def test_real_runtime_consumes_entitlement_only_after_committed_forecast():
+    runtime = _runtime()
+    run_id = _start(runtime, 3)
+    _complete(runtime, 1.0)
+    decision, mode = _complete(runtime, 0.5)
+    assert decision["reason"] == "one-point bootstrap forecast"
+    assert mode == "forecast"
+    assert runtime._core_bsa_bootstrap_entitlement_unused is False
+    runtime.end_run(run_id)
+
+
+def test_real_runtime_defers_bootstrap_after_exact_prefix_and_backend_reset():
+    runtime = _runtime()
+    run_id = _start(runtime, 4, min_actual_prefix_steps=2)
+    _complete(runtime, 1.0, policy="dense")
+    second, mode = _complete(runtime, 0.75, policy="sparse-cold")
+    assert mode == "actual"
+    assert second["reason"] == "H3 Continuum actual prefix"
+    assert runtime.forecaster.latest_anchor_ids(1) == (1,)
+    assert runtime._core_bsa_bootstrap_entitlement_unused is True
+
+    decision, mode = _complete(runtime, 0.5, policy="sparse-cold")
+    assert decision["reason"] == "deferred one-point bootstrap forecast"
+    assert mode == "forecast"
+    assert runtime._core_bsa_bootstrap_entitlement_unused is False
+    runtime.end_run(run_id)
+
+
+def test_backend_vetoed_bootstrap_does_not_consume_entitlement():
+    runtime = _runtime()
+    run_id = _start(runtime, 4)
+    _complete(runtime, 1.0, policy="a")
+
+    decision = runtime.begin_step(torch.tensor([0.75]))
+    assert decision["actual"] is False
+    runtime.prepare_backend_history(
+        decision["run_id"], decision["step_id"], "b", True
+    )
+    assert runtime._step.mode == "actual"
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"],
+        decision["step_id"],
+        topology=TOPOLOGY,
+        labels=LABEL,
+        expected_shape=(1, 3, 4),
+    )
+    assert actual
+    runtime.observe_actual(
+        decision["run_id"], decision["step_id"], call_id, torch.ones(1, 3, 4)
+    )
+    runtime.observe_backend_history(
+        decision["run_id"], decision["step_id"], "b", ("receipt", "b"), True
+    )
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    assert runtime._core_bsa_bootstrap_entitlement_unused is True
+
+    deferred, mode = _complete(runtime, 0.5, policy="b")
+    assert deferred["reason"] == "deferred one-point bootstrap forecast"
+    assert mode == "forecast"
+    runtime.end_run(run_id)
+
+
+def test_rollback_restores_entitlement_state():
+    runtime = _runtime()
+    run_id = _start(runtime, 4)
+    _complete(runtime, 1.0)
+    snapshot = runtime.create_rollback_snapshot()
+    _complete(runtime, 0.75)
+    assert runtime._core_bsa_bootstrap_entitlement_unused is False
+    runtime.restore_rollback_snapshot(snapshot)
+    assert runtime._core_bsa_bootstrap_entitlement_unused is True
+    runtime.end_run(run_id)
+
+
+def _audit(route, patch, owners, *, identity_tail="same"):
+    routes = (
+        ("h3_dense", (0, 0), (0, 0)),
+        ("h3_dense", (0, 0), (0, 0)),
+        (route, (0, 1), (0, 0)),
+    )
+    identity = (
+        core_bsa_compat.ADAPTER_KEY,
+        core_bsa_compat.ADAPTER_VERSION,
+        "006d1eb352f946a7c85595edf75d3cda9ac79194",
+        17,
+        ("settings", (False, 1.0, 0.0)),
+        ("layout", ("layout", 1)),
+        ("routes", routes),
+        ("pool_ownership", ((0, "missing"), (1, "missing"), (2, *owners))),
+        ("ownership", identity_tail),
+    )
+    return N(
+        identity=identity,
+        safe=True,
+        patch=patch,
+        patch_generation=17,
+        block_count=3,
+        seq_len=64,
+        uuids=("u",),
+        layout_identity=("layout", 1),
+        settings_identity=(False, 1.0, 0.0),
+        route_specs=routes,
+        pool_specs=((1, 2, None), (1, 2, None), (1, 2, None)),
+        expected_receipts=(("r", 0), ("r", 1), ("r", 2)),
+        source_blob="006d1eb352f946a7c85595edf75d3cda9ac79194",
+    )
+
+
+def test_cold_to_primed_carry_requires_exact_adjacent_calibration_owners(monkeypatch):
+    kmean = torch.zeros(1, 2, dtype=torch.float32)
+    vscale = torch.ones(1, 2, dtype=torch.float32)
+    patch = N(pooled={(2, 64, ("u",)): (kmean, vscale)})
+    cold = _audit("h3_chunked_sparse_cold", patch, ("missing",))
+    primed = _audit("h3_chunked_sparse_primed", patch, (11, 12))
+    # Route/pool fields are intentionally the only semantic difference.
+    assert cold.identity != primed.identity
+
+    runtime = N(
+        _backend_history=BackendHistory(cold.identity, cold.expected_receipts, True),
+        _step=N(mode="actual"),
+        config=N(debug=False),
+    )
+    monkeypatch.setattr(core_bsa_compat, "accepts_actual", lambda *_args: True)
+    _capture_transition_proof(runtime, 4, 2, cold, cold.expected_receipts)
+    assert runtime._core_bsa_cold_successor_proof is not None
+
+    runtime._step.mode = "forecast"
+    assert _prove_forecast_carry(runtime, 4, 3, primed, primed.identity, True)
+    assert runtime._backend_history.policy == primed.identity
+    assert runtime._backend_history.receipt == cold.expected_receipts
+    assert runtime._core_bsa_cold_successor_proof is None
+
+
+def test_cold_to_primed_carry_rejects_replaced_calibration_owner(monkeypatch):
+    kmean = torch.zeros(1, 2, dtype=torch.float32)
+    vscale = torch.ones(1, 2, dtype=torch.float32)
+    patch = N(pooled={(2, 64, ("u",)): (kmean, vscale)})
+    cold = _audit("h3_chunked_sparse_cold", patch, ("missing",))
+    primed = _audit("h3_chunked_sparse_primed", patch, (11, 12))
+    runtime = N(
+        _backend_history=BackendHistory(cold.identity, cold.expected_receipts, True),
+        _step=N(mode="actual"),
+        config=N(debug=False),
+    )
+    monkeypatch.setattr(core_bsa_compat, "accepts_actual", lambda *_args: True)
+    _capture_transition_proof(runtime, 4, 2, cold, cold.expected_receipts)
+
+    patch.pooled[(2, 64, ("u",))] = (kmean.clone(), vscale)
+    runtime._step.mode = "forecast"
+    assert not _prove_forecast_carry(runtime, 4, 3, primed, primed.identity, True)
+    assert runtime._backend_history.policy == cold.identity
+
+
+def test_carry_is_not_used_for_actual_steps(monkeypatch):
+    kmean = torch.zeros(1, 2, dtype=torch.float32)
+    vscale = torch.ones(1, 2, dtype=torch.float32)
+    patch = N(pooled={(2, 64, ("u",)): (kmean, vscale)})
+    cold = _audit("h3_chunked_sparse_cold", patch, ("missing",))
+    primed = _audit("h3_chunked_sparse_primed", patch, (11, 12))
+    runtime = N(
+        _backend_history=BackendHistory(cold.identity, cold.expected_receipts, True),
+        _step=N(mode="actual"),
+        config=N(debug=False),
+    )
+    monkeypatch.setattr(core_bsa_compat, "accepts_actual", lambda *_args: True)
+    _capture_transition_proof(runtime, 4, 2, cold, cold.expected_receipts)
+    assert not _prove_forecast_carry(runtime, 4, 3, primed, primed.identity, True)

--- a/tests/test_core_bsa_loader_compat.py
+++ b/tests/test_core_bsa_loader_compat.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import core_bsa_compat, core_bsa_flow_compat
+
+
+class _FakeAttention:
+    def __init__(self):
+        self.heads = 2
+        self.head_dim = 128
+        self.qkv_proj = SimpleNamespace(
+            weight=torch.empty(1, dtype=torch.bfloat16, device="cpu")
+        )
+
+    def forward(self, x, rope_freqs=None, transformer_options=None):
+        return x
+
+
+class _FakeBlock:
+    def __init__(self):
+        self.attn = _FakeAttention()
+
+
+class _FakeModel:
+    def __init__(self, count=2):
+        self.blocks = [_FakeBlock() for _ in range(count)]
+        self.dtype = torch.bfloat16
+
+
+def _layout(seq_len=128):
+    return SimpleNamespace(
+        seq_len=seq_len,
+        signature=(64, 8, 4, 4, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, seq_len, "video"),
+        ],
+    )
+
+
+def _runtime_loaded_bsa(monkeypatch):
+    try:
+        import comfy_extras.nodes_sparse_attention as canonical
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"core BSA fixture unavailable: {exc}")
+    source = Path(canonical.__file__).resolve()
+    if core_bsa_compat._module_blob_sha(canonical) not in core_bsa_compat.AUDITED_BSA_GIT_BLOBS:
+        pytest.skip("ComfyUI fixture is not the reviewed core BSA source")
+
+    # Mirror ComfyUI nodes.load_custom_node for builtin extra-node files: the
+    # sys.modules key is the source path stem, not comfy_extras.<module>.
+    alias_name = str(source.with_suffix(""))
+    spec = importlib.util.spec_from_file_location(alias_name, source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, alias_name, module)
+    spec.loader.exec_module(module)
+    assert module.__name__ == alias_name
+    return module
+
+
+def _installation(module, *, count=2):
+    model = _FakeModel(count)
+    patch = module.SparseAttnPatch(
+        tau=1.3,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=64,
+        verbose=False,
+    )
+    override = module.make_attention_override(patch, None)
+    patch.installed.add(override)
+    replacements = {
+        ("double_block", index): module.make_h3_block_patch(block, index, patch)
+        for index, block in enumerate(model.blocks)
+    }
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {"dit": replacements},
+        # Outside BSA's sparse sigma window so CPU fixture availability is not
+        # part of this loader-identity regression.
+        "sigmas": torch.tensor([1.0]),
+        "uuids": ("positive",),
+    }
+    return model, patch, override, options
+
+
+def test_runtime_path_loaded_core_bsa_is_recognized(monkeypatch):
+    module = _runtime_loaded_bsa(monkeypatch)
+    model, patch, override, options = _installation(module)
+
+    replacement = options["patches_replace"]["dit"][("double_block", 0)]
+    assert replacement.__module__ == module.__name__
+    assert module.__name__ != "comfy_extras.nodes_sparse_attention"
+    assert core_bsa_compat._looks_like_core_bsa_callable(
+        replacement,
+        "make_h3_block_patch",
+        "block_patch",
+    )
+    assert core_bsa_compat._looks_like_core_bsa_callable(
+        override,
+        "make_attention_override",
+        "override",
+    )
+
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.patch is patch
+    assert all(spec[0] == "h3_dense" for spec in audit.route_specs)
+
+
+def test_runtime_path_loaded_bsa_under_reviewed_flow_wrapper(monkeypatch):
+    module = _runtime_loaded_bsa(monkeypatch)
+    model, patch, _override, options = _installation(module, count=1)
+    try:
+        from h3_flow_regenerate import attention
+        from h3_flow_regenerate.metrics import H3FlowMetrics
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"reviewed Flow fixture unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(attention)
+        not in core_bsa_flow_compat.AUDITED_FLOW_ATTENTION_GIT_BLOBS
+    ):
+        pytest.skip("Flow attention fixture is not the reviewed source")
+
+    key = ("double_block", 0)
+    previous = options["patches_replace"]["dit"][key]
+    metrics = H3FlowMetrics()
+    wrapper = attention.make_layout_block_wrapper(0, metrics, previous)
+    wrapper = attention.mark_layout_wrapper(
+        wrapper,
+        metrics=metrics,
+        previous=previous,
+        scope="layout",
+    )
+    options["patches_replace"]["dit"][key] = wrapper
+
+    audit, reason = core_bsa_flow_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.patch is patch
+    assert audit.flow_outer_replacements[0] is wrapper
+    assert audit.flow_bsa_replacements[0] is previous

--- a/tests/test_core_bsa_preprocess_compat.py
+++ b/tests/test_core_bsa_preprocess_compat.py
@@ -1,0 +1,380 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import core_bsa_compat, core_bsa_preprocess_compat
+from comfyui_spectrum_h3.backend_history import (
+    BackendHistory,
+    RECEIPTS,
+    observe,
+    preflight,
+    prepare,
+)
+
+
+class _FakeAttention:
+    def __init__(self):
+        self.heads = 2
+        self.head_dim = 128
+        self.qkv_proj = SimpleNamespace(
+            weight=torch.empty(1, dtype=torch.bfloat16, device="cpu")
+        )
+
+    def forward(self, x, rope_freqs=None, transformer_options=None):
+        return x
+
+
+class _FakeBlock:
+    def __init__(self):
+        self.attn = _FakeAttention()
+
+
+class _FakeModel:
+    def __init__(self, count=2):
+        self.blocks = [_FakeBlock() for _ in range(count)]
+        self.dtype = torch.bfloat16
+
+
+class _EmptyForecaster:
+    history_length = 0
+
+
+class _BackendRuntime:
+    def __init__(self):
+        self.config = SimpleNamespace(debug=False)
+        self._backend_history = BackendHistory()
+        self._history_topology = None
+        self._history_labels = None
+        self._primary_forecaster = _EmptyForecaster()
+        self._stage_forecasters = {}
+        self._step = None
+        self._offline_archive = None
+        self._offline_smoother = None
+        self.prepared = None
+        self.observed = None
+
+    def prepare_backend_history(self, run_id, step_id, identity, safe):
+        self.prepared = (run_id, step_id, identity, bool(safe))
+
+    def observe_backend_history(self, run_id, step_id, identity, receipts, safe):
+        self.observed = (run_id, step_id, identity, receipts, bool(safe))
+
+
+def _audited_nodes():
+    try:
+        import comfy_extras.nodes_sparse_attention as nodes
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"core BSA is unavailable in this reviewed ComfyUI fixture: {exc}")
+    if core_bsa_compat._module_blob_sha(nodes) not in core_bsa_compat.AUDITED_BSA_GIT_BLOBS:
+        pytest.skip("this ComfyUI fixture is not the reviewed core BSA source")
+    return nodes
+
+
+def _untwist_factory():
+    try:
+        from flux_untwist import patches
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"reviewed Untwist fixture is unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(patches)
+        not in core_bsa_preprocess_compat.AUDITED_UNTWIST_GIT_BLOBS
+    ):
+        pytest.skip("this Untwist fixture is not the reviewed v0.2.4 source")
+    return patches.make_minimax_h3_attention_override
+
+
+def _layout(seq_len=128):
+    return SimpleNamespace(
+        seq_len=seq_len,
+        signature=(64, 1, 8, 8, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, seq_len, "video"),
+        ],
+    )
+
+
+def _installation(*, count=2, sigma=1.0):
+    nodes = _audited_nodes()
+    model = _FakeModel(count)
+    patch = nodes.SparseAttnPatch(
+        tau=1.0,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=0,
+        verbose=False,
+    )
+    override = nodes.make_attention_override(patch, None)
+    patch.installed.add(override)
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {
+            "dit": {
+                ("double_block", index): nodes.make_h3_block_patch(block, index, patch)
+                for index, block in enumerate(model.blocks)
+            }
+        },
+        "sigmas": torch.tensor([sigma]),
+        "uuids": ("positive",),
+    }
+    return model, patch, override, options
+
+
+def _with_untwist(
+    options,
+    bsa_override,
+    *,
+    progress=0.5,
+    instance_id="untwist-h3-1",
+    active=True,
+):
+    outer = _untwist_factory()(bsa_override)
+    out = dict(options)
+    out["optimized_attention_override"] = outer
+    out["minimax_h3_untwist_rope"] = {"enabled": bool(active), "progress": float(progress)}
+    out["spectrum_h3_visual_reference_patch_runtime"] = (
+        {
+            "schema_version": 2,
+            "provider": "comfyui-flux2-untwisting-rope",
+            "instance_id": instance_id,
+            "schedule_progress": float(progress),
+            "active": bool(active),
+        },
+    )
+    return out, outer
+
+
+def _actual_args(options, layout, seq_len=128):
+    call_options = dict(options)
+    call_options["minimax_h3_layout"] = layout
+    return {
+        "img": torch.zeros(seq_len, 4, dtype=torch.bfloat16),
+        "rope_freqs": torch.zeros(seq_len, 1),
+        "transformer_options": call_options,
+    }
+
+
+def _run_prepared_dense_block(prepared, layout):
+    args = _actual_args(prepared, layout)
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+    wrapped(
+        args,
+        {"original_block": lambda call_args: {"img": call_args["img"]}},
+    )
+    return args
+
+
+def test_reviewed_untwist_wrapper_keeps_stable_backend_identity():
+    model, _patch, bsa_override, options = _installation()
+    first_options, first_outer = _with_untwist(options, bsa_override, progress=0.25)
+    first, reason = core_bsa_preprocess_compat.probe(first_options, _layout(), model)
+    assert reason is None and first is not None and first.safe
+    assert first.current_override is first_outer
+
+    second_options, second_outer = _with_untwist(options, bsa_override, progress=0.75)
+    assert second_outer is not first_outer
+    second, reason = core_bsa_preprocess_compat.probe(second_options, _layout(), model)
+    assert reason is None and second is not None and second.safe
+    assert second.current_override is second_outer
+    # Smooth Untwist schedule progress is handled by Spectrum's external-patch
+    # runtime contract, not by forcing a backend-history reset on every call.
+    assert first.identity == second.identity
+
+
+def test_comfy_loader_namespaced_untwist_module_is_accepted(monkeypatch):
+    model, _patch, bsa_override, options = _installation()
+    options, outer = _with_untwist(options, bsa_override)
+    transform, _previous = outer.attention_preprocess_v1
+    original_module_name = transform.__module__
+    module = sys.modules[original_module_name]
+    namespaced_module_name = (
+        "/home/toor/ComfyUI/custom_nodes/comfyui-untwisting-rope"
+        ".flux_untwist.patches"
+    )
+    monkeypatch.setitem(sys.modules, namespaced_module_name, module)
+    monkeypatch.setattr(transform, "__module__", namespaced_module_name)
+
+    audit, reason = core_bsa_preprocess_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.current_override is outer
+
+
+def test_backend_history_uses_reviewed_untwist_aware_core_bsa_probe():
+    model, _patch, bsa_override, options = _installation()
+    options, _outer = _with_untwist(options, bsa_override)
+    identity, safe = preflight(options, _layout(), model)
+    assert safe
+    assert identity[0] == core_bsa_compat.ADAPTER_KEY
+    assert identity[-1][0] == "outer_preprocess"
+
+
+def test_uncontracted_outer_attention_stays_fail_closed():
+    model, _patch, bsa_override, options = _installation()
+
+    def outer(*args, **kwargs):
+        return bsa_override(*args, **kwargs)
+
+    options["optimized_attention_override"] = outer
+    audit, reason = core_bsa_preprocess_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "ownership_unproven"
+
+
+def test_unknown_preprocess_contract_stays_fail_closed():
+    model, _patch, bsa_override, options = _installation()
+
+    def preprocess(q, k, v, heads, **kwargs):
+        return q, k, v
+
+    def outer(original, q, k, v, heads, *args, **kwargs):
+        return bsa_override(original, q, k, v, heads, *args, **kwargs)
+
+    outer.attention_preprocess_v1 = (preprocess, bsa_override)
+    options["optimized_attention_override"] = outer
+    audit, reason = core_bsa_preprocess_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "untwist_preprocess_unreviewed"
+
+
+def test_reviewed_untwist_requires_spectrum_runtime_descriptor():
+    model, _patch, bsa_override, options = _installation()
+    outer = _untwist_factory()(bsa_override)
+    options["optimized_attention_override"] = outer
+    options["minimax_h3_untwist_rope"] = {"enabled": True, "progress": 0.5}
+    audit, reason = core_bsa_preprocess_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "untwist_runtime_unproven"
+
+
+def test_inactive_untwist_runtime_stays_fail_closed_if_wrapper_is_present():
+    model, _patch, bsa_override, options = _installation()
+    options, _outer = _with_untwist(options, bsa_override, active=False)
+    audit, reason = core_bsa_preprocess_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "untwist_runtime_unproven"
+
+
+def test_untwist_instance_change_changes_backend_identity():
+    model, _patch, bsa_override, options = _installation()
+    first_options, _outer = _with_untwist(
+        options, bsa_override, instance_id="untwist-h3-1"
+    )
+    first, reason = core_bsa_preprocess_compat.probe(first_options, _layout(), model)
+    assert reason is None and first is not None
+
+    second_options, _outer = _with_untwist(
+        options, bsa_override, instance_id="untwist-h3-2"
+    )
+    second, reason = core_bsa_preprocess_compat.probe(second_options, _layout(), model)
+    assert reason is None and second is not None
+    assert first.identity != second.identity
+
+
+def test_dense_actual_receipt_accepts_real_untwist_owner():
+    model, _patch, bsa_override, options = _installation(count=1)
+    options, outer = _with_untwist(options, bsa_override)
+    layout = _layout()
+    audit, reason = core_bsa_preprocess_compat.probe(options, layout, model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.current_override is outer
+    assert audit.route_specs[0][0] == "h3_dense"
+
+    prepared = {**options, RECEIPTS: []}
+    prepared = core_bsa_compat.instrument_actual_options(prepared, audit, RECEIPTS)
+    output_args = _run_prepared_dense_block(prepared, layout)
+    assert output_args["img"].shape[0] == layout.seq_len
+    assert audit.failure is None
+    assert core_bsa_compat.accepts_actual(audit, tuple(prepared[RECEIPTS]))
+
+
+def test_midforward_untwist_owner_swap_invalidates_receipts():
+    model, _patch, bsa_override, options = _installation(count=2)
+    options, _outer = _with_untwist(options, bsa_override)
+    layout = _layout()
+    audit, reason = core_bsa_preprocess_compat.probe(options, layout, model)
+    assert reason is None and audit is not None
+
+    prepared = {**options, RECEIPTS: []}
+    prepared = core_bsa_compat.instrument_actual_options(prepared, audit, RECEIPTS)
+    args = _actual_args(prepared, layout)
+    context = {"original_block": lambda call_args: {"img": call_args["img"]}}
+
+    first = prepared["patches_replace"]["dit"][("double_block", 0)]
+    first(args, context)
+    assert audit.failure is None
+
+    replacement_options, replacement_outer = _with_untwist(options, bsa_override)
+    assert replacement_outer is not audit.current_override
+    args["transformer_options"]["optimized_attention_override"] = replacement_options[
+        "optimized_attention_override"
+    ]
+    second = prepared["patches_replace"]["dit"][("double_block", 1)]
+    second(args, context)
+    assert audit.failure == "actual_route_mismatch"
+    assert not core_bsa_compat.accepts_actual(audit, tuple(prepared[RECEIPTS]))
+
+
+def test_untwist_introspection_failure_is_actual_only(monkeypatch):
+    def fail(_options):
+        raise RuntimeError("introspection exploded")
+
+    monkeypatch.setattr(core_bsa_preprocess_compat, "_unwrap_reviewed_untwist", fail)
+    audit, reason = core_bsa_preprocess_compat.probe({}, None, None)
+    assert audit is None
+    assert reason == "untwist_introspection_failed"
+
+
+def test_untwist_introspection_oom_propagates(monkeypatch):
+    def fail(_options):
+        raise torch.cuda.OutOfMemoryError("oom")
+
+    monkeypatch.setattr(core_bsa_preprocess_compat, "_unwrap_reviewed_untwist", fail)
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        core_bsa_preprocess_compat.probe({}, None, None)
+
+
+def test_backend_prepare_observe_round_trip_accepts_untwist_bsa():
+    model, _patch, bsa_override, options = _installation(count=1)
+    options, _outer = _with_untwist(options, bsa_override)
+    layout = _layout()
+    runtime = _BackendRuntime()
+
+    prepared, pending = prepare(runtime, 7, 3, options, layout, model)
+    assert pending is not None
+    assert core_bsa_compat.PRIVATE_AUDIT_KEY in prepared
+    _run_prepared_dense_block(prepared, layout)
+    observe(runtime, 7, 3, prepared, pending)
+
+    assert runtime.observed is not None
+    assert runtime.observed[-1] is True
+    assert len(runtime.observed[-2]) == 1
+
+
+def test_backend_prepare_observe_round_trip_rejects_owner_change():
+    model, _patch, bsa_override, options = _installation(count=1)
+    options, _outer = _with_untwist(options, bsa_override)
+    layout = _layout()
+    runtime = _BackendRuntime()
+
+    prepared, pending = prepare(runtime, 7, 4, options, layout, model)
+    assert pending is not None
+    args = _actual_args(prepared, layout)
+    args["transformer_options"]["optimized_attention_override"] = object()
+    wrapped = prepared["patches_replace"]["dit"][("double_block", 0)]
+    wrapped(
+        args,
+        {"original_block": lambda call_args: {"img": call_args["img"]}},
+    )
+    observe(runtime, 7, 4, prepared, pending)
+
+    assert runtime.observed is not None
+    assert runtime.observed[-1] is False

--- a/tests/test_core_bsa_source_hardening.py
+++ b/tests/test_core_bsa_source_hardening.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+
+from comfyui_spectrum_h3 import core_bsa_compat, core_bsa_preprocess_compat
+
+
+def _audited_untwist_module():
+    try:
+        from flux_untwist import patches
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"reviewed Untwist fixture unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(patches)
+        not in core_bsa_preprocess_compat.AUDITED_UNTWIST_GIT_BLOBS
+    ):
+        pytest.skip("Untwist fixture is not the reviewed source")
+    return patches
+
+
+def test_untwist_code_proof_does_not_trust_replaced_factory_binding(monkeypatch):
+    patches = _audited_untwist_module()
+    original_factory = patches.make_minimax_h3_attention_override
+    real_outer = original_factory(None)
+    real_transform, _previous = real_outer.attention_preprocess_v1
+    assert core_bsa_preprocess_compat._audited_untwist_preprocess(real_transform) is not None
+
+    source_path = str(Path(patches.__file__).resolve())
+    malicious_source = """
+def make_minimax_h3_attention_override(previous):
+    def preprocess(q, k, v, heads, **kwargs):
+        return q * 2, k, v
+    return preprocess
+"""
+    namespace = {"__name__": patches.__name__}
+    exec(compile(malicious_source, source_path, "exec"), namespace)  # noqa: S102 - intentional synthetic source
+    fake_factory = namespace["make_minimax_h3_attention_override"]
+    fake_transform = fake_factory(None)
+
+    # The old proof derived its expected nested code from this mutable module
+    # binding and could therefore accept a coordinated factory+transform swap.
+    monkeypatch.setattr(patches, "make_minimax_h3_attention_override", fake_factory)
+    assert fake_transform.__module__ == patches.__name__
+    assert fake_transform.__qualname__ == real_transform.__qualname__
+    assert Path(fake_transform.__code__.co_filename).resolve() == Path(patches.__file__).resolve()
+
+    assert core_bsa_preprocess_compat._audited_untwist_preprocess(fake_transform) is None

--- a/tests/test_reviewed_bsa_fixture_gate.py
+++ b/tests/test_reviewed_bsa_fixture_gate.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+
+from comfyui_spectrum_h3 import (
+    core_bsa_compat,
+    core_bsa_flow_compat,
+    core_bsa_preprocess_compat,
+)
+
+
+def _required() -> bool:
+    return os.environ.get("SPECTRUM_REQUIRE_REVIEWED_BSA_FIXTURE") == "1"
+
+
+def test_required_reviewed_bsa_untwist_and_flow_fixtures_are_real():
+    if not _required():
+        pytest.skip("reviewed BSA/Untwist/Flow fixture gate is enabled only for the pinned CI lane")
+
+    try:
+        import comfy_extras.nodes_sparse_attention as nodes
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"required reviewed core BSA fixture could not import: {exc}")
+
+    bsa_blob = core_bsa_compat._module_blob_sha(nodes)
+    assert bsa_blob in core_bsa_compat.AUDITED_BSA_GIT_BLOBS, (
+        f"required reviewed core BSA fixture digest mismatch: {bsa_blob}"
+    )
+
+    try:
+        from flux_untwist import patches
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"required reviewed Untwist fixture could not import: {exc}")
+
+    untwist_blob = core_bsa_compat._module_blob_sha(patches)
+    assert untwist_blob in core_bsa_preprocess_compat.AUDITED_UNTWIST_GIT_BLOBS, (
+        f"required reviewed Untwist fixture digest mismatch: {untwist_blob}"
+    )
+
+    try:
+        from h3_flow_regenerate import attention, mixed_grid
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"required reviewed Flow fixture could not import: {exc}")
+
+    attention_blob = core_bsa_compat._module_blob_sha(attention)
+    assert attention_blob in core_bsa_flow_compat.AUDITED_FLOW_ATTENTION_GIT_BLOBS, (
+        f"required reviewed Flow attention fixture digest mismatch: {attention_blob}"
+    )
+    mixed_blob = core_bsa_compat._module_blob_sha(mixed_grid)
+    assert mixed_blob in core_bsa_flow_compat.AUDITED_FLOW_MIXED_GRID_GIT_BLOBS, (
+        f"required reviewed Flow mixed-grid fixture digest mismatch: {mixed_blob}"
+    )

--- a/tests/test_scheduler_bootstrap_entitlement.py
+++ b/tests/test_scheduler_bootstrap_entitlement.py
@@ -1,0 +1,359 @@
+"""Focused prototype tests for deferred first-successful-forecast entitlement.
+
+This intentionally exercises SpectrumH3Runtime's real decision/finalization chain while
+keeping the proposed scheduler policy test-local until BSA transition diagnostics justify
+production history carry.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3.config import SpectrumH3Config
+from comfyui_spectrum_h3.runtime import SolverCallDescriptor, SpectrumH3Runtime
+
+TOPOLOGY = (
+    ("video", (1, 24, 2, 4, 4)),
+    ("audio", (1, 32, 2, 8)),
+    ("hidden", 4),
+    ("target_audio_rows", 1),
+    ("target_video_rows", 2),
+)
+LABEL = ((0, "positive"),)
+
+
+class EntitlementRuntime(SpectrumH3Runtime):
+    """Test-only prototype of the proposed run-local entitlement semantics."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._bootstrap_entitlement_unused = False
+        self._entitlement_snapshots = {}
+
+    def start_run(self, *args, **kwargs):
+        run_id = super().start_run(*args, **kwargs)
+        self._bootstrap_entitlement_unused = bool(self.config.bootstrap_first_forecast)
+        self._entitlement_snapshots.clear()
+        return run_id
+
+    def begin_step(self, timestep):
+        decision = super().begin_step(timestep)
+        step = self._step
+        run = self._run
+        previous_anchor = (
+            self.forecaster.latest_anchor_ids(1) == (self._last_completed_step_id,)
+            if self._last_completed_step_id is not None
+            else False
+        )
+        if (
+            decision["actual"]
+            and decision["reason"] == "insufficient actual history"
+            and self._bootstrap_entitlement_unused
+            and self.config.bootstrap_first_forecast
+            and self.config.degree == 1
+            and run is not None
+            and not run.state_conditioned_residual
+            and not run.separate_stage_histories
+            and self.offline_phase is None
+            and self.forecaster.history_length == 1
+            and self._last_completed_mode == "actual"
+            and self._last_completed_step_id == step.step_id - 1
+            and previous_anchor
+        ):
+            step.mode = "forecast"
+            step.reason = "deferred one-point bootstrap forecast"
+            step.bootstrap_forecast = True
+            decision["actual"] = False
+            decision["reason"] = step.reason
+        return decision
+
+    def finalize_step(self, run_id, step_id):
+        committed_forecast = self._step is not None and self._step.mode == "forecast"
+        super().finalize_step(run_id, step_id)
+        if committed_forecast:
+            self._bootstrap_entitlement_unused = False
+
+    def create_rollback_snapshot(self):
+        snapshot = super().create_rollback_snapshot()
+        self._entitlement_snapshots[id(snapshot)] = self._bootstrap_entitlement_unused
+        return snapshot
+
+    def restore_rollback_snapshot(self, snapshot):
+        entitlement = self._entitlement_snapshots[id(snapshot)]
+        super().restore_rollback_snapshot(snapshot)
+        self._bootstrap_entitlement_unused = entitlement
+
+
+def _runtime(**overrides):
+    values = {
+        "degree": 1,
+        "max_history": 4,
+        "warmup_steps": 0,
+        "tail_actual_steps": 1,
+        "window_size": 2.0,
+        "bootstrap_first_forecast": True,
+        "offline_smoothing_replay": False,
+    }
+    values.update(overrides)
+    return EntitlementRuntime(SpectrumH3Config(**values))
+
+
+def _start(runtime, steps, **kwargs):
+    sigmas = torch.linspace(1.0, 0.0, steps + 1)
+    return runtime.start_run(
+        sigmas,
+        "sample_res_multistep",
+        supported_sampler=True,
+        min_actual_steps_after_forecast=0,
+        **kwargs,
+    )
+
+
+def _complete(runtime, timestep, *, policy=None, safe=True):
+    decision = runtime.begin_step(torch.tensor([timestep]))
+    if policy is not None:
+        runtime.prepare_backend_history(decision["run_id"], decision["step_id"], policy, safe)
+    step_mode = runtime._step.mode
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"], decision["step_id"], topology=TOPOLOGY,
+        labels=LABEL, expected_shape=(1, 3, 4),
+    )
+    if actual:
+        runtime.observe_actual(
+            decision["run_id"], decision["step_id"], call_id,
+            torch.full((1, 3, 4), float(decision["step_id"])),
+        )
+        if policy is not None:
+            runtime.observe_backend_history(
+                decision["run_id"], decision["step_id"], policy,
+                ("receipt", policy), safe,
+            )
+    else:
+        prediction = runtime.predict(
+            decision["run_id"], decision["step_id"], call_id,
+            device=torch.device("cpu"), dtype=torch.float32,
+        )
+        assert prediction is not None
+    final_mode = runtime._step.mode
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    return decision, step_mode, final_mode
+
+
+def test_native_five_step_low_consumes_entitlement_on_first_committed_forecast():
+    runtime = _runtime()
+    run_id = _start(runtime, 5)
+    modes = []
+    for index, sigma in enumerate((1.0, 0.8, 0.6, 0.4, 0.2)):
+        # Dense -> sparse-cold remains a hard boundary at step 2. The future
+        # proven cold->primed carry is represented by keeping the sparse identity.
+        policy = "dense" if index < 2 else "sparse"
+        _, _, mode = _complete(runtime, sigma, policy=policy)
+        modes.append(mode)
+    assert modes == ["actual", "forecast", "actual", "actual", "actual"]
+    assert runtime.stats.actual_steps == 4 and runtime.stats.forecast_steps == 1
+    assert runtime._bootstrap_entitlement_unused is False
+    runtime.end_run(run_id)
+
+
+def test_mixed_five_step_low_defers_entitlement_through_prefix_and_backend_veto():
+    runtime = _runtime()
+    run_id = _start(runtime, 5, min_actual_prefix_steps=2)
+    modes = []
+    for index, sigma in enumerate((1.0, 0.8, 0.6, 0.4, 0.2)):
+        policy = "dense" if index < 2 else "sparse"
+        _, _, mode = _complete(runtime, sigma, policy=policy)
+        modes.append(mode)
+        if index < 3:
+            assert runtime._bootstrap_entitlement_unused is True
+    assert modes == ["actual", "actual", "actual", "forecast", "actual"]
+    assert runtime.stats.actual_steps == 4 and runtime.stats.forecast_steps == 1
+    assert runtime._bootstrap_entitlement_unused is False
+    runtime.end_run(run_id)
+
+
+def test_three_step_high_uses_one_bootstrap_and_tail_remains_exact():
+    runtime = _runtime()
+    run_id = _start(runtime, 3, min_actual_prefix_steps=1)
+    modes = [_complete(runtime, sigma, policy="sparse")[2]
+             for sigma in (1.0, 0.5, 0.25)]
+    assert modes == ["actual", "forecast", "actual"]
+    assert runtime.stats.actual_steps == 2 and runtime.stats.forecast_steps == 1
+    runtime.end_run(run_id)
+
+
+def test_backend_vetoed_forecast_attempt_does_not_consume_entitlement():
+    runtime = _runtime(tail_actual_steps=1)
+    run_id = _start(runtime, 4)
+    _complete(runtime, 1.0, policy="a")
+    decision = runtime.begin_step(torch.tensor([0.75]))
+    assert not decision["actual"] and runtime._bootstrap_entitlement_unused
+    runtime.prepare_backend_history(decision["run_id"], decision["step_id"], "b", True)
+    assert runtime._step.mode == "actual"
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"], decision["step_id"], topology=TOPOLOGY,
+        labels=LABEL, expected_shape=(1, 3, 4),
+    )
+    assert actual
+    runtime.observe_actual(decision["run_id"], decision["step_id"], call_id, torch.ones(1, 3, 4))
+    runtime.observe_backend_history(decision["run_id"], decision["step_id"], "b", ("receipt", "b"), True)
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    assert runtime._bootstrap_entitlement_unused is True
+    deferred, _, mode = _complete(runtime, 0.5, policy="b")
+    assert deferred["reason"] == "deferred one-point bootstrap forecast"
+    assert mode == "forecast" and runtime._bootstrap_entitlement_unused is False
+    runtime.end_run(run_id)
+
+
+def test_fallback_to_actual_after_prediction_does_not_consume_entitlement():
+    runtime = _runtime(tail_actual_steps=0)
+    run_id = _start(runtime, 3)
+    _complete(runtime, 1.0)
+    decision = runtime.begin_step(torch.tensor([0.5]))
+    assert not decision["actual"] and runtime._bootstrap_entitlement_unused
+    call_id, actual = runtime.begin_model_call(
+        decision["run_id"], decision["step_id"], topology=TOPOLOGY,
+        labels=LABEL, expected_shape=(1, 3, 4),
+    )
+    assert not actual
+    assert runtime.predict(
+        decision["run_id"], decision["step_id"], call_id,
+        device=torch.device("cpu"), dtype=torch.float32,
+    ) is not None
+    runtime.prepare_actual_retry(decision["run_id"], decision["step_id"], "test retry")
+    retry_id, retry_actual = runtime.begin_model_call(
+        decision["run_id"], decision["step_id"], topology=TOPOLOGY,
+        labels=LABEL, expected_shape=(1, 3, 4),
+    )
+    assert retry_actual
+    runtime.observe_actual(
+        decision["run_id"], decision["step_id"], retry_id, torch.ones(1, 3, 4)
+    )
+    runtime.finalize_step(decision["run_id"], decision["step_id"])
+    assert runtime._bootstrap_entitlement_unused is True
+    runtime.end_run(run_id)
+
+
+def test_abort_does_not_consume_entitlement_and_backend_reset_never_replenishes_it():
+    runtime = _runtime(tail_actual_steps=0)
+    run_id = _start(runtime, 5)
+    _complete(runtime, 1.0, policy="a")
+    decision = runtime.begin_step(torch.tensor([0.8]))
+    assert not decision["actual"] and runtime._bootstrap_entitlement_unused
+    runtime.abort_step(decision["run_id"], decision["step_id"])
+    assert runtime._bootstrap_entitlement_unused is True
+    _complete(runtime, 0.8, policy="a")
+    assert runtime._bootstrap_entitlement_unused is False
+    _complete(runtime, 0.6, policy="b")
+    assert runtime._bootstrap_entitlement_unused is False
+    _, _, mode = _complete(runtime, 0.4, policy="b")
+    assert mode == "actual"
+    runtime.end_run(run_id)
+
+
+def test_rollback_restores_entitlement_transactionally():
+    runtime = _runtime(tail_actual_steps=0)
+    run_id = _start(runtime, 4)
+    _complete(runtime, 1.0, policy="a")
+    snapshot = runtime.create_rollback_snapshot()
+    assert runtime._bootstrap_entitlement_unused is True
+    _complete(runtime, 0.75, policy="a")
+    assert runtime._bootstrap_entitlement_unused is False
+    runtime.restore_rollback_snapshot(snapshot)
+    assert runtime._bootstrap_entitlement_unused is True
+    runtime.end_run(run_id)
+
+
+def test_sampler_required_exact_stage_dominates_and_does_not_consume_entitlement():
+    runtime = _runtime(tail_actual_steps=0)
+    run_id = _start(
+        runtime,
+        3,
+        forecastable_stage_indices=(),
+        history_stage_indices=(0,),
+    )
+    _first, _, first_mode = _complete(runtime, 1.0)
+    second, _, second_mode = _complete(runtime, 0.5)
+    assert first_mode == second_mode == "actual"
+    assert second["reason"] == "sampler-required exact stage"
+    assert runtime._bootstrap_entitlement_unused is True
+    runtime.end_run(run_id)
+
+
+def test_deferred_bootstrap_requires_the_previous_actual_to_be_the_retained_anchor():
+    runtime = _runtime(tail_actual_steps=0)
+    run_id = _start(
+        runtime,
+        4,
+        forced_actual_step_ids=(1,),
+        history_step_ids=(0,),
+    )
+    _complete(runtime, 1.0)
+    exact, _, exact_mode = _complete(runtime, 0.75)
+    assert exact_mode == "actual" and exact["reason"] == "sampler-required exact step"
+    assert runtime.forecaster.latest_anchor_ids(1) == (0,)
+    candidate, _, candidate_mode = _complete(runtime, 0.5)
+    assert candidate_mode == "actual"
+    assert candidate["reason"] == "insufficient actual history"
+    assert runtime._bootstrap_entitlement_unused is True
+    runtime.end_run(run_id)
+
+
+def test_sa_pece_state_conditioned_topology_does_not_acquire_ordinary_bootstrap():
+    runtime = _runtime(tail_actual_steps=0)
+    sigmas = torch.tensor([1.0, 0.5, 0.0])
+    topology = (
+        SolverCallDescriptor(0, 0, "predicted"),
+        SolverCallDescriptor(1, 0, "predicted"),
+        SolverCallDescriptor(1, 1, "corrected"),
+    )
+    run_id = runtime.start_run(
+        sigmas,
+        "sample_sa_solver_pece",
+        supported_sampler=True,
+        expected_model_calls=len(topology),
+        stage_count=2,
+        logical_call_topology=topology,
+        state_conditioned_residual=True,
+        separate_stage_histories=False,
+        forecastable_stage_indices=(0,),
+        history_stage_indices=(0, 1),
+        history_step_ids=(0, 2),
+        tail_actual_stage_indices=(1,),
+        allow_state_conditioned_bootstrap=False,
+        min_actual_prefix_steps=1,
+        min_actual_steps_after_forecast=0,
+        max_consecutive_forecasts=1,
+        model_aware_can_force_actual=False,
+    )
+    _first, _, first_mode = _complete(runtime, 1.0)
+    predicted, _, predicted_mode = _complete(runtime, 0.5)
+    corrected, _, corrected_mode = _complete(runtime, 0.5)
+    assert first_mode == predicted_mode == corrected_mode == "actual"
+    assert predicted["reason"] == "insufficient actual history"
+    assert corrected["reason"] == "sampler-required exact stage"
+    assert runtime._bootstrap_entitlement_unused is True
+    runtime.end_run(run_id)
+
+
+def test_prefix_tail_disabled_degree_and_state_conditioned_restrictions():
+    prefix = _runtime()
+    prefix_id = _start(prefix, 4, min_actual_prefix_steps=2)
+    first = _complete(prefix, 1.0)[2]
+    second = _complete(prefix, 0.75)[2]
+    assert (first, second) == ("actual", "actual")
+    assert prefix._bootstrap_entitlement_unused is True
+    prefix.end_run(prefix_id)
+
+    disabled = _runtime(bootstrap_first_forecast=False, tail_actual_steps=0)
+    disabled_id = _start(disabled, 3)
+    assert [_complete(disabled, s)[2] for s in (1.0, 0.5)] == ["actual", "actual"]
+    disabled.end_run(disabled_id)
+
+    with pytest.raises(ValueError, match="bootstrap_first_forecast requires degree == 1"):
+        _runtime(degree=2, tail_actual_steps=0)
+
+    state = _runtime(tail_actual_steps=0)
+    state_id = _start(state, 3, state_conditioned_residual=True, min_actual_prefix_steps=1)
+    assert [_complete(state, s)[2] for s in (1.0, 0.5)] == ["actual", "actual"]
+    assert state._bootstrap_entitlement_unused is True
+    state.end_run(state_id)


### PR DESCRIPTION
## Purpose

Make Spectrum interoperate safely with ComfyUI core `BlockSparseAttention` on MiniMax-H3, including Flow Mixed-Grid execution, while recovering the forecasts that were lost at the audited `h3_chunked_sparse_cold -> h3_chunked_sparse_primed` transition.

This PR is intentionally **one implementation commit** on top of `main`.

## Core-BSA audit

Spectrum proves the actual core-BSA owner, layout, settings, route and accepted per-block receipts before retaining forecasting history. Unknown source/ownership, malformed pool state, unexpected route changes or foreign/opaque backends remain fail-closed and execute actual H3 evaluations.

The audited composition includes the reviewed Untwist preprocess and Flow Mixed-Grid wrapper chain. Actual model execution still uses the original wrapper chain; Spectrum only unwraps copied metadata for proof.

## Cold -> primed recovery

CUDA diagnostics proved that a cold sparse actual creates the exact `kmean` / `vscale` tensor owners consumed by the immediately adjacent primed call. The production recovery therefore permits a one-way history carry only when all structural conditions remain true:

- current step was selected as a forecast;
- previous accepted actual and current preflight are exactly adjacent in the same Spectrum run;
- both core-BSA audits are accepted-safe;
- patch object/generation, source identity, sequence layout and UUIDs are unchanged;
- all non-route/non-pool numerical identity remains unchanged;
- predecessor sparse routes are `h3_chunked_sparse_cold`;
- current sparse routes are `h3_chunked_sparse_primed`;
- every current sparse pool entry still contains the exact same calibration tensor objects produced by the predecessor cold actual.

Only Spectrum backend-history identity is rebound. BSA calibration is not synthesized, mutated or marked refreshed. Dense -> sparse, reverse transitions, changed owners/layout/settings/source and every unproven transition retain the normal hard reset.

## Deferred one-point bootstrap entitlement

The scheduler change is not a hard-coded NFE target. Each ordinary degree-1 Spectrum run gets one bootstrap entitlement when `bootstrap_first_forecast` is enabled. It may survive exact-prefix/backend-veto steps and is consumed only by a successfully finalized forecast.

Deferred use requires exactly one retained forecaster anchor, and that anchor must be the immediately preceding completed actual step. Abort, retry-to-actual and backend veto do not consume the entitlement; rollback restores it transactionally. State-conditioned residual, separate-stage history and offline replay remain excluded from this rule.

## Production result

The full production workflow on RTX PRO 6000 Blackwell, Python 3.12 / PyTorch 2.10+cu130, ComfyUI 0.35 patcher stack, VDN, DiffAid, Untwist, core BSA, Spectrum, Continuum, Progressive Mixed-Grid Flow handoff and the learned latent upscaler reached exactly:

```text
sampler_logical_calls       18
transformer_actual_nfe      14
spectrum_forecast_calls      4

low                         10 logical = 8 actual + 2 forecast
high                         6 logical = 4 actual + 2 forecast
probe                        2 logical = 2 actual + 0 forecast
```

The log contains four real `path=forecast` calls. The three recovered sparse-transition forecasts are accompanied by the narrow cold->primed carry proof. All Spectrum-tracked preflights remained audited-safe; all real actual calls retained the expected 50/50 receipts; there were zero Spectrum fallbacks, zero speculative transformer calls, zero discarded actual transformer calls and zero replayed transformer calls.

Controlled timing versus the safe 17A/1F run:

- later Mixed-Grid sampler: `179.745 s -> 132.611 s` = **-47.133 s / -26.2%**, about **1.355x throughput**;
- Mixed-Grid high stage: `82.362 s -> 51.141 s` = **-31.221 s / -37.9%**.

The generated outputs differ slightly, as expected for the additional forecasts, but controlled visual inspection found **no apparent quality degradation and no clear winner** between the safe 17A/1F run and recovered 14A/4F run. This satisfies the production quality gate for this change.

A separate chunk-boundary frame-jump/frame-shift remains reproducible with Spectrum fully bypassed, so it is explicitly not attributed to this PR and is being investigated at the Flow/Continuum/VDN boundary instead.

## comfy-kitchen compatibility

The retained diagnostic/reproduction harness does not pin an exact comfy-kitchen wheel version or Python-source blob. Installed package/source identities are provenance only. The diagnostic checks only the required runtime API contract (`sol_attn_chunked` with `kmean` and `vscale`) and therefore does not reject current/source-built comfy-kitchen merely for being newer or having different package metadata.

The expensive BSA shadow diagnostic is manual-only in ordinary production runs.

## Validation

The pre-consolidation production-candidate tree was validated by GitHub Actions run `34508833420` across all 10 matrix jobs, including the reviewed core-BSA fixture lane, Ruff, compileall, focused external compatibility suites and native MiniMax-H3 tests.

The final consolidated PR head contains that exact validated tree, rewritten as one commit directly on current `main`:

```text
base:    be95adecec0b85c80d0c9fc5dd8d07386d50aaee
head:    53af77b51e6d292d77ea8acc5a7e5bd280b44154
tree:    4dae22b6eeb4ba4ba66ff226520ea7f635e8f39b
commits: 1
```

A fresh CI run on the consolidated head is the final mechanical merge gate.