### PR TITLE
Stream H3 forecasts and fix retained CUDA target tensors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -20,6 +20,9 @@ from .sampling import (
 LOG = logging.getLogger(__name__)
 
 _STATE_BASIS_CHUNK_BYTES = 16 * 1024 * 1024
+_SANITIZE_CHUNK_BYTES = 16 * 1024 * 1024
+_FORECAST_HEAD_CHUNK_BYTES = 16 * 1024 * 1024
+_H3_OPTIMIZATIONS_FINAL_LAYER_MODULE = "h3_optimizations.memory.final_layer"
 
 
 def locate_minimax_h3_inner(model: Any) -> tuple[Any | None, str | None]:
@@ -387,6 +390,54 @@ def _prepare_output_state(
 def _sanitize_prediction(feature: torch.Tensor, dtype: torch.dtype) -> tuple[torch.Tensor | None, dict[str, Any] | None]:
     if not dtype.is_floating_point:
         return None, {"reason": "target dtype is not floating point"}
+    if not feature.dtype.is_floating_point:
+        return None, {"reason": "forecast dtype is not floating point"}
+
+    # Spectrum predicts directly in the native H3/context dtype. Keep that
+    # full forecast in BF16/FP16 and validate it in bounded chunks instead of
+    # materializing a second full-size FP32 tensor plus full-size masks.
+    #
+    # A finite value already stored in the target dtype is necessarily within
+    # that dtype's representable range, so same-dtype forecasts only need a
+    # finiteness check. Repair is in-place and only touches chunks containing
+    # NaN/Inf values.
+    if feature.dtype == dtype:
+        flat = feature.reshape(-1)
+        element_size = max(1, feature.element_size())
+        chunk_elements = max(1, _SANITIZE_CHUNK_BYTES // element_size)
+        finite_values = 0
+        nonfinite = 0
+        bad_chunks: list[tuple[int, int]] = []
+
+        for start in range(0, flat.numel(), chunk_elements):
+            stop = min(flat.numel(), start + chunk_elements)
+            chunk = flat[start:stop]
+            finite = torch.isfinite(chunk)
+            if bool(finite.all().item()):
+                finite_values += chunk.numel()
+            else:
+                finite_count = int(finite.sum().item())
+                finite_values += finite_count
+                nonfinite += chunk.numel() - finite_count
+                bad_chunks.append((start, stop))
+
+        if finite_values == 0:
+            return None, {"reason": "forecast contains no finite values"}
+        if nonfinite == 0:
+            return feature, None
+
+        finfo = torch.finfo(dtype)
+        for start, stop in bad_chunks:
+            torch.nan_to_num_(
+                flat[start:stop],
+                nan=0.0,
+                posinf=finfo.max,
+                neginf=finfo.min,
+            )
+        return feature, {"nonfinite": nonfinite, "below": 0, "above": 0}
+
+    # Compatibility fallback for an unexpected dtype mismatch. The normal H3
+    # forecast path above avoids this full-size FP32 conversion entirely.
     fp32 = feature.to(torch.float32)
     finite = torch.isfinite(fp32)
     if not bool(finite.any().item()):
@@ -467,7 +518,6 @@ def _execute_actual(
         # packed tail. Keep a view here; materializing torch.cat would create a
         # second full target tensor on the GPU before the required CPU archive.
         target = hidden[aa:vb].unsqueeze(0)
-        actual_target = target
         from .bsa_transition_probe import hidden
         hidden(target, target_segments(layout)[0][1] - aa)
         from .backend_history import observe
@@ -476,6 +526,10 @@ def _execute_actual(
                 local_options.get("attention_backend_preflight_v1"))
         if runtime.stats.backend_history_resets != resets_before:
             residual_probe = None  # discard old-backend shadow/hold evidence
+        # hidden(...) above copies its diagnostic target to CPU. Retain this
+        # CUDA view only while a residual probe still needs the actual feature;
+        # otherwise it pins the complete final-hidden storage across later calls.
+        actual_target = target if residual_probe is not None else None
         if runtime.active_state_conditioned_residual:
             try:
                 if state_input_target is None:
@@ -520,20 +574,24 @@ def _execute_actual(
 
     dit_replacements[("double_block", last_index)] = capture_replacement
     from .bsa_transition_probe import actual_scope
-    with actual_scope(runtime, run_id, step_id, call_id, local_options) as diagnostic:
-        result = executor(
-            x,
-            timestep,
-            context,
-            local_options,
-            minimax_payload=minimax_payload,
-            **kwargs,
-        )
-        if diagnostic is not None:
-            from .core_bsa_compat import accepts_actual
-            diagnostic.complete(accepts_actual(
-                diagnostic.audit, tuple(local_options.get("attention_backend_receipts_v1", ()))
-            ))
+    try:
+        with actual_scope(runtime, run_id, step_id, call_id, local_options) as diagnostic:
+            result = executor(
+                x,
+                timestep,
+                context,
+                local_options,
+                minimax_payload=minimax_payload,
+                **kwargs,
+            )
+            if diagnostic is not None:
+                from .core_bsa_compat import accepts_actual
+                diagnostic.complete(accepts_actual(
+                    diagnostic.audit, tuple(local_options.get("attention_backend_receipts_v1", ()))
+                ))
+    except Exception:
+        actual_target = None
+        raise
     if not observed:
         raise RuntimeError("native MiniMax H3 final transformer block was not executed")
     if residual_probe is not None and actual_target is not None:
@@ -552,8 +610,25 @@ def _execute_actual(
             )
             output_head_started = time.perf_counter()
             try:
-                shadow_output = _execute_forecast(inner, residual_probe.shadow, state, x[0], x[1])
-                hold_output = _execute_forecast(inner, residual_probe.hold, state, x[0], x[1])
+                residual_state_scale = (
+                    1.0 if runtime.active_state_conditioned_residual else 0.0
+                )
+                shadow_output = _execute_forecast(
+                    inner,
+                    residual_probe.shadow,
+                    state,
+                    x[0],
+                    x[1],
+                    state_embedding_scale=residual_state_scale,
+                )
+                hold_output = _execute_forecast(
+                    inner,
+                    residual_probe.hold,
+                    state,
+                    x[0],
+                    x[1],
+                    state_embedding_scale=residual_state_scale,
+                )
             finally:
                 runtime.record_residual_output_head_seconds(
                     time.perf_counter() - output_head_started
@@ -572,6 +647,11 @@ def _execute_actual(
             raise
         except (RuntimeError, TypeError, ValueError) as exc:
             runtime.disable_experiment(f"residual output-head evaluation failed: {exc}")
+        finally:
+            # Break the replacement-closure reference immediately. Otherwise a
+            # retained patches_replace callback can pin the full final-hidden
+            # CUDA storage across later sampler steps.
+            actual_target = None
     return result
 
 
@@ -596,24 +676,19 @@ def _final_layer_uses_pdd_contract(module: Any) -> bool:
     return False
 
 
-def _execute_forecast(
+def _final_layer_project(
     inner: Any,
-    predicted: torch.Tensor,
+    module: Any,
+    compact: torch.Tensor,
     state: _OutputState,
-    video_x: torch.Tensor,
-    audio_x: torch.Tensor,
-):
-    module = _native_module(inner)
-    (aa, ab), (va, vb) = target_segments(state.layout)
-    audio_rows = ab - aa
-    video_rows = vb - va
-    compact = predicted[0]
-    if compact.shape != (audio_rows + video_rows, inner.hidden_size):
-        raise RuntimeError("forecasted MiniMax H3 target feature has an invalid compact shape")
-    audio_segment = (0, audio_rows, state.audio_timestep_row)
-    video_segment = (audio_rows, audio_rows + video_rows, state.video_timestep_row)
+    video_segment: tuple[int, int, Any],
+    audio_segment: tuple[int, int, Any],
+    *,
+    forward_override: Any | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    forward = forward_override if forward_override is not None else inner.final_layer
     if _final_layer_uses_pdd_contract(module):
-        video_projected, audio_projected = inner.final_layer(
+        return forward(
             compact,
             state.t_emb,
             video_segment,
@@ -622,13 +697,455 @@ def _execute_forecast(
             sample_sigmas=state.sample_sigmas,
             shifts=(state.shift_v, state.shift_a),
         )
-    else:
-        video_projected, audio_projected = inner.final_layer(
+    return forward(
+        compact,
+        state.t_emb,
+        video_segment,
+        audio_segment,
+    )
+
+
+def _callable_marker(callable_obj: Any, name: str, default: Any = None) -> Any:
+    value = getattr(callable_obj, name, None)
+    if value is None:
+        value = getattr(getattr(callable_obj, "__func__", None), name, None)
+    return default if value is None else value
+
+
+def _same_bound_callable(candidate: Any, owner: Any, function: Any) -> bool:
+    """Compare a bound callable without relying on transient method identity."""
+    return (
+        getattr(candidate, "__self__", None) is owner
+        and getattr(candidate, "__func__", None) is function
+    )
+
+
+def _final_layer_stream_kind(inner: Any) -> str | None:
+    """Return the audited slab-safe FinalLayer contract, if any."""
+    module = _native_module(inner)
+    forward = getattr(inner.final_layer, "forward", None)
+    native_type = getattr(module, "FinalLayer", None)
+    native_forward = getattr(native_type, "forward", None)
+    if (
+        forward is not None
+        and native_forward is not None
+        and _same_bound_callable(forward, inner.final_layer, native_forward)
+    ):
+        return "native"
+
+    function = getattr(forward, "__func__", forward)
+    if (
+        bool(_callable_marker(forward, "_h3_optimizations_final_layer", False))
+        and getattr(function, "__module__", None)
+        == _H3_OPTIMIZATIONS_FINAL_LAYER_MODULE
+    ):
+        return "h3_optimizations"
+    return None
+
+
+def _final_layer_stream_supported(inner: Any) -> bool:
+    return _final_layer_stream_kind(inner) is not None
+
+
+def _forecast_prediction_device(inner: Any, model_device: torch.device) -> torch.device:
+    """Keep complete forecasts on CPU only for audited slab-safe FinalLayers."""
+    if model_device.type == "cuda" and _final_layer_stream_supported(inner):
+        return torch.device("cpu")
+    return model_device
+
+
+def _resolve_final_layer_stream_compat(
+    inner: Any,
+    video_rows: int,
+) -> tuple[Any | None, Any | None, bool, int | None] | None:
+    """Resolve native or audited H3-Optimizations FinalLayer slab semantics."""
+    kind = _final_layer_stream_kind(inner)
+    if kind is None:
+        return None
+    if kind == "native":
+        return None, None, False, None
+
+    forward = inner.final_layer.forward
+    signature = _callable_marker(
+        forward,
+        "_h3_optimizations_final_layer_signature",
+        None,
+    )
+    chunk_rows = None if signature is None else int(signature)
+    cube_state = _callable_marker(
+        forward,
+        "_h3_optimizations_cube_order_state",
+        None,
+    )
+    if cube_state is None:
+        # FinalLayer-memory-only patching is explicitly supported and accepts
+        # arbitrary row counts; retain its wrapper for Spectrum's bounded slabs.
+        return None, None, False, chunk_rows
+
+    original = _callable_marker(
+        forward,
+        "_h3_optimizations_final_layer_original",
+        None,
+    )
+    if not callable(original):
+        raise TypeError(
+            "H3-Optimizations FinalLayer cube-order wrapper has no recoverable original"
+        )
+
+    module = _native_module(inner)
+    native_forward = getattr(getattr(module, "FinalLayer", None), "forward", None)
+    if native_forward is None or not _same_bound_callable(
+        original,
+        inner.final_layer,
+        native_forward,
+    ):
+        # Do not slab-call a foreign original hidden under an otherwise
+        # recognizable wrapper. Preserve the historical one-shot contract.
+        return None
+
+    topology, active = cube_state.resolve(int(video_rows))
+    if len(topology.forward) != int(video_rows):
+        raise RuntimeError("H3 cube-order topology does not match Spectrum video rows")
+    return original, topology, not bool(active), chunk_rows
+
+
+def _slice_mod_selector(
+    selector: Any,
+    start: int,
+    stop: int,
+    stream_rows: int,
+    *,
+    topology: Any | None = None,
+) -> Any:
+    """Slice per-token modulation selectors while preserving scalar selectors."""
+    if (
+        torch.is_tensor(selector)
+        and selector.ndim > 0
+        and int(selector.shape[0]) == int(stream_rows)
+    ):
+        if topology is not None:
+            index = torch.tensor(
+                topology.forward[int(start) : int(stop)],
+                dtype=torch.long,
+                device=selector.device,
+            )
+            return selector.index_select(0, index)
+        return selector[int(start) : int(stop)]
+    return selector
+
+
+def _prepare_exact_state_rows_cpu(
+    inner: Any,
+    video_x: torch.Tensor,
+    audio_x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build exact H3 input rows in system RAM for streamed residual reconstruction."""
+    module = _native_module(inner)
+    common_dit = importlib.import_module("comfy.ldm.common_dit")
+    video_cpu = video_x.detach().to(device="cpu", dtype=torch.float32).contiguous()
+    audio_cpu = audio_x.detach().to(device="cpu", dtype=torch.float32).contiguous()
+    padded_video = common_dit.pad_to_patch_size(video_cpu, tuple(inner.patch_size))
+    video_rows = module.patchify_video(
+        padded_video,
+        tuple(inner.patch_size),
+    ).contiguous()
+    audio_rows = module.pack_audio(audio_cpu).contiguous()
+    if audio_rows.ndim != 2 or video_rows.ndim != 2:
+        raise ValueError("native H3 patch helpers returned an unexpected row layout")
+    return audio_rows, video_rows
+
+
+def _copy_cpu_chunk_to_workspace_(
+    workspace: torch.Tensor,
+    source: torch.Tensor,
+) -> torch.Tensor:
+    """Copy into reusable device storage; pageable CPU sources stay synchronous."""
+    count = int(source.shape[0])
+    if count > int(workspace.shape[0]):
+        raise RuntimeError("Spectrum streaming workspace is smaller than its chunk")
+    target = workspace[:count]
+    target.copy_(source, non_blocking=bool(source.is_pinned()))
+    return target
+
+
+def _project_cpu_forecast_stream(
+    inner: Any,
+    module: Any,
+    compact_cpu: torch.Tensor,
+    state: _OutputState,
+    *,
+    global_start: int,
+    stream_rows: int,
+    selector: Any,
+    video: bool,
+    device: torch.device,
+    forward_override: Any | None = None,
+    topology: Any | None = None,
+    reorder_selector: bool = False,
+    chunk_rows_override: int | None = None,
+    state_rows_cpu: torch.Tensor | None = None,
+    state_projection: Any | None = None,
+    state_scale: float = 0.0,
+    hidden_workspace: torch.Tensor | None = None,
+    state_workspace: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Project one audited forecast stream without a full hidden device tensor."""
+    rows = int(stream_rows)
+    hidden = int(inner.hidden_size)
+    if rows <= 0:
+        head = inner.final_layer.video_out if video else inner.final_layer.audio_out
+        return torch.empty(
+            (0, int(head.out_features)),
+            device=device,
+            dtype=torch.float32,
+        )
+
+    bytes_per_row = max(1, hidden * compact_cpu.element_size())
+    chunk_rows = max(1, _FORECAST_HEAD_CHUNK_BYTES // bytes_per_row)
+    if chunk_rows_override is not None and int(chunk_rows_override) > 0:
+        chunk_rows = min(chunk_rows, int(chunk_rows_override))
+    if state_rows_cpu is not None and int(state_rows_cpu.shape[0]) != rows:
+        raise ValueError("streamed exact-state rows do not match the target stream")
+    if hidden_workspace is not None:
+        if (
+            hidden_workspace.device != device
+            or hidden_workspace.dtype != compact_cpu.dtype
+            or int(hidden_workspace.shape[1]) != hidden
+        ):
+            raise ValueError("Spectrum hidden streaming workspace is incompatible")
+        chunk_rows = min(chunk_rows, int(hidden_workspace.shape[0]))
+    projected = None
+
+    for local_start in range(0, rows, chunk_rows):
+        local_stop = min(rows, local_start + chunk_rows)
+        count = local_stop - local_start
+        hidden_source = compact_cpu[
+            int(global_start) + local_start : int(global_start) + local_stop
+        ]
+        if hidden_workspace is None:
+            hidden_chunk = hidden_source.to(
+                device=device,
+                dtype=compact_cpu.dtype,
+                non_blocking=bool(hidden_source.is_pinned()),
+            )
+        else:
+            hidden_chunk = _copy_cpu_chunk_to_workspace_(
+                hidden_workspace,
+                hidden_source,
+            )
+        if state_rows_cpu is not None:
+            if state_projection is None:
+                raise RuntimeError("streamed exact-state rows have no patch projection")
+            if topology is None:
+                state_chunk_cpu = state_rows_cpu[local_start:local_stop]
+            else:
+                state_index = torch.tensor(
+                    topology.forward[local_start:local_stop],
+                    dtype=torch.long,
+                    device=state_rows_cpu.device,
+                )
+                state_chunk_cpu = state_rows_cpu.index_select(0, state_index)
+            if state_workspace is None:
+                state_chunk = state_chunk_cpu.to(
+                    device=device,
+                    dtype=torch.float32,
+                    non_blocking=bool(state_chunk_cpu.is_pinned()),
+                )
+            else:
+                if (
+                    state_workspace.device != device
+                    or state_workspace.dtype != torch.float32
+                    or int(state_workspace.shape[1]) != int(state_chunk_cpu.shape[1])
+                ):
+                    raise ValueError(
+                        "Spectrum exact-state streaming workspace is incompatible"
+                    )
+                state_chunk = _copy_cpu_chunk_to_workspace_(
+                    state_workspace,
+                    state_chunk_cpu,
+                )
+            embedded = state_projection(state_chunk).to(hidden_chunk.dtype)
+            hidden_chunk.add_(embedded, alpha=float(state_scale))
+            del state_chunk, embedded
+
+        row_selector = _slice_mod_selector(
+            selector,
+            local_start,
+            local_stop,
+            rows,
+            topology=(topology if reorder_selector else None),
+        )
+        # Audited native/H3-Optimizations FinalLayers are row-local. Give the
+        # inactive stream an empty range with a scalar selector.
+        if video:
+            video_segment = (0, count, row_selector)
+            audio_segment = (count, count, 0)
+        else:
+            video_segment = (count, count, 0)
+            audio_segment = (0, count, row_selector)
+
+        video_chunk, audio_chunk = _final_layer_project(
+            inner,
+            module,
+            hidden_chunk,
+            state,
+            video_segment,
+            audio_segment,
+            forward_override=forward_override,
+        )
+        selected = video_chunk if video else audio_chunk
+        if projected is None:
+            projected = selected.new_empty((rows, *selected.shape[1:]))
+        if video and topology is not None:
+            # topology.forward maps cube-major row -> raster row. Restore each
+            # projected slab directly, avoiding another full output allocation.
+            restore_index = torch.tensor(
+                topology.forward[local_start:local_stop],
+                dtype=torch.long,
+                device=selected.device,
+            )
+            projected.index_copy_(0, restore_index, selected)
+        else:
+            projected[local_start:local_stop].copy_(selected)
+        del hidden_source, hidden_chunk, video_chunk, audio_chunk, selected
+
+    if projected is None:
+        raise RuntimeError("streamed Spectrum FinalLayer projection produced no rows")
+    return projected
+
+
+def _execute_forecast(
+    inner: Any,
+    predicted: torch.Tensor,
+    state: _OutputState,
+    video_x: torch.Tensor,
+    audio_x: torch.Tensor,
+    *,
+    state_embedding_scale: float = 0.0,
+):
+    module = _native_module(inner)
+    (aa, ab), (va, vb) = target_segments(state.layout)
+    audio_rows = ab - aa
+    video_rows = vb - va
+    compact = predicted[0]
+    if compact.shape != (audio_rows + video_rows, inner.hidden_size):
+        raise RuntimeError("forecasted MiniMax H3 target feature has an invalid compact shape")
+
+    stream_compat = None
+    if compact.device.type == "cpu" and video_x.device.type == "cuda":
+        stream_compat = _resolve_final_layer_stream_compat(inner, video_rows)
+
+    if stream_compat is not None:
+        forward_override, video_topology, reorder_selector, h3_chunk_rows = stream_compat
+        state_audio_rows = None
+        state_video_rows = None
+        if float(state_embedding_scale) != 0.0:
+            state_audio_rows, state_video_rows = _prepare_exact_state_rows_cpu(
+                inner,
+                video_x,
+                audio_x,
+            )
+            if (
+                int(state_audio_rows.shape[0]) != audio_rows
+                or int(state_video_rows.shape[0]) != video_rows
+            ):
+                raise ValueError(
+                    "state-conditioned residual input rows do not match forecast topology"
+                )
+
+        bytes_per_hidden_row = max(1, int(inner.hidden_size) * compact.element_size())
+        workspace_rows = max(
+            1,
+            _FORECAST_HEAD_CHUNK_BYTES // bytes_per_hidden_row,
+        )
+        if h3_chunk_rows is not None and int(h3_chunk_rows) > 0:
+            workspace_rows = min(workspace_rows, int(h3_chunk_rows))
+        workspace_rows = min(workspace_rows, max(audio_rows, video_rows))
+        hidden_workspace = torch.empty(
+            (workspace_rows, int(inner.hidden_size)),
+            device=video_x.device,
+            dtype=compact.dtype,
+        )
+        audio_state_workspace = None
+        video_state_workspace = None
+        if state_audio_rows is not None:
+            audio_state_workspace = torch.empty(
+                (min(workspace_rows, audio_rows), int(state_audio_rows.shape[1])),
+                device=video_x.device,
+                dtype=torch.float32,
+            )
+            video_state_workspace = torch.empty(
+                (min(workspace_rows, video_rows), int(state_video_rows.shape[1])),
+                device=video_x.device,
+                dtype=torch.float32,
+            )
+
+        audio_projected = _project_cpu_forecast_stream(
+            inner,
+            module,
             compact,
-            state.t_emb,
+            state,
+            global_start=0,
+            stream_rows=audio_rows,
+            selector=state.audio_timestep_row,
+            video=False,
+            device=video_x.device,
+            forward_override=forward_override,
+            chunk_rows_override=h3_chunk_rows,
+            state_rows_cpu=state_audio_rows,
+            state_projection=inner.audio_patch_proj,
+            state_scale=state_embedding_scale,
+            hidden_workspace=hidden_workspace,
+            state_workspace=audio_state_workspace,
+        )
+        video_projected = _project_cpu_forecast_stream(
+            inner,
+            module,
+            compact,
+            state,
+            global_start=audio_rows,
+            stream_rows=video_rows,
+            selector=state.video_timestep_row,
+            video=True,
+            device=video_x.device,
+            forward_override=forward_override,
+            topology=video_topology,
+            reorder_selector=reorder_selector,
+            chunk_rows_override=h3_chunk_rows,
+            state_rows_cpu=state_video_rows,
+            state_projection=inner.video_patch_proj,
+            state_scale=state_embedding_scale,
+            hidden_workspace=hidden_workspace,
+            state_workspace=video_state_workspace,
+        )
+        del hidden_workspace
+        del audio_state_workspace, video_state_workspace
+        del state_audio_rows, state_video_rows
+    else:
+        # Unknown object patches retain the historical one-shot FinalLayer
+        # contract, including the old full-hidden device cost.
+        if compact.device != video_x.device:
+            predicted = predicted.to(device=video_x.device)
+            compact = predicted[0]
+        if float(state_embedding_scale) != 0.0:
+            _apply_exact_state_input_embedding_(
+                predicted,
+                inner,
+                video_x,
+                audio_x,
+                scale=float(state_embedding_scale),
+            )
+        audio_segment = (0, audio_rows, state.audio_timestep_row)
+        video_segment = (audio_rows, audio_rows + video_rows, state.video_timestep_row)
+        video_projected, audio_projected = _final_layer_project(
+            inner,
+            module,
+            compact,
+            state,
             video_segment,
             audio_segment,
         )
+
     latent_t, latent_h, latent_w = state.padded_video_shape
     video_out = module.unpatchify_video(
         video_projected,
@@ -725,11 +1242,15 @@ def diffusion_model_wrapper(
         )
 
     if actual:
+        residual_prediction_device = _forecast_prediction_device(
+            inner,
+            video_x.device,
+        )
         residual_probe = runtime.prepare_residual_probe(
             int(run_id),
             int(step_id),
             call_id,
-            device=video_x.device,
+            device=residual_prediction_device,
             dtype=context.dtype,
         )
         return _execute_actual(
@@ -770,11 +1291,15 @@ def diffusion_model_wrapper(
                 kwargs,
             )
 
+    prediction_device = _forecast_prediction_device(
+        inner,
+        video_x.device,
+    )
     predicted = runtime.predict(
         int(run_id),
         int(step_id),
         call_id,
-        device=video_x.device,
+        device=prediction_device,
         dtype=context.dtype,
     )
     if predicted is None:
@@ -793,39 +1318,6 @@ def diffusion_model_wrapper(
             minimax_payload,
             kwargs,
         )
-
-    if runtime.active_state_conditioned_residual:
-        try:
-            _apply_exact_state_input_embedding_(
-                predicted,
-                inner,
-                video_x,
-                audio_x,
-                scale=1.0,
-            )
-        except torch.cuda.OutOfMemoryError:
-            raise
-        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
-            runtime.fallback_current_step(
-                int(run_id),
-                int(step_id),
-                f"state-conditioned residual forecast reconstruction failed: {exc}",
-            )
-            return _execute_actual(
-                executor,
-                inner,
-                runtime,
-                int(run_id),
-                int(step_id),
-                call_id,
-                layout,
-                x,
-                timestep,
-                context,
-                options,
-                minimax_payload,
-                kwargs,
-            )
 
     sanitized, event = _sanitize_prediction(predicted, context.dtype)
     if sanitized is None:
@@ -860,12 +1352,47 @@ def diffusion_model_wrapper(
             denoise_mask=kwargs.get("denoise_mask"),
             audio_denoise_mask=kwargs.get("audio_denoise_mask"),
         )
-        output = _execute_forecast(inner, sanitized, state, video_x, audio_x)
+        output = _execute_forecast(
+            inner,
+            sanitized,
+            state,
+            video_x,
+            audio_x,
+            state_embedding_scale=(
+                1.0 if runtime.active_state_conditioned_residual else 0.0
+            ),
+        )
+        del state
+        del sanitized
+        del predicted
     except torch.cuda.OutOfMemoryError:
         raise
-    except (RuntimeError, TypeError, ValueError) as exc:
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
         if runtime.offline_phase == "replay":
-            raise OfflineReplayAbort(f"offline replay output-head evaluation failed: {exc}") from exc
+            raise OfflineReplayAbort(
+                f"offline replay output-head evaluation failed: {exc}"
+            ) from exc
+        if runtime.active_state_conditioned_residual:
+            runtime.fallback_current_step(
+                int(run_id),
+                int(step_id),
+                f"state-conditioned residual forecast reconstruction failed: {exc}",
+            )
+            return _execute_actual(
+                executor,
+                inner,
+                runtime,
+                int(run_id),
+                int(step_id),
+                call_id,
+                layout,
+                x,
+                timestep,
+                context,
+                options,
+                minimax_payload,
+                kwargs,
+            )
         raise
     if runtime.config.debug:
         LOG.warning(

--- a/comfyui_spectrum_h3/minimax_h3.py
+++ b/comfyui_spectrum_h3/minimax_h3.py
@@ -1352,6 +1352,29 @@ def diffusion_model_wrapper(
             denoise_mask=kwargs.get("denoise_mask"),
             audio_denoise_mask=kwargs.get("audio_denoise_mask"),
         )
+
+        debug_cuda = (
+            runtime.config.debug
+            and video_x.device.type == "cuda"
+        )
+
+        if debug_cuda:
+            benchmark_device = video_x.device
+
+            # Make the starting point well-defined and ensure work from the
+            # preceding forecast/prediction setup is not included.
+            torch.cuda.synchronize(benchmark_device)
+            torch.cuda.reset_peak_memory_stats(benchmark_device)
+
+            forecast_before_allocated = torch.cuda.memory_allocated(
+                benchmark_device
+            )
+            forecast_before_reserved = torch.cuda.memory_reserved(
+                benchmark_device
+            )
+
+            forecast_started = time.perf_counter()
+
         output = _execute_forecast(
             inner,
             sanitized,
@@ -1362,9 +1385,69 @@ def diffusion_model_wrapper(
                 1.0 if runtime.active_state_conditioned_residual else 0.0
             ),
         )
+
+        if debug_cuda:
+            # _execute_forecast queues CUDA work, so synchronize before stopping
+            # the wall-clock timer or reading allocator statistics.
+            torch.cuda.synchronize(benchmark_device)
+
+            forecast_ms = (
+                time.perf_counter() - forecast_started
+            ) * 1000.0
+
+            forecast_peak_allocated = torch.cuda.max_memory_allocated(
+                benchmark_device
+            )
+            forecast_peak_reserved = torch.cuda.max_memory_reserved(
+                benchmark_device
+            )
+
         del state
         del sanitized
         del predicted
+
+        if debug_cuda:
+            # Measure persistent allocator state after the temporary forecast
+            # tensors have gone out of scope.
+            torch.cuda.synchronize(benchmark_device)
+
+            forecast_after_allocated = torch.cuda.memory_allocated(
+                benchmark_device
+            )
+            forecast_after_reserved = torch.cuda.memory_reserved(
+                benchmark_device
+            )
+
+            forecast_path = (
+                "streamed"
+                if prediction_device.type == "cpu"
+                else "monolithic"
+            )
+
+            mib = 1024.0 * 1024.0
+
+            LOG.warning(
+                "Spectrum H3 CUDA forecast benchmark "
+                "run_id=%s step=%s call=%s path=%s "
+                "latency_ms=%.3f "
+                "before_allocated_mib=%.1f "
+                "before_reserved_mib=%.1f "
+                "peak_allocated_mib=%.1f "
+                "peak_reserved_mib=%.1f "
+                "after_allocated_mib=%.1f "
+                "after_reserved_mib=%.1f",
+                run_id,
+                step_id,
+                call_id,
+                forecast_path,
+                forecast_ms,
+                forecast_before_allocated / mib,
+                forecast_before_reserved / mib,
+                forecast_peak_allocated / mib,
+                forecast_peak_reserved / mib,
+                forecast_after_allocated / mib,
+                forecast_after_reserved / mib,
+            )
     except torch.cuda.OutOfMemoryError:
         raise
     except (AttributeError, RuntimeError, TypeError, ValueError) as exc:

--- a/tests/test_minimax_h3_streaming.py
+++ b/tests/test_minimax_h3_streaming.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import comfyui_spectrum_h3.backend_history as backend_history
+import comfyui_spectrum_h3.minimax_h3 as minimax_h3
+
+
+class _RowLocalFinalLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.video_out = SimpleNamespace(out_features=4)
+        self.audio_out = SimpleNamespace(out_features=4)
+        self.calls = 0
+
+    @staticmethod
+    def _project(x, segment, bias):
+        first, last, selector = segment
+        value = x[first:last].clone()
+        if torch.is_tensor(selector) and selector.ndim > 0:
+            modulation = selector.to(device=x.device, dtype=x.dtype).reshape(-1, 1)
+        else:
+            modulation = torch.as_tensor(
+                float(selector),
+                device=x.device,
+                dtype=x.dtype,
+            )
+        return value + modulation + float(bias)
+
+    def forward(self, x, t_emb, video_segment, audio_segment):
+        del t_emb
+        self.calls += 1
+        return (
+            self._project(x, video_segment, 10.0),
+            self._project(x, audio_segment, -5.0),
+        )
+
+
+class _PDDRowLocalFinalLayer(_RowLocalFinalLayer):
+    def forward(
+        self,
+        x,
+        t_emb,
+        video_segment,
+        audio_segment,
+        sigma=None,
+        sample_sigmas=None,
+        shifts=None,
+    ):
+        del t_emb
+        self.calls += 1
+        assert sigma is not None
+        assert sample_sigmas is not None
+        assert shifts is not None
+        pdd_bias = (
+            float(sigma)
+            + float(sample_sigmas.sum())
+            + float(shifts[0])
+            + float(shifts[1])
+        )
+        return (
+            self._project(x, video_segment, 10.0 + pdd_bias),
+            self._project(x, audio_segment, -5.0 + pdd_bias),
+        )
+
+
+class _ForeignFinalLayer(torch.nn.Module):
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+        self.video_out = inner.video_out
+        self.audio_out = inner.audio_out
+        self.calls = 0
+
+    def forward(self, *args, **kwargs):
+        self.calls += 1
+        return self.inner(*args, **kwargs)
+
+
+class _H3OptimizationsCompatibleFinalLayer(_RowLocalFinalLayer):
+    def forward(self, x, t_emb, video_segment, audio_segment):
+        return super().forward(x, t_emb, video_segment, audio_segment)
+
+
+_H3OptimizationsCompatibleFinalLayer.forward.__module__ = (
+    "h3_optimizations.memory.final_layer"
+)
+_H3OptimizationsCompatibleFinalLayer.forward._h3_optimizations_final_layer = True
+_H3OptimizationsCompatibleFinalLayer.forward._h3_optimizations_final_layer_signature = 2
+_H3OptimizationsCompatibleFinalLayer.forward._h3_optimizations_cube_order_state = None
+
+
+def _state(audio_selector, video_selector):
+    return minimax_h3._OutputState(
+        layout=None,
+        t_emb=torch.zeros(1, 4),
+        video_timestep_row=video_selector,
+        audio_timestep_row=audio_selector,
+        sigma_v=torch.tensor(0.5),
+        sample_sigmas=torch.tensor([1.0, 0.5, 0.0]),
+        shift_v=1.1,
+        shift_a=0.9,
+        original_video_shape=(1, 1, 1),
+        padded_video_shape=(1, 1, 1),
+    )
+
+
+@pytest.mark.parametrize("pdd", [False, True])
+@pytest.mark.parametrize("per_token", [False, True])
+def test_streamed_final_layer_matches_monolithic_for_selectors_and_pdd(
+    monkeypatch,
+    pdd,
+    per_token,
+):
+    torch.manual_seed(7)
+    audio_rows = 5
+    video_rows = 6
+    hidden = 4
+    compact = torch.randn(audio_rows + video_rows, hidden)
+    layer = _PDDRowLocalFinalLayer() if pdd else _RowLocalFinalLayer()
+    inner = SimpleNamespace(hidden_size=hidden, final_layer=layer)
+    module = SimpleNamespace(FinalLayer=type(layer))
+    audio_selector = (
+        torch.arange(audio_rows, dtype=torch.long)
+        if per_token
+        else 2
+    )
+    video_selector = (
+        torch.arange(video_rows, dtype=torch.long) + 3
+        if per_token
+        else 4
+    )
+    state = _state(audio_selector, video_selector)
+
+    video_segment = (
+        audio_rows,
+        audio_rows + video_rows,
+        state.video_timestep_row,
+    )
+    audio_segment = (0, audio_rows, state.audio_timestep_row)
+    monolithic_video, monolithic_audio = minimax_h3._final_layer_project(
+        inner,
+        module,
+        compact,
+        state,
+        video_segment,
+        audio_segment,
+    )
+
+    # Force multiple slabs even on this tiny CPU fixture.
+    monkeypatch.setattr(
+        minimax_h3,
+        "_FORECAST_HEAD_CHUNK_BYTES",
+        hidden * compact.element_size() * 2,
+    )
+    streamed_audio = minimax_h3._project_cpu_forecast_stream(
+        inner,
+        module,
+        compact,
+        state,
+        global_start=0,
+        stream_rows=audio_rows,
+        selector=state.audio_timestep_row,
+        video=False,
+        device=torch.device("cpu"),
+    )
+    streamed_video = minimax_h3._project_cpu_forecast_stream(
+        inner,
+        module,
+        compact,
+        state,
+        global_start=audio_rows,
+        stream_rows=video_rows,
+        selector=state.video_timestep_row,
+        video=True,
+        device=torch.device("cpu"),
+    )
+
+    torch.testing.assert_close(streamed_audio, monolithic_audio)
+    torch.testing.assert_close(streamed_video, monolithic_video)
+
+
+def test_cube_order_stream_reorders_selector_and_restores_video_output(monkeypatch):
+    hidden = 4
+    raster = torch.arange(16, dtype=torch.float32).reshape(4, hidden)
+    forward = (2, 0, 3, 1)
+    cube = raster.index_select(0, torch.tensor(forward))
+    selector = torch.tensor([11, 22, 33, 44], dtype=torch.long)
+    topology = SimpleNamespace(forward=forward)
+    layer = _RowLocalFinalLayer()
+    inner = SimpleNamespace(hidden_size=hidden, final_layer=layer)
+    module = SimpleNamespace(FinalLayer=_RowLocalFinalLayer)
+    state = _state(0, selector)
+
+    expected, _ = minimax_h3._final_layer_project(
+        inner,
+        module,
+        raster,
+        state,
+        (0, 4, selector),
+        (4, 4, 0),
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_FORECAST_HEAD_CHUNK_BYTES",
+        hidden * raster.element_size() * 2,
+    )
+    streamed = minimax_h3._project_cpu_forecast_stream(
+        inner,
+        module,
+        cube,
+        state,
+        global_start=0,
+        stream_rows=4,
+        selector=selector,
+        video=True,
+        device=torch.device("cpu"),
+        topology=topology,
+        reorder_selector=True,
+    )
+
+    torch.testing.assert_close(streamed, expected)
+
+
+def test_streamed_state_reconstruction_matches_monolithic_projection(monkeypatch):
+    torch.manual_seed(9)
+    rows = 5
+    hidden = 4
+    compact = torch.randn(rows, hidden)
+    state_rows = torch.randn(rows, 3)
+    projection = torch.nn.Linear(3, hidden, bias=False)
+    scale = 0.75
+    layer = _RowLocalFinalLayer()
+    inner = SimpleNamespace(hidden_size=hidden, final_layer=layer)
+    module = SimpleNamespace(FinalLayer=_RowLocalFinalLayer)
+    state = _state(1, 2)
+
+    reconstructed = compact + projection(state_rows).to(compact.dtype) * scale
+    _, expected = minimax_h3._final_layer_project(
+        inner,
+        module,
+        reconstructed,
+        state,
+        (rows, rows, 0),
+        (0, rows, state.audio_timestep_row),
+    )
+
+    monkeypatch.setattr(
+        minimax_h3,
+        "_FORECAST_HEAD_CHUNK_BYTES",
+        hidden * compact.element_size() * 2,
+    )
+    streamed = minimax_h3._project_cpu_forecast_stream(
+        inner,
+        module,
+        compact,
+        state,
+        global_start=0,
+        stream_rows=rows,
+        selector=state.audio_timestep_row,
+        video=False,
+        device=torch.device("cpu"),
+        state_rows_cpu=state_rows,
+        state_projection=projection,
+        state_scale=scale,
+    )
+
+    torch.testing.assert_close(streamed, expected)
+
+
+def test_same_dtype_sanitizer_reuses_storage_and_repairs_nonfinite():
+    feature = torch.tensor([1.0, -2.0, 3.0], dtype=torch.bfloat16)
+    sanitized, event = minimax_h3._sanitize_prediction(feature, torch.bfloat16)
+    assert sanitized is feature
+    assert event is None
+
+    damaged = torch.tensor(
+        [1.0, float("nan"), float("inf"), -float("inf")],
+        dtype=torch.bfloat16,
+    )
+    sanitized, event = minimax_h3._sanitize_prediction(damaged, torch.bfloat16)
+    assert sanitized is damaged
+    assert event == {"nonfinite": 3, "below": 0, "above": 0}
+    assert torch.isfinite(damaged).all()
+
+
+def test_streaming_identity_gate_rejects_foreign_final_layer(monkeypatch):
+    native = _RowLocalFinalLayer()
+    foreign = _ForeignFinalLayer(native)
+    module = SimpleNamespace(FinalLayer=_RowLocalFinalLayer)
+    monkeypatch.setattr(minimax_h3, "_native_module", lambda inner: module)
+
+    native_inner = SimpleNamespace(hidden_size=4, final_layer=native)
+    foreign_inner = SimpleNamespace(hidden_size=4, final_layer=foreign)
+    assert minimax_h3._final_layer_stream_kind(native_inner) == "native"
+    assert minimax_h3._final_layer_stream_kind(foreign_inner) is None
+    assert minimax_h3._resolve_final_layer_stream_compat(foreign_inner, 4) is None
+    assert minimax_h3._forecast_prediction_device(
+        foreign_inner,
+        torch.device("cuda:0"),
+    ) == torch.device("cuda:0")
+
+
+def test_h3_optimizations_contract_is_source_gated(monkeypatch):
+    layer = _H3OptimizationsCompatibleFinalLayer()
+    module = SimpleNamespace(FinalLayer=_RowLocalFinalLayer)
+    monkeypatch.setattr(minimax_h3, "_native_module", lambda inner: module)
+    inner = SimpleNamespace(hidden_size=4, final_layer=layer)
+
+    assert minimax_h3._final_layer_stream_kind(inner) == "h3_optimizations"
+    compat = minimax_h3._resolve_final_layer_stream_compat(inner, 4)
+    assert compat == (None, None, False, 2)
+
+    # Markers alone are insufficient when the callable does not originate from
+    # the reviewed H3-Optimizations FinalLayer module.
+    layer.forward.__func__.__module__ = __name__
+    try:
+        assert minimax_h3._final_layer_stream_kind(inner) is None
+    finally:
+        layer.forward.__func__.__module__ = "h3_optimizations.memory.final_layer"
+
+
+
+def test_unrecognized_final_layer_keeps_one_shot_projection(monkeypatch):
+    native = _RowLocalFinalLayer()
+    foreign = _ForeignFinalLayer(native)
+    inner = SimpleNamespace(
+        hidden_size=4,
+        final_layer=foreign,
+        patch_size=(1, 1, 1),
+        latents_dim=1,
+    )
+    module = SimpleNamespace(
+        FinalLayer=_RowLocalFinalLayer,
+        unpatchify_video=lambda value, *args: torch.zeros(1, 1, 1, 1, 1),
+        unpack_audio=lambda value: value,
+    )
+    monkeypatch.setattr(minimax_h3, "_native_module", lambda inner: module)
+    layout = SimpleNamespace(
+        segments=((0, 1, "audio"), (1, 2, "video")),
+        seq_len=2,
+    )
+    state = minimax_h3._OutputState(
+        layout=layout,
+        t_emb=torch.zeros(1, 4),
+        video_timestep_row=1,
+        audio_timestep_row=0,
+        sigma_v=torch.tensor(0.5),
+        sample_sigmas=torch.tensor([1.0, 0.5, 0.0]),
+        shift_v=1.0,
+        shift_a=1.0,
+        original_video_shape=(1, 1, 1),
+        padded_video_shape=(1, 1, 1),
+    )
+    predicted = torch.randn(1, 2, 4)
+    video_x = torch.zeros(1, 1, 1, 1, 1)
+    audio_x = torch.zeros(1, 1, 1, 1)
+
+    minimax_h3._execute_forecast(
+        inner,
+        predicted,
+        state,
+        video_x,
+        audio_x,
+    )
+
+    assert foreign.calls == 1
+
+@pytest.mark.parametrize("error_type", [AttributeError, ValueError])
+def test_state_conditioned_reconstruction_failure_falls_back_to_actual(
+    monkeypatch,
+    error_type,
+):
+    class FakeRuntime:
+        def __init__(self):
+            self.config = SimpleNamespace(debug=False)
+            self.active_state_conditioned_residual = True
+            self.offline_phase = None
+            self.active_stage_index = 0
+            self.last_prediction_chunk_count = 1
+            self.prediction_history_length = 2
+            self.fallback_reason = None
+
+        def begin_model_call(self, *args, **kwargs):
+            return 3, False
+
+        def predict(self, *args, **kwargs):
+            return torch.zeros(1, 2, 4)
+
+        def fallback_current_step(self, run_id, step_id, reason):
+            self.fallback_reason = reason
+
+    runtime = FakeRuntime()
+    layout = SimpleNamespace(
+        segments=((0, 1, "audio"), (1, 2, "video")),
+        seq_len=2,
+    )
+    inner = SimpleNamespace(hidden_size=4)
+    executor = SimpleNamespace(class_obj=inner)
+    options = {
+        minimax_h3.RUNTIME_KEY: runtime,
+        minimax_h3.RUN_ID_KEY: 1,
+        minimax_h3.STEP_ID_KEY: 2,
+    }
+    x = [
+        torch.zeros(1, 1, 1, 1, 1),
+        torch.zeros(1, 1, 1, 1),
+    ]
+    context = torch.zeros(1, 1, 4)
+    actual_result = [torch.tensor([123.0]), torch.tensor([456.0])]
+
+    monkeypatch.setattr(minimax_h3, "SpectrumH3Runtime", FakeRuntime)
+    monkeypatch.setattr(minimax_h3, "is_native_minimax_h3", lambda inner: True)
+    monkeypatch.setattr(minimax_h3, "_resolve_layout", lambda *args, **kwargs: layout)
+    monkeypatch.setattr(
+        minimax_h3,
+        "topology_signature",
+        lambda *args, **kwargs: ("fixture",),
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_forecast_prediction_device",
+        lambda inner, device: device,
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_prepare_output_state",
+        lambda *args, **kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_execute_forecast",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            error_type("fixture reconstruction failure")
+        ),
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_execute_actual",
+        lambda *args, **kwargs: actual_result,
+    )
+    monkeypatch.setattr(
+        backend_history,
+        "prepare",
+        lambda runtime, run_id, step_id, options, layout, inner: (options, None),
+    )
+
+    result = minimax_h3.diffusion_model_wrapper(
+        executor,
+        x,
+        torch.tensor([500.0]),
+        context,
+        options,
+        minimax_payload={},
+    )
+
+    assert result is actual_result
+    assert runtime.fallback_reason is not None
+    assert "state-conditioned residual forecast reconstruction failed" in (
+        runtime.fallback_reason
+    )


### PR DESCRIPTION
## Stream MiniMax H3 forecasts and fix retained actual-target VRAM

This PR substantially reduces Spectrum's GPU memory pressure on MiniMax H3, particularly on memory-constrained GPUs.

It addresses two separate sources of excessive VRAM use:

1. full forecast hidden states being materialized on CUDA
2. actual-step final hidden tensors remaining referenced on CUDA across later sampler steps

## 1. Stream forecast output projection from system RAM

Previously, Spectrum forecasting could require a full predicted hidden state to exist on CUDA before passing through the MiniMax H3 output head.

For large H3 video sequences, this hidden representation can be hundreds of MiB.

The forecast path now keeps predicted hidden features in system RAM and streams them through the H3 FinalLayer in bounded chunks.

### Bounded CUDA workspace

Forecast projection uses a fixed memory budget:

```python
_FORECAST_HEAD_CHUNK_BYTES = 16 * 1024 * 1024
```

The implementation determines the number of hidden rows that fit within that budget and transfers only that chunk to CUDA at a time.

A reusable hidden workspace is allocated for the forecast and reused across chunks instead of repeatedly allocating full-size forecast tensors.

Conceptually:

```text
CPU predicted hidden
        |
        | ~16 MiB chunk
        v
reusable CUDA workspace
        |
        v
MiniMax H3 FinalLayer
        |
        v
projected output
```

This avoids materializing the complete forecast hidden state on the GPU.

## CPU-side forecast prediction

When the H3 input is on CUDA, Spectrum now computes/materializes forecast hidden features on CPU.

The GPU is therefore used only for the bounded output-head projection rather than storing the complete predicted hidden trajectory.

This keeps Spectrum's large forecast history and prediction tensors out of scarce VRAM.

## Stream audio and video independently

The packed H3 target contains separate audio and video streams.

The output-head path projects those streams independently with `_project_cpu_forecast_stream()` while preserving MiniMax's exact row layout and timestep selectors.

Each stream is processed chunk-by-chunk and reconstructed into the normal model output after projection.

## Reusable state-conditioned residual workspace

State-conditioned residual forecasting is also compatible with the streamed path.

Exact H3 input-state rows can remain in system RAM and are transferred through their own bounded reusable CUDA workspace as needed.

This avoids reintroducing a full hidden-sized CUDA allocation when state-conditioned residual mode is enabled.

## H3-Optimizations / cube-order compatibility

The streaming implementation preserves compatibility with H3-Optimizations' cube-order path.

Spectrum resolves the underlying compatible FinalLayer when cube-order wrapping is active so chunked FinalLayer projection still uses the correct H3 output-head implementation.

The change does not disable or bypass H3 attention optimizations.

## FinalLayer chunk compatibility

The streamer also honors H3-Optimizations' FinalLayer memory/chunk constraints when available rather than assuming Spectrum's default chunk size is always appropriate.

This allows both projects' memory controls to cooperate.

## 2. Fix retained actual-target CUDA tensors

A separate VRAM issue was found in the actual H3 execution path.

Spectrum observes the final target hidden feature using a view into the final packed H3 hidden state:

```python
target = hidden[aa:vb].unsqueeze(0)
```

For the workload used to diagnose the issue, this tensor was:

```text
shape:        (1, 44541, 5376)
dtype:        bfloat16
tensor data:  ~456.7 MiB
CUDA storage: ~480 MiB
```

Spectrum correctly copied the history representation to system RAM, but the original CUDA view was also assigned unconditionally to `actual_target`.

Because `actual_target` is captured by the final-block replacement callback, that reference could outlive the immediate transformer call and pin the entire final-hidden CUDA storage.

Runtime diagnostics showed distinct ~480 MiB storages accumulating across actual steps.

For example, the number of retained target-hidden CUDA storages progressed from approximately:

```text
1 x ~480 MiB
2 x ~480 MiB
3 x ~480 MiB
4 x ~480 MiB
```

even though Spectrum history itself reported `retained_device=cpu`.

Eventually these live target tensors consumed enough VRAM that subsequent full H3 passes failed on large native allocations such as video patch projection or attention output buffers.

## Actual-target lifetime fix

The CUDA target view is now retained only when an active residual probe actually needs it:

```python
actual_target = target if residual_probe is not None else None
```

Normal actual steps therefore no longer keep an unnecessary reference to the final hidden CUDA storage.

When a residual probe does require the target, the same tensor is still available for the immediate comparison, preserving existing behavior.

The reference is explicitly cleared after that comparison:

```python
finally:
    actual_target = None
```

It is also cleared when the H3 executor raises, preventing an exception after target capture from leaving the large storage pinned.

## Why the target is not cloned

The target remains a view of the final H3 hidden state.

Cloning it would allocate another ~457 MiB CUDA tensor at peak memory usage, defeating the purpose of the fix.

Instead, this change corrects the lifetime of the existing view.

## Compatibility

These changes preserve the existing Spectrum functionality, including:

* streamed CPU forecast prediction
* bounded/reusable CUDA forecast workspaces
* streamed MiniMax H3 FinalLayer projection
* separate streamed audio and video projection
* state-conditioned residual forecasting
* exact H3 input-state reconstruction
* H3-Optimizations cube-order compatibility
* H3 FinalLayer chunk constraints
* model-aware forecasting and correction
* CPU-backed history
* ER-SDE integration
* residual probes

The actual-target fix is independent of the forecast streaming path: it controls the lifetime of an actual-step H3 hidden view, while the forecast streamer operates from CPU-predicted hidden features through its bounded CUDA workspace.

## Expected memory impact

The streaming changes eliminate the need to materialize a full forecast hidden representation on CUDA.

The actual-target fix additionally prevents old ~480 MiB final-hidden CUDA storages from accumulating across sampler steps.

Together, these changes significantly reduce Spectrum's peak and persistent VRAM requirements while preserving the existing H3 execution and forecasting behavior.

No model-quality change is intended.
