### PR TITLE
Audit weighted Mixed-Grid BSA history and VDN completion receipts

### DIFF
--- a/comfyui_spectrum_h3/backend_history.py
+++ b/comfyui_spectrum_h3/backend_history.py
@@ -44,6 +44,41 @@ def _provider_accepts(provider, receipts):
         return False
 
 
+def _core_bsa_numerical_receipts(audit, receipts):
+    """Drop only dispatch-local call tokens from accepted weighted BSA receipts.
+
+    Raw receipts remain the authority for ``accepts_actual``.  The per-preflight
+    call token proves that the current actual block consumed the capability bound
+    for that invocation, but it deliberately changes on every preflight and is
+    therefore not part of numerical history identity.  Every numerical field,
+    including cold/primed route, owner generation, measure digest, profile/route,
+    exact K range, preprocessing identity and VDN completion evidence, remains.
+    """
+    if getattr(audit, "measure", None) is None:
+        return receipts
+    normalized = []
+    for receipt in receipts:
+        # Accepted weighted core-BSA receipts have the measure evidence as field
+        # 8. Keep this fail closed even though callers invoke us only after the
+        # source-gated exact receipt comparison has succeeded.
+        if (
+            not isinstance(receipt, tuple)
+            or len(receipt) != 9
+            or not isinstance(receipt[8], tuple)
+            or len(receipt[8]) < 3
+            or receipt[8][0] != audit.measure.core.ATTENTION_MEASURE_KEY
+        ):
+            raise ValueError("accepted weighted core-BSA receipt has an invalid shape")
+        measure_receipt = receipt[8]
+        normalized.append(
+            (
+                *receipt[:8],
+                (measure_receipt[0], *measure_receipt[2:]),
+            )
+        )
+    return tuple(normalized)
+
+
 def _runtime_has_backend_evidence(runtime) -> bool:
     history = runtime._backend_history
     if history.policy is not None or history.receipt is not None:
@@ -189,6 +224,7 @@ def observe(runtime, run_id, step_id, options, policy):
         return
     identity, safe = policy
     receipts = tuple(options.get(RECEIPTS, ()))
+    numerical_receipts = receipts
 
     from . import core_bsa_compat
 
@@ -196,6 +232,12 @@ def observe(runtime, run_id, step_id, options, policy):
     if audit is not None:
         accepted = core_bsa_compat.accepts_actual(audit, receipts)
         safe = safe and accepted
+        if accepted:
+            try:
+                numerical_receipts = _core_bsa_numerical_receipts(audit, receipts)
+            except Exception:  # noqa: BLE001 - receipt normalization fails closed
+                safe = False
+                numerical_receipts = receipts
         if runtime.config.debug:
             routes = ",".join(
                 str(item[4]) if isinstance(item, tuple) and len(item) > 4 else "malformed"
@@ -235,4 +277,4 @@ def observe(runtime, run_id, step_id, options, policy):
                 identity[1],
                 len(receipts),
             )
-    runtime.observe_backend_history(run_id, step_id, identity, receipts, safe)
+    runtime.observe_backend_history(run_id, step_id, identity, numerical_receipts, safe)

--- a/comfyui_spectrum_h3/core_bsa_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_compat.py
@@ -21,20 +21,49 @@ import weakref
 
 import torch
 
+from . import vdn_measure_compat
+
 ADAPTER_KEY = "spectrum_core_bsa_v1"
 ADAPTER_VERSION = 1
 PRIVATE_AUDIT_KEY = "_spectrum_core_bsa_audit_v1"
 
-# Comfy-Org/ComfyUI comfy_extras/nodes_sparse_attention.py as reviewed at
-# be92396834f9b6e3e361cfe30e7eed693137a448 (unchanged from its parent).
-# Any source change is actual-only until the new implementation is audited.
+# Comfy-Org/ComfyUI comfy_extras/nodes_sparse_attention.py sources reviewed
+# for Spectrum numerical-history compatibility. The second blob is the generic
+# attention-measure implementation from ComfyUI PR #16239; unreviewed sources
+# remain actual-only.
 AUDITED_BSA_GIT_BLOBS = frozenset(
-    {"006d1eb352f946a7c85595edf75d3cda9ac79194"}
+    {
+        "006d1eb352f946a7c85595edf75d3cda9ac79194",
+        "a2b0d601529d776265b7b37cfe49b804158ae4a2",
+    }
 )
+MEASURE_CAPABLE_BSA_GIT_BLOBS = frozenset(
+    {"a2b0d601529d776265b7b37cfe49b804158ae4a2"}
+)
+# Only the optional-VDN-correct adapter is forecast-audited. The earlier
+# attention-measure adapter conflated Flow's API-2 geometry contract with VDN
+# ownership and can therefore fail a valid weighted Flow+BSA execution without
+# VDN; it remains actual-only rather than inheriting this proof.
+AUDITED_BSA_MEASURE_GIT_BLOBS = frozenset(
+    {"8c2b181dc663f43dbb09ca8035126a2a99fabfe5"}
+)
+AUDITED_ATTENTION_MEASURE_GIT_BLOBS = frozenset(
+    {"439f2798f8514d38ea56f12c330068b78e8fa539"}
+)
+ATTENTION_MEASURE_KEY = "attention_measure_v1"
+ATTENTION_MEASURE_CAPABILITIES_KEY = "attention_measure_capabilities_v1"
+CORE_BSA_MEASURE_PROVIDER = "comfy.core.block_sparse_attention"
+SPARSE_MEASURE_PROFILE = "weighted_exact_blocks_v1"
+SPARSE_MEASURE_ROUTE = "core_bsa_h3_chunked"
+SPARSE_MEASURE_PREPROCESS = "core_h3_chunked_rms_rope_split_half_v1"
+DENSE_MEASURE_PROFILE = "dense_exact_v1"
+DENSE_MEASURE_ROUTE = "core_dense_sdpa"
+DENSE_MEASURE_PREPROCESS = "caller_attention_domain_v1"
 
 _MISSING = object()
 _IDENTITY_LOCK = threading.RLock()
 _IDENTITY_COUNTER = itertools.count(1)
+_MEASURE_CALL_COUNTER = itertools.count(1)
 _IDENTITY_REGISTRY: dict[int, tuple[weakref.ReferenceType[Any] | None, int, Any | None]] = {}
 
 
@@ -80,6 +109,29 @@ def _lifetime_generation(value: Any) -> int:
         return generation
 
 
+@dataclass(frozen=True)
+class CoreBSAMeasureAudit:
+    bsa_module: Any
+    adapter: Any
+    core: Any
+    capability: Any
+    semantic_digest: str
+    normalized_request: Any
+    external_sequence: Any
+    owner_generation: str
+    provider_identity: str
+    q_rows: int
+    kv_rows: int
+    exact_k_block_range: tuple[int, int]
+    exact_range_digest: str
+    pool_keys: tuple[tuple[Any, ...], ...]
+    call_tokens: tuple[tuple[int, int], ...]
+    core_blob: str
+    adapter_blob: str
+    chunked_key_bias: bool
+    vdn: vdn_measure_compat.VDNMeasureAudit
+
+
 @dataclass
 class CoreBSAAudit:
     identity: tuple[Any, ...]
@@ -96,7 +148,9 @@ class CoreBSAAudit:
     expected_receipts: tuple[tuple[Any, ...], ...]
     source_blob: str
     current_override: Any
+    measure: CoreBSAMeasureAudit | None = None
     failure: str | None = None
+    vdn_receipts: list[Any] | None = None
 
 
 def has_core_bsa_callback(options: dict[str, Any]) -> bool:
@@ -527,6 +581,329 @@ def _replacement_ownership(
     )
 
 
+def _measure_audit(
+    module: Any,
+    source_blob: str,
+    patch: Any,
+    options: dict[str, Any],
+    layout: Any,
+    model: Any,
+    seq_len: int,
+    uuids: tuple[Any, ...],
+    layout_identity: tuple[Any, ...],
+    block_count: int,
+) -> tuple[CoreBSAMeasureAudit | None, str | None]:
+    request = options.get(ATTENTION_MEASURE_KEY, _MISSING)
+    if request is _MISSING:
+        return None, None
+    if source_blob not in MEASURE_CAPABLE_BSA_GIT_BLOBS:
+        return None, "measure_bsa_source_unreviewed"
+
+    adapter = getattr(module, "measure", None)
+    if adapter is None:
+        return None, "measure_adapter_missing"
+    try:
+        core = importlib.import_module("comfy.attention_measure")
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - source-gated optional contract
+        return None, "measure_core_missing"
+
+    adapter_blob = _module_blob_sha(adapter)
+    core_blob = _module_blob_sha(core)
+    if adapter_blob not in AUDITED_BSA_MEASURE_GIT_BLOBS:
+        return None, "measure_adapter_source_unreviewed"
+    if core_blob not in AUDITED_ATTENTION_MEASURE_GIT_BLOBS:
+        return None, "measure_core_source_unreviewed"
+
+    required_adapter = (
+        "ATTENTION_MEASURE_KEY",
+        "PROVIDER_IDENTITY",
+        "Capability",
+        "VDN_EXTERNAL_SEQUENCE_KEY",
+        "VDN_FORWARD_MARKER",
+        "VDN_EXTERNAL_SEQUENCE_API_ATTR",
+        "supports_key_bias",
+    )
+    required_core = (
+        "ATTENTION_MEASURE_CAPABILITIES_KEY",
+        "normalize",
+        "semantic_digest",
+        "validate_h3",
+        "merge_exact_k_blocks",
+    )
+    if any(not hasattr(adapter, name) for name in required_adapter) or any(
+        not hasattr(core, name) for name in required_core
+    ):
+        return None, "measure_source_shape_changed"
+    if (
+        adapter.ATTENTION_MEASURE_KEY != ATTENTION_MEASURE_KEY
+        or core.ATTENTION_MEASURE_CAPABILITIES_KEY
+        != ATTENTION_MEASURE_CAPABILITIES_KEY
+        or adapter.PROVIDER_IDENTITY != CORE_BSA_MEASURE_PROVIDER
+        or adapter.VDN_FORWARD_MARKER != vdn_measure_compat.VDN_FORWARD_MARKER
+        or adapter.VDN_EXTERNAL_SEQUENCE_API_ATTR
+        != vdn_measure_compat.VDN_EXTERNAL_SEQUENCE_API_ATTR
+    ):
+        return None, "measure_contract_identity_changed"
+
+    registry = options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+    capability = registry.get(CORE_BSA_MEASURE_PROVIDER) if isinstance(registry, dict) else None
+    owner_generation = getattr(patch, "measure_owner_generation", None)
+    if (
+        capability is None
+        or capability is not getattr(patch, "measure_capability", None)
+        or type(capability) is not adapter.Capability
+        or getattr(capability, "patch", None) is not patch
+        or not isinstance(owner_generation, str)
+        or not owner_generation
+        or not isinstance(getattr(patch, "measure_plans", None), dict)
+    ):
+        return None, "measure_capability_unproven"
+
+    external = options.get(adapter.VDN_EXTERNAL_SEQUENCE_KEY)
+    try:
+        normalized = core.validate_h3(
+            request,
+            layout=layout,
+            q_rows=seq_len,
+            kv_rows=seq_len,
+            external_sequence=external,
+        )
+        digest = core.semantic_digest(normalized)
+        sinks = _conditioning_sinks(patch, layout_identity, seq_len)
+        if sinks is None:
+            return None, "measure_sink_unproven"
+        exact_range = core.merge_exact_k_blocks(normalized, 64, sinks[0])
+        exact_range_digest = hashlib.sha256(
+            f"{exact_range[0]}:{exact_range[1]}".encode("ascii")
+        ).hexdigest()
+        chunked_key_bias = bool(adapter.supports_key_bias(module.ck.sol_attn_chunked))
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - malformed/stale measure must be actual-only
+        return None, "measure_contract_unproven"
+
+    vdn, vdn_reason = vdn_measure_compat.probe(
+        model, external, block_count, options
+    )
+    if vdn is None:
+        return None, vdn_reason or "vdn_owner_unproven"
+    if vdn.active and vdn_measure_compat.VDN_EPILOGUE_RECEIPTS_KEY in options:
+        return None, "vdn_receipt_ownership_conflict"
+
+    plan_identity = (
+        ATTENTION_MEASURE_KEY,
+        digest,
+        CORE_BSA_MEASURE_PROVIDER,
+        owner_generation,
+        SPARSE_MEASURE_ROUTE,
+        SPARSE_MEASURE_PREPROCESS,
+        SPARSE_MEASURE_PROFILE,
+    )
+    pool_keys = tuple(
+        (index, seq_len, uuids, plan_identity) for index in range(block_count)
+    )
+    with _IDENTITY_LOCK:
+        call_generation = next(_MEASURE_CALL_COUNTER)
+    call_tokens = tuple((call_generation, index) for index in range(block_count))
+    return CoreBSAMeasureAudit(
+        bsa_module=module,
+        adapter=adapter,
+        core=core,
+        capability=capability,
+        semantic_digest=digest,
+        normalized_request=_freeze(normalized),
+        external_sequence=_freeze(external),
+        owner_generation=owner_generation,
+        provider_identity=CORE_BSA_MEASURE_PROVIDER,
+        q_rows=seq_len,
+        kv_rows=seq_len,
+        exact_k_block_range=tuple(exact_range),
+        exact_range_digest=exact_range_digest,
+        pool_keys=pool_keys,
+        call_tokens=call_tokens,
+        core_blob=core_blob,
+        adapter_blob=adapter_blob,
+        chunked_key_bias=chunked_key_bias,
+        vdn=vdn,
+    ), None
+
+
+def _measure_identity(measure: CoreBSAMeasureAudit) -> tuple[Any, ...]:
+    return (
+        ATTENTION_MEASURE_KEY,
+        measure.semantic_digest,
+        ("provider", measure.provider_identity, measure.owner_generation),
+        ("sources", measure.core_blob, measure.adapter_blob),
+        ("rows", measure.q_rows, measure.kv_rows),
+        ("exact_range", measure.exact_k_block_range, measure.exact_range_digest),
+        ("mask", "none"),
+        ("sparse_profile", SPARSE_MEASURE_PROFILE, SPARSE_MEASURE_ROUTE, SPARSE_MEASURE_PREPROCESS),
+        ("dense_profile", DENSE_MEASURE_PROFILE, DENSE_MEASURE_ROUTE, DENSE_MEASURE_PREPROCESS),
+        ("external_sequence", measure.external_sequence),
+        ("vdn_epilogue", vdn_measure_compat.identity(measure.vdn)),
+        ("chunked_key_bias", measure.chunked_key_bias),
+        ("calibration_key_policy", "measure_bound_v1"),
+    )
+
+
+def _pool_key(audit: CoreBSAAudit, index: int) -> tuple[Any, ...]:
+    measure = getattr(audit, "measure", None)
+    if measure is not None:
+        return measure.pool_keys[index]
+    return index, audit.seq_len, audit.uuids
+
+
+def _measure_runtime_matches(
+    audit: CoreBSAAudit,
+    index: int,
+    call_options: Any,
+    *,
+    sparse_selected: bool,
+) -> bool:
+    measure = getattr(audit, "measure", None)
+    if not isinstance(call_options, dict):
+        return measure is None
+    request = call_options.get(ATTENTION_MEASURE_KEY, _MISSING)
+    if measure is None:
+        return request is _MISSING
+    if request is _MISSING:
+        return False
+    try:
+        registry = call_options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+        capability = (
+            registry.get(measure.provider_identity) if isinstance(registry, dict) else None
+        )
+        if (
+            capability is not measure.capability
+            or capability is not getattr(audit.patch, "measure_capability", None)
+            or getattr(capability, "patch", None) is not audit.patch
+            or getattr(audit.patch, "measure_owner_generation", None)
+            != measure.owner_generation
+        ):
+            return False
+        layout = call_options.get("minimax_h3_layout")
+        external = call_options.get(measure.adapter.VDN_EXTERNAL_SEQUENCE_KEY)
+        normalized = measure.core.validate_h3(
+            request,
+            layout=layout,
+            q_rows=audit.seq_len,
+            kv_rows=audit.seq_len,
+            external_sequence=external,
+        )
+        if (
+            measure.core.semantic_digest(normalized) != measure.semantic_digest
+            or _freeze(normalized) != measure.normalized_request
+            or _freeze(external) != measure.external_sequence
+            or not vdn_measure_compat.runtime_matches(measure.vdn, index)
+        ):
+            return False
+        if sparse_selected and not measure.adapter.supports_key_bias(
+            measure.bsa_module.ck.sol_attn_chunked
+        ):
+            return False
+        return type(index) is int and 0 <= index < audit.block_count
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - execution metadata mismatch is fail closed
+        return False
+
+
+def _measure_receipt_fields(
+    measure: CoreBSAMeasureAudit,
+    index: int,
+    route: str,
+    *,
+    completed: bool,
+    vdn_fields: tuple[tuple[str, Any], ...] | None = None,
+) -> tuple[Any, ...]:
+    if route == "h3_dense":
+        profile = DENSE_MEASURE_PROFILE
+        numerical_route = DENSE_MEASURE_ROUTE
+        preprocess = DENSE_MEASURE_PREPROCESS
+    else:
+        profile = SPARSE_MEASURE_PROFILE
+        numerical_route = SPARSE_MEASURE_ROUTE
+        preprocess = SPARSE_MEASURE_PREPROCESS
+    fields: tuple[Any, ...] = (
+        measure.call_tokens[index],
+        index,
+        measure.owner_generation,
+        measure.semantic_digest,
+        profile,
+        numerical_route,
+        measure.q_rows,
+        measure.kv_rows,
+        measure.exact_range_digest,
+        preprocess,
+    )
+    expected_vdn = vdn_measure_compat.expected_receipt(measure.vdn, index, route)
+    if expected_vdn is not None:
+        actual_vdn = (
+            (("vdn_receipt_missing", True),)
+            if vdn_fields is None
+            else vdn_fields
+        )
+        fields = (*fields, (vdn_measure_compat.VDN_EPILOGUE_KEY, *actual_vdn))
+    return (*fields, bool(completed))
+
+
+def _receipt(
+    audit: CoreBSAAudit,
+    index: int,
+    route: str,
+    *,
+    completed: bool,
+    vdn_fields: tuple[tuple[str, Any], ...] | None = None,
+) -> tuple[Any, ...]:
+    _expected_route, sink, sink_q = audit.route_specs[index]
+    receipt = (
+        ADAPTER_KEY,
+        ADAPTER_VERSION,
+        audit.patch_generation,
+        index,
+        route,
+        audit.seq_len,
+        sink,
+        sink_q,
+    )
+    measure = getattr(audit, "measure", None)
+    if measure is None:
+        return receipt
+    return (
+        *receipt,
+        (
+            ATTENTION_MEASURE_KEY,
+            *_measure_receipt_fields(
+                measure,
+                index,
+                route,
+                completed=completed,
+                vdn_fields=vdn_fields,
+            ),
+        ),
+    )
+
+
+def _expected_receipts(audit: CoreBSAAudit) -> tuple[tuple[Any, ...], ...]:
+    measure = getattr(audit, "measure", None)
+    return tuple(
+        _receipt(
+            audit,
+            index,
+            route,
+            completed=True,
+            vdn_fields=(
+                None
+                if measure is None
+                else vdn_measure_compat.expected_receipt(measure.vdn, index, route)
+            ),
+        )
+        for index, (route, _sink, _sink_q) in enumerate(audit.route_specs)
+    )
+
+
 def _pool_entry(
     patch: Any,
     key: tuple[Any, ...],
@@ -563,10 +940,12 @@ def _pool_ownership_identity(
     seq_len: int,
     uuids: tuple[Any, ...],
     pool_specs: tuple[tuple[int, int, str | None], ...],
+    measure: CoreBSAMeasureAudit | None = None,
 ) -> tuple[Any, ...]:
     ownership = []
     for index in range(block_count):
-        state = _pool_entry(patch, (index, seq_len, uuids), pool_specs[index])
+        key = measure.pool_keys[index] if measure is not None else (index, seq_len, uuids)
+        state = _pool_entry(patch, key, pool_specs[index])
         if state[0] == "present":
             ownership.append(
                 (
@@ -610,6 +989,7 @@ def _route_specs(
     options: dict[str, Any],
     sparse_runtime_ok: bool,
     pool_specs: tuple[tuple[int, int, str | None], ...],
+    measure: CoreBSAMeasureAudit | None = None,
 ) -> tuple[tuple[tuple[str, tuple[int, int], tuple[int, int]], ...], bool] | None:
     sigma = _sigma_value(options)
     if sigma is None:
@@ -626,6 +1006,8 @@ def _route_specs(
     if sinks is None:
         return None
     sink, sink_q = sinks
+    if measure is not None:
+        sink = measure.exact_k_block_range
     dense_set = set(dense_blocks)
     specs = []
     safe = True
@@ -633,11 +1015,12 @@ def _route_specs(
         if not inside_window or seq_len < min_tokens or index in dense_set:
             specs.append(("h3_dense", (0, 0), (0, 0)))
             continue
-        if not sparse_runtime_ok:
+        if not sparse_runtime_ok or (measure is not None and not measure.chunked_key_bias):
             safe = False
             specs.append(("h3_sparse_unproven", sink, sink_q))
             continue
-        state = _pool_entry(patch, (index, seq_len, uuids), pool_specs[index])
+        key = measure.pool_keys[index] if measure is not None else (index, seq_len, uuids)
+        state = _pool_entry(patch, key, pool_specs[index])
         if state[0] == "missing":
             route = "h3_chunked_sparse_cold"
         elif state[0] == "present":
@@ -694,6 +1077,21 @@ def probe(
         except (AttributeError, TypeError, ValueError, RuntimeError):
             return None, "pool_shape_unproven"
 
+        measure_audit, measure_reason = _measure_audit(
+            module,
+            source_blob,
+            patch,
+            options,
+            layout,
+            model,
+            seq_len,
+            uuids,
+            layout_identity,
+            len(model.blocks),
+        )
+        if measure_reason is not None:
+            return None, measure_reason
+
         sparse_runtime_ok = _sparse_runtime_eligible(model, module)
         routed = _route_specs(
             patch,
@@ -704,27 +1102,25 @@ def probe(
             options,
             sparse_runtime_ok,
             pool_specs,
+            measure_audit,
         )
         if routed is None:
             return None, "route_unproven"
         route_specs, safe = routed
         pool_ownership = _pool_ownership_identity(
-            patch, len(model.blocks), seq_len, uuids, pool_specs
-        )
-        expected_receipts = tuple(
-            (
-                ADAPTER_KEY,
-                ADAPTER_VERSION,
-                patch_generation,
-                index,
-                route,
-                seq_len,
-                sink,
-                sink_q,
-            )
-            for index, (route, sink, sink_q) in enumerate(route_specs)
+            patch,
+            len(model.blocks),
+            seq_len,
+            uuids,
+            pool_specs,
+            measure_audit,
         )
         mode = "sol-attn" if settings_identity[2] == 0.0 else "sla"
+        measure_identity = (
+            ()
+            if measure_audit is None
+            else (("attention_measure", _measure_identity(measure_audit)),)
+        )
         identity = (
             ADAPTER_KEY,
             ADAPTER_VERSION,
@@ -736,10 +1132,11 @@ def probe(
             ("uuids", _freeze(uuids)),
             ("routes", route_specs),
             ("pool_ownership", pool_ownership),
+            *measure_identity,
             ("ownership", ownership_identity),
             ("execution", execution_identity),
         )
-        return CoreBSAAudit(
+        audit = CoreBSAAudit(
             identity=identity,
             safe=bool(safe),
             patch=patch,
@@ -751,10 +1148,13 @@ def probe(
             settings_identity=settings_identity,
             route_specs=route_specs,
             pool_specs=pool_specs,
-            expected_receipts=expected_receipts,
+            expected_receipts=(),
             source_blob=source_blob,
             current_override=options.get("optimized_attention_override"),
-        ), None
+            measure=measure_audit,
+        )
+        audit.expected_receipts = _expected_receipts(audit)
+        return audit, None
     except torch.cuda.OutOfMemoryError:
         raise
     except Exception:  # noqa: BLE001 - all adapter introspection is fail closed
@@ -812,13 +1212,60 @@ def _current_route_matches(
     return not dense
 
 
+def _prepare_vdn_receipt_sink(
+    options: dict[str, Any], audit: CoreBSAAudit
+) -> dict[str, Any]:
+    measure = getattr(audit, "measure", None)
+    if measure is None or not measure.vdn.active:
+        return options
+    prepared = dict(options)
+    key = vdn_measure_compat.VDN_EPILOGUE_RECEIPTS_KEY
+    existing = prepared.get(key, _MISSING)
+    if existing is not _MISSING:
+        if existing is audit.vdn_receipts and isinstance(existing, list):
+            return prepared
+        audit.failure = "vdn_receipt_ownership_conflict"
+        return prepared
+    sink: list[Any] = []
+    prepared[key] = sink
+    audit.vdn_receipts = sink
+    return prepared
+
+
+def _vdn_receipt_before(audit: CoreBSAAudit) -> int | None:
+    measure = getattr(audit, "measure", None)
+    if measure is None or not measure.vdn.active:
+        return None
+    if not isinstance(audit.vdn_receipts, list):
+        return -1
+    return len(audit.vdn_receipts)
+
+
+def _vdn_receipt_after(
+    audit: CoreBSAAudit,
+    index: int,
+    route: str,
+    before: int | None,
+):
+    measure = getattr(audit, "measure", None)
+    if measure is None or not measure.vdn.active:
+        return True, None
+    return vdn_measure_compat.validate_receipt_delta(
+        measure.vdn,
+        index,
+        route,
+        audit.vdn_receipts,
+        before,
+    )
+
+
 def _make_actual_wrapper(
     audit: CoreBSAAudit,
     index: int,
     replacement: Any,
     receipts: list[Any],
 ):
-    key = (index, audit.seq_len, audit.uuids)
+    key = _pool_key(audit, index)
     replacement_closure = _closure_values(replacement)
     expected_attention = (
         replacement_closure.get("attention")
@@ -827,6 +1274,7 @@ def _make_actual_wrapper(
     )
 
     def audited_replacement(args, replacement_context):
+        vdn_before = _vdn_receipt_before(audit)
         try:
             metadata_ok = _current_route_matches(audit, index, args)
         except torch.cuda.OutOfMemoryError:
@@ -850,9 +1298,17 @@ def _make_actual_wrapper(
             output = replacement(args, replacement_context)
         else:
             def audited_original_block(call_args):
-                nonlocal sparse_selected, original_block_calls
+                nonlocal sparse_selected, original_block_calls, metadata_ok
                 original_block_calls += 1
                 sparse_selected = call_args.get("attention") is expected_attention
+                if not _measure_runtime_matches(
+                    audit,
+                    index,
+                    call_args.get("transformer_options"),
+                    sparse_selected=sparse_selected,
+                ):
+                    metadata_ok = False
+                    audit.failure = "actual_measure_metadata_failed"
                 if sparse_selected:
                     from .bsa_transition_probe import attention
                     call_args = {**call_args, "attention": attention(expected_attention, audit, index)}
@@ -871,18 +1327,22 @@ def _make_actual_wrapper(
                 after,
                 sparse_selected=sparse_selected,
             )
-            expected_route, expected_sink, expected_sink_q = audit.route_specs[index]
-            if not metadata_ok or observed != expected_route:
-                audit.failure = "actual_route_mismatch"
-            receipt = (
-                ADAPTER_KEY,
-                ADAPTER_VERSION,
-                audit.patch_generation,
+            vdn_ok, vdn_fields = _vdn_receipt_after(
+                audit, index, observed, vdn_before
+            )
+            expected_route, _expected_sink, _expected_sink_q = audit.route_specs[index]
+            if not vdn_ok:
+                audit.failure = "actual_vdn_epilogue_receipt_failed"
+            if not metadata_ok or observed != expected_route or not vdn_ok:
+                audit.failure = audit.failure or "actual_route_mismatch"
+            receipt = _receipt(
+                audit,
                 index,
                 observed,
-                audit.seq_len,
-                expected_sink,
-                expected_sink_q,
+                completed=bool(
+                    metadata_ok and observed == expected_route and vdn_ok
+                ),
+                vdn_fields=vdn_fields,
             )
             receipts.append(receipt)
         except torch.cuda.OutOfMemoryError:
@@ -898,7 +1358,9 @@ def instrument_actual_options(
     options: dict[str, Any], audit: CoreBSAAudit, receipts_key: str
 ) -> dict[str, Any]:
     """Wrap copied main-H3 replacements so an actual call proves its route."""
-    prepared = dict(options)
+    prepared = _prepare_vdn_receipt_sink(dict(options), audit)
+    if audit.failure is not None:
+        return prepared
     receipts = prepared.get(receipts_key)
     if not isinstance(receipts, list):
         audit.failure = "receipt_buffer_missing"
@@ -934,7 +1396,7 @@ def accepts_actual(audit: CoreBSAAudit, receipts: tuple[Any, ...]) -> bool:
         return False
     seen = set()
     for receipt in receipts:
-        if not isinstance(receipt, tuple) or len(receipt) != 8:
+        if not isinstance(receipt, tuple) or len(receipt) < 8:
             return False
         if receipt[0] != ADAPTER_KEY or receipt[1] != ADAPTER_VERSION:
             return False
@@ -946,4 +1408,11 @@ def accepts_actual(audit: CoreBSAAudit, receipts: tuple[Any, ...]) -> bool:
         seen.add(block)
         if receipt != audit.expected_receipts[block]:
             return False
+    measure = getattr(audit, "measure", None)
+    if measure is not None and not vdn_measure_compat.validate_final_receipts(
+        measure.vdn,
+        audit.route_specs,
+        audit.vdn_receipts,
+    ):
+        return False
     return seen == set(range(audit.block_count))

--- a/comfyui_spectrum_h3/core_bsa_flow_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_flow_compat.py
@@ -8,6 +8,7 @@ chain without depending on inference-tensor version counters.
 """
 from __future__ import annotations
 
+from math import gcd
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -24,11 +25,25 @@ AUDITED_FLOW_MIXED_GRID_GIT_BLOBS = frozenset(
     {
         "8fc0f753ff2cd21fae898a4dd3c9ab1025f98443",  # released v0.3.3
         "66c59f26ad41154fcce7e1ce5250fa233a96dc3b",  # PR #26 canonical layout propagation
+        "51b5bb068018f3336d1a036bd0065344788c3e6c",  # PR #30 first explicit weighted profile
+        "41586100e74e43e2efbfc3ef30a9540647f1c8f6",  # PR #30 authoritative optional profile semantics
     }
 )
 _FLOW_MIXED_LAYOUT_PROPAGATED_BLOBS = frozenset(
-    {"66c59f26ad41154fcce7e1ce5250fa233a96dc3b"}
+    {
+        "66c59f26ad41154fcce7e1ce5250fa233a96dc3b",
+        "51b5bb068018f3336d1a036bd0065344788c3e6c",
+        "41586100e74e43e2efbfc3ef30a9540647f1c8f6",
+    }
 )
+_FLOW_EXPLICIT_PROFILE_AUTHORITATIVE_BLOBS = frozenset(
+    {"41586100e74e43e2efbfc3ef30a9540647f1c8f6"}
+)
+_FLOW_MEASURE_PROFILE_OFF = "off"
+_FLOW_MEASURE_PROFILE_LEGACY = "legacy_representative_v1"
+_FLOW_MEASURE_PROFILE_WEIGHTED = "weighted_measure_v1"
+_ATTENTION_MEASURE_KEY = "attention_measure_v1"
+_VDN_EXTERNAL_SEQUENCE_KEY = "vdn_h3_external_sequence_v1"
 _FLOW_ATTENTION_TOPLEVEL = "h3_flow_regenerate.attention"
 _FLOW_ATTENTION_SUFFIX = ".h3_flow_regenerate.attention"
 _FLOW_MIXED_TOPLEVEL = "h3_flow_regenerate.mixed_grid"
@@ -156,7 +171,46 @@ def _audited_layout_wrapper(
     )
 
 
-def _plan_geometry(plan: Any) -> dict[str, Any] | None:
+def _normalize_measure_profile(
+    attention_measure: bool, raw_profile: Any, *, source_blob: str
+) -> str | None:
+    if type(attention_measure) is not bool:
+        return None
+    if source_blob not in AUDITED_FLOW_MIXED_GRID_GIT_BLOBS:
+        return None
+    if source_blob in _FLOW_EXPLICIT_PROFILE_AUTHORITATIVE_BLOBS:
+        if raw_profile is None:
+            return (
+                _FLOW_MEASURE_PROFILE_LEGACY
+                if attention_measure
+                else _FLOW_MEASURE_PROFILE_OFF
+            )
+        if type(raw_profile) is not str:
+            return None
+        if raw_profile not in {
+            _FLOW_MEASURE_PROFILE_OFF,
+            _FLOW_MEASURE_PROFILE_LEGACY,
+            _FLOW_MEASURE_PROFILE_WEIGHTED,
+        }:
+            return None
+        return raw_profile
+
+    if type(raw_profile) is not str:
+        return None
+    if raw_profile == _FLOW_MEASURE_PROFILE_OFF and attention_measure:
+        return _FLOW_MEASURE_PROFILE_LEGACY
+    if raw_profile == _FLOW_MEASURE_PROFILE_LEGACY and not attention_measure:
+        return None
+    if raw_profile not in {
+        _FLOW_MEASURE_PROFILE_OFF,
+        _FLOW_MEASURE_PROFILE_LEGACY,
+        _FLOW_MEASURE_PROFILE_WEIGHTED,
+    }:
+        return None
+    return raw_profile
+
+
+def _plan_geometry(plan: Any, *, source_blob: str) -> dict[str, Any] | None:
     try:
         prefix = plan.prefix
         prefix_noise = plan.prefix_noise
@@ -164,6 +218,13 @@ def _plan_geometry(plan: Any) -> dict[str, Any] | None:
         source_h = plan.source_h
         source_w = plan.source_w
         attention_measure = plan.attention_measure
+        raw_measure_profile = getattr(
+            plan,
+            "measure_profile",
+            None
+            if source_blob in _FLOW_EXPLICIT_PROFILE_AUTHORITATIVE_BLOBS
+            else _FLOW_MEASURE_PROFILE_OFF,
+        )
     except (AttributeError, RuntimeError, TypeError, ValueError):
         return None
     if not torch.is_tensor(prefix) or prefix.ndim != 5:
@@ -176,6 +237,11 @@ def _plan_geometry(plan: Any) -> dict[str, Any] | None:
         or type(source_w) is not int
         or type(attention_measure) is not bool
     ):
+        return None
+    measure_profile = _normalize_measure_profile(
+        attention_measure, raw_measure_profile, source_blob=source_blob
+    )
+    if measure_profile is None:
         return None
     prefix_t = int(prefix.shape[2])
     target_h, target_w = map(int, prefix.shape[-2:])
@@ -202,14 +268,54 @@ def _plan_geometry(plan: Any) -> dict[str, Any] | None:
         "target_rows": target_rows,
         "mixed_rows": mixed_rows,
         "attention_measure": attention_measure,
+        "measure_profile": measure_profile,
     }
 
 
 def _expected_measure_contract(
     geometry: dict[str, Any], *, video_start: int, sequence_rows: int
 ) -> dict[str, Any] | None:
-    if not geometry["attention_measure"]:
+    profile = geometry["measure_profile"]
+    if profile == _FLOW_MEASURE_PROFILE_OFF:
         return None
+    if profile == _FLOW_MEASURE_PROFILE_WEIGHTED:
+        source_rows = geometry["source_rows"]
+        target_rows = geometry["target_rows"]
+        common = gcd(source_rows, target_rows)
+        prefix_stop = video_start + geometry["prefix_t"] * target_rows
+        segments = [
+            {"start": 0, "stop": video_start, "mass_num": 1, "mass_den": 1},
+            {
+                "start": video_start,
+                "stop": prefix_stop,
+                "mass_num": source_rows // common,
+                "mass_den": target_rows // common,
+            },
+        ]
+        if prefix_stop < sequence_rows:
+            segments.append(
+                {
+                    "start": prefix_stop,
+                    "stop": sequence_rows,
+                    "mass_num": 1,
+                    "mass_den": 1,
+                }
+            )
+        return {
+            "api": 1,
+            "operator": "key_log_measure",
+            "normalization": "h3_native_source_carrier_v1",
+            "topology": "mixed_grid_low_suffix",
+            "q_rows": sequence_rows,
+            "kv_rows": sequence_rows,
+            "video_start": video_start,
+            "temporal": geometry["temporal"],
+            "prefix_t": geometry["prefix_t"],
+            "source_grid": [geometry["source_h"] // 2, geometry["source_w"] // 2],
+            "prefix_grid": [geometry["target_h"] // 2, geometry["target_w"] // 2],
+            "segments": segments,
+            "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+        }
     return {
         "api": 1,
         "mode": "prefix_kv_stratified_subsample",
@@ -227,6 +333,23 @@ def _expected_measure_contract(
         + geometry["temporal"] * geometry["source_rows"],
         "exact_prefix_queries_preserved": True,
         "suffix_kv_unchanged": True,
+    }
+
+
+def _expected_external_sequence(
+    geometry: dict[str, Any], *, video_start: int, native_sequence_rows: int, sequence_rows: int
+) -> dict[str, Any]:
+    return {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": native_sequence_rows,
+        "sequence_rows": sequence_rows,
+        "video_start": video_start,
+        "temporal": geometry["temporal"],
+        "prefix_t": geometry["prefix_t"],
+        "source_rows_per_frame": geometry["source_rows"],
+        "prefix_rows_per_frame": geometry["target_rows"],
     }
 
 
@@ -280,7 +403,7 @@ def _audited_mixed_wrapper(
     closed_carrier = closure["layout"]
     if type(plan) is not getattr(module, "MixedGridPlan", object):
         return None
-    geometry = _plan_geometry(plan)
+    geometry = _plan_geometry(plan, source_blob=blob)
     if geometry is None:
         return None
     normalized_carrier = core_bsa_compat._normalize_layout(carrier_layout)
@@ -366,6 +489,8 @@ def _audited_mixed_wrapper(
         "native": native,
         "inner": model,
         "measure_contract": expected_measure,
+        "measure_profile": geometry["measure_profile"],
+        "geometry": geometry,
         "old_prefix": closure["old_prefix"],
         "va": va,
         "vb": vb,
@@ -532,6 +657,8 @@ def probe(options: dict[str, Any], layout: Any, model: Any):
                     or item["native"] is not mixed["native"]
                     or item["inner"] is not mixed["inner"]
                     or item["measure_contract"] != mixed["measure_contract"]
+                    or item["measure_profile"] != mixed["measure_profile"]
+                    or item["geometry"] != mixed["geometry"]
                     or item["old_prefix"] != mixed["old_prefix"]
                     or item["va"] != mixed["va"]
                     or item["vb"] != mixed["vb"]
@@ -543,6 +670,16 @@ def probe(options: dict[str, Any], layout: Any, model: Any):
         normalized_patches["dit"] = normalized_dit
         normalized["patches_replace"] = normalized_patches
         audit_layout = _effective_mixed_layout(mixed, layout) if mixed is not None else layout
+        if mixed is not None and mixed["measure_profile"] == _FLOW_MEASURE_PROFILE_WEIGHTED:
+            if _ATTENTION_MEASURE_KEY in options or _VDN_EXTERNAL_SEQUENCE_KEY in options:
+                return None, "flow_weighted_measure_ownership_conflict"
+            normalized[_ATTENTION_MEASURE_KEY] = mixed["measure_contract"]
+            normalized[_VDN_EXTERNAL_SEQUENCE_KEY] = _expected_external_sequence(
+                mixed["geometry"],
+                video_start=mixed["va"],
+                native_sequence_rows=mixed["carrier_seq"],
+                sequence_rows=mixed["mixed_seq"],
+            )
         audit, reason = core_bsa_compat.probe(normalized, audit_layout, model)
         if audit is None:
             return None, reason
@@ -608,7 +745,7 @@ def _pool_entry(
 ) -> tuple[Any, ...]:
     return core_bsa_compat._pool_entry(
         audit.patch,
-        (index, audit.seq_len, audit.uuids),
+        core_bsa_compat._pool_key(audit, index),
         audit.pool_specs[index],
     )
 
@@ -677,6 +814,7 @@ def _make_actual_wrapper(
     )
 
     def audited_replacement(args, replacement_context):
+        vdn_before = core_bsa_compat._vdn_receipt_before(audit)
         try:
             metadata_ok = _current_metadata_matches(audit, index, args)
             before = _pool_entry(audit, index)
@@ -698,9 +836,17 @@ def _make_actual_wrapper(
             output = replacement(args, replacement_context)
         else:
             def audited_original_block(call_args):
-                nonlocal sparse_selected, original_block_calls
+                nonlocal sparse_selected, original_block_calls, metadata_ok
                 original_block_calls += 1
                 sparse_selected = call_args.get("attention") is expected_attention
+                if not core_bsa_compat._measure_runtime_matches(
+                    audit,
+                    index,
+                    call_args.get("transformer_options"),
+                    sparse_selected=sparse_selected,
+                ):
+                    metadata_ok = False
+                    audit.failure = "actual_measure_metadata_failed"
                 if sparse_selected:
                     from .bsa_transition_probe import attention
                     call_args = {**call_args, "attention": attention(expected_attention, audit, index)}
@@ -719,19 +865,23 @@ def _make_actual_wrapper(
                 after,
                 sparse_selected=sparse_selected,
             )
-            expected_route, expected_sink, expected_sink_q = audit.route_specs[index]
-            if not metadata_ok or observed != expected_route:
-                audit.failure = "actual_route_mismatch"
+            vdn_ok, vdn_fields = core_bsa_compat._vdn_receipt_after(
+                audit, index, observed, vdn_before
+            )
+            expected_route, _expected_sink, _expected_sink_q = audit.route_specs[index]
+            if not vdn_ok:
+                audit.failure = "actual_vdn_epilogue_receipt_failed"
+            if not metadata_ok or observed != expected_route or not vdn_ok:
+                audit.failure = audit.failure or "actual_route_mismatch"
             receipts.append(
-                (
-                    core_bsa_compat.ADAPTER_KEY,
-                    core_bsa_compat.ADAPTER_VERSION,
-                    audit.patch_generation,
+                core_bsa_compat._receipt(
+                    audit,
                     index,
                     observed,
-                    audit.seq_len,
-                    expected_sink,
-                    expected_sink_q,
+                    completed=bool(
+                        metadata_ok and observed == expected_route and vdn_ok
+                    ),
+                    vdn_fields=vdn_fields,
                 )
             )
         except torch.cuda.OutOfMemoryError:
@@ -750,7 +900,9 @@ def instrument_actual_options(
 ) -> dict[str, Any]:
     if not hasattr(audit, "flow_wrapper_specs"):
         return core_bsa_compat.instrument_actual_options(options, audit, receipts_key)
-    prepared = dict(options)
+    prepared = core_bsa_compat._prepare_vdn_receipt_sink(dict(options), audit)
+    if audit.failure is not None:
+        return prepared
     receipts = prepared.get(receipts_key)
     patches = prepared.get("patches_replace")
     if not isinstance(receipts, list) or not isinstance(patches, dict):

--- a/comfyui_spectrum_h3/core_bsa_forecast_recovery.py
+++ b/comfyui_spectrum_h3/core_bsa_forecast_recovery.py
@@ -91,7 +91,7 @@ def _capture_transition_proof(runtime, run_id: int, step_id: int, audit, receipt
     for index in sparse:
         entry = core_bsa_compat._pool_entry(
             audit.patch,
-            (index, audit.seq_len, audit.uuids),
+            core_bsa_compat._pool_key(audit, index),
             audit.pool_specs[index],
         )
         if entry[0] != "present":
@@ -154,7 +154,7 @@ def _prove_forecast_carry(runtime, run_id: int, step_id: int, audit, identity, s
     for index, owners in zip(sparse, proof.owners):
         entry = core_bsa_compat._pool_entry(
             audit.patch,
-            (index, audit.seq_len, audit.uuids),
+            core_bsa_compat._pool_key(audit, index),
             audit.pool_specs[index],
         )
         if (

--- a/comfyui_spectrum_h3/core_bsa_loader_compat.py
+++ b/comfyui_spectrum_h3/core_bsa_loader_compat.py
@@ -229,6 +229,21 @@ def _runtime_alias_probe(
         except (AttributeError, TypeError, ValueError, RuntimeError):
             return None, "pool_shape_unproven"
 
+        measure_audit, measure_reason = core_bsa_compat._measure_audit(
+            module,
+            source_blob,
+            patch,
+            options,
+            layout,
+            model,
+            seq_len,
+            uuids,
+            layout_identity,
+            len(model.blocks),
+        )
+        if measure_reason is not None:
+            return None, measure_reason
+
         sparse_runtime_ok = core_bsa_compat._sparse_runtime_eligible(model, module)
         routed = core_bsa_compat._route_specs(
             patch,
@@ -239,6 +254,7 @@ def _runtime_alias_probe(
             options,
             sparse_runtime_ok,
             pool_specs,
+            measure_audit,
         )
         if routed is None:
             return None, "route_unproven"
@@ -249,21 +265,14 @@ def _runtime_alias_probe(
             seq_len,
             uuids,
             pool_specs,
-        )
-        expected_receipts = tuple(
-            (
-                core_bsa_compat.ADAPTER_KEY,
-                core_bsa_compat.ADAPTER_VERSION,
-                patch_generation,
-                index,
-                route,
-                seq_len,
-                sink,
-                sink_q,
-            )
-            for index, (route, sink, sink_q) in enumerate(route_specs)
+            measure_audit,
         )
         mode = "sol-attn" if settings_identity[2] == 0.0 else "sla"
+        measure_identity = (
+            ()
+            if measure_audit is None
+            else (("attention_measure", core_bsa_compat._measure_identity(measure_audit)),)
+        )
         identity = (
             core_bsa_compat.ADAPTER_KEY,
             core_bsa_compat.ADAPTER_VERSION,
@@ -275,10 +284,11 @@ def _runtime_alias_probe(
             ("uuids", core_bsa_compat._freeze(uuids)),
             ("routes", route_specs),
             ("pool_ownership", pool_ownership),
+            *measure_identity,
             ("ownership", ownership_identity),
             ("execution", execution_identity),
         )
-        return core_bsa_compat.CoreBSAAudit(
+        audit = core_bsa_compat.CoreBSAAudit(
             identity=identity,
             safe=bool(safe),
             patch=patch,
@@ -290,10 +300,13 @@ def _runtime_alias_probe(
             settings_identity=settings_identity,
             route_specs=route_specs,
             pool_specs=pool_specs,
-            expected_receipts=expected_receipts,
+            expected_receipts=(),
             source_blob=source_blob,
             current_override=options.get("optimized_attention_override"),
-        ), None
+            measure=measure_audit,
+        )
+        audit.expected_receipts = core_bsa_compat._expected_receipts(audit)
+        return audit, None
     except torch.cuda.OutOfMemoryError:
         raise
     except Exception:  # noqa: BLE001 - source/ownership introspection stays fail closed

--- a/comfyui_spectrum_h3/vdn_measure_compat.py
+++ b/comfyui_spectrum_h3/vdn_measure_compat.py
@@ -1,0 +1,518 @@
+"""Source-gated VDN ownership and completion receipts for weighted H3 measure.
+
+The Flow API-2 external-sequence contract describes Mixed-Grid geometry; it does
+not imply that VDN is installed.  This module distinguishes an absent VDN owner
+from the reviewed VDN attention owner and, when VDN is present, binds Spectrum's
+numerical identity to the concrete learned-gate/output-projection epilogue.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sys
+from typing import Any, Mapping
+
+import torch
+
+VDN_FORWARD_MARKER = "_vdn_forward"
+VDN_EXTERNAL_SEQUENCE_API_ATTR = "_vdn_external_sequence_api"
+VDN_EPILOGUE_KEY = "vdn_h3_external_softmax_epilogue_v1"
+VDN_EPILOGUE_RECEIPTS_KEY = "vdn_h3_external_softmax_epilogue_receipts_v1"
+VDN_EXTERNAL_SEQUENCE_API = 2
+
+AUDITED_VDN_HYBRID_GIT_BLOBS = frozenset(
+    {"bdaf4c59e6ff26acfaa6bffb902423f103b5c18b"}
+)
+AUDITED_VDN_EPILOGUE_GIT_BLOBS = frozenset(
+    {"e363ecdf814144fdf3c700b3eeb551776207a773"}
+)
+
+_EXTERNAL_COUNT_FIELDS = (
+    "native_sequence_rows",
+    "sequence_rows",
+    "video_start",
+    "temporal",
+    "prefix_t",
+    "source_rows_per_frame",
+    "prefix_rows_per_frame",
+)
+
+
+@dataclass(frozen=True)
+class VDNMeasureAudit:
+    active: bool
+    attentions: tuple[Any, ...]
+    forwards: tuple[Any, ...]
+    capabilities: tuple[Any, ...]
+    owner_generations: tuple[str, ...]
+    config_digests: tuple[str, ...]
+    weight_owner_digests: tuple[str, ...]
+    gate_expected: tuple[bool, ...]
+    external_digest: str | None
+    external_counts: tuple[tuple[str, int], ...]
+    expected_receipts: tuple[tuple[tuple[str, Any], ...], ...]
+    hybrid_blob: str | None
+    epilogue_blob: str | None
+    epilogue_module: Any | None
+
+
+def _core():
+    # Imported lazily because core_bsa_compat delegates its VDN proof here.
+    from . import core_bsa_compat
+
+    return core_bsa_compat
+
+
+def _loaded_exact_module(name: str, expected_blobs: frozenset[str]):
+    module = sys.modules.get(name)
+    if module is None or getattr(module, "__name__", None) != name:
+        return None, None
+    blob = _core()._module_blob_sha(module)
+    if blob not in expected_blobs:
+        return None, blob
+    return module, blob
+
+
+def _external_digest(epilogue_module, external: Any) -> str | None:
+    if not isinstance(external, Mapping) or external.get("api") != VDN_EXTERNAL_SEQUENCE_API:
+        return None
+    if any(type(external.get(name)) is not int for name in _EXTERNAL_COUNT_FIELDS):
+        return None
+    normalized = {name: int(external[name]) for name in _EXTERNAL_COUNT_FIELDS}
+    try:
+        digest = epilogue_module._digest(normalized)
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - audited companion introspection fails closed
+        return None
+    return digest if isinstance(digest, str) and digest else None
+
+
+def _state_layout_matches_external(
+    state: Any, external_counts: tuple[tuple[str, int], ...]
+) -> bool:
+    counts = dict(external_counts)
+    layout = getattr(state, "layout", None)
+    if layout is None:
+        return False
+    try:
+        return (
+            int(layout.seq_len) == counts["native_sequence_rows"]
+            and int(layout.video_start) == counts["video_start"]
+            and int(layout.num_frames) == counts["temporal"]
+            and int(layout.tokens_per_frame) == counts["source_rows_per_frame"]
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return False
+
+
+def _current_capability_fields(
+    epilogue_module,
+    capability,
+    attention,
+    index: int,
+    external_digest: str,
+    external_counts: tuple[tuple[str, int], ...],
+    *,
+    require_active_layout: bool = True,
+):
+    try:
+        if (
+            getattr(capability, "api", None) != 1
+            or getattr(capability, "block_index", None) != index
+            or getattr(capability, "out_proj", None) is not attention.out_proj
+            or int(capability.heads) != int(attention.heads)
+            or int(capability.head_dim) != int(attention.head_dim)
+        ):
+            return None
+        state = capability.state
+        branches = state.branches
+        if not isinstance(branches, (tuple, list)) or index >= len(branches):
+            return None
+        branch = branches[index]
+        if capability.branch_owner is not branch:
+            return None
+        weight_owner = epilogue_module._weight_owner(state, branch)
+        if capability.weight_owner is not weight_owner:
+            return None
+        owner_generation = capability.owner_generation
+        config_digest = capability.config_digest
+        weight_owner_digest = capability.weight_owner_digest
+        if not all(isinstance(value, str) and value for value in (
+            owner_generation, config_digest, weight_owner_digest
+        )):
+            return None
+        if epilogue_module._digest(
+            epilogue_module._config_identity(state, index, branch)
+        ) != config_digest:
+            return None
+        expected_weight_digest = epilogue_module._digest(
+            {
+                "epilogue_owner_generation": owner_generation,
+                "owner_type": None
+                if weight_owner is None
+                else f"{type(weight_owner).__module__}.{type(weight_owner).__qualname__}",
+                "block_index": index,
+                "branch_present": branch is not None,
+            }
+        )
+        if expected_weight_digest != weight_owner_digest:
+            return None
+        cfg = state.cfg
+        if not isinstance(cfg, Mapping):
+            return None
+        if require_active_layout and not _state_layout_matches_external(
+            state, external_counts
+        ):
+            return None
+        gate_expected = bool(branch is not None and cfg.get("enable_softmax_gate", True))
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001 - ownership proof fails closed
+        return None
+
+    fields = (
+        ("vdn_owner_generation", owner_generation),
+        ("vdn_config_digest", config_digest),
+        ("vdn_weight_owner_digest", weight_owner_digest),
+        ("vdn_external_digest", external_digest),
+        ("vdn_gate_expected", gate_expected),
+        ("vdn_gate_calls", 1 if gate_expected else 0),
+        ("vdn_projection_calls", 1),
+        ("vdn_completed", True),
+    )
+    return fields
+
+
+def _spectrum_wrapper(function: Any) -> bool:
+    module = sys.modules.get("comfyui_spectrum_h3.minimax_h3")
+    expected = None if module is None else getattr(module, "diffusion_model_wrapper", None)
+    return function is expected and callable(expected)
+
+
+def _deferred_layout_context_proven(
+    hybrid: Any, state: Any, options: Any
+) -> bool:
+    if not isinstance(options, Mapping):
+        return False
+    wrappers = options.get("wrappers")
+    if not isinstance(wrappers, Mapping):
+        return False
+    groups = wrappers.get("diffusion_model")
+    if not isinstance(groups, Mapping):
+        return False
+
+    expected_code = _core()._nested_code(hybrid.make_layout_wrapper, "wrap")
+    if expected_code is None:
+        return False
+
+    flattened = []
+    try:
+        for key, functions in groups.items():
+            if not isinstance(functions, (tuple, list)):
+                return False
+            for function in functions:
+                flattened.append((key, function))
+    except Exception:  # noqa: BLE001 - malformed wrapper metadata fails closed
+        return False
+
+    spectrum_indices = [
+        index
+        for index, (key, function) in enumerate(flattened)
+        if key == "spectrum_minimax_h3" and _spectrum_wrapper(function)
+    ]
+    vdn_indices = []
+    for index, (key, function) in enumerate(flattened):
+        if key != "vdn_h3":
+            continue
+        base = getattr(function, "__func__", function)
+        if (
+            getattr(base, "__module__", None) != "vdn_h3.hybrid"
+            or getattr(base, "__qualname__", None)
+            != "make_layout_wrapper.<locals>.wrap"
+            or getattr(base, "__code__", None) is not expected_code
+        ):
+            continue
+        closure = _core()._closure_values(base)
+        if closure is None or set(closure) != {"state"} or closure.get("state") is not state:
+            continue
+        vdn_indices.append(index)
+
+    # If VDN has already executed outside Spectrum, state.layout is live and this
+    # helper is not needed.  A missing layout is safe to defer only when the exact
+    # wrapper for this VDN state is still downstream of this Spectrum wrapper.
+    return (
+        len(spectrum_indices) == 1
+        and len(vdn_indices) == 1
+        and spectrum_indices[0] < vdn_indices[0]
+    )
+
+
+def probe(
+    model: Any, external: Any, block_count: int, options: Any = None
+):
+    """Return reviewed per-block VDN epilogue ownership, or a fail-closed reason."""
+    try:
+        blocks = getattr(model, "blocks", None)
+        if not isinstance(blocks, (tuple, list, torch.nn.ModuleList)) or len(blocks) != block_count:
+            return None, "vdn_model_shape_unproven"
+        attentions = tuple(block.attn for block in blocks)
+        forwards = tuple(attention.forward for attention in attentions)
+        marked = tuple(
+            getattr(forward, VDN_FORWARD_MARKER, False) is True for forward in forwards
+        )
+    except torch.cuda.OutOfMemoryError:
+        raise
+    except Exception:  # noqa: BLE001
+        return None, "vdn_owner_introspection_failed"
+
+    if not any(marked):
+        return VDNMeasureAudit(
+            active=False,
+            attentions=attentions,
+            forwards=forwards,
+            capabilities=(),
+            owner_generations=(),
+            config_digests=(),
+            weight_owner_digests=(),
+            gate_expected=(),
+            external_digest=None,
+            external_counts=(),
+            expected_receipts=(),
+            hybrid_blob=None,
+            epilogue_blob=None,
+            epilogue_module=None,
+        ), None
+    if not all(marked):
+        return None, "vdn_owner_incomplete"
+
+    if not isinstance(external, Mapping) or external.get("api") != VDN_EXTERNAL_SEQUENCE_API:
+        return None, "vdn_external_contract_missing"
+    if external.get("mode") != "dense_gate_no_linear" or external.get("topology") != "mixed_grid_low_suffix":
+        return None, "vdn_external_contract_unreviewed"
+
+    hybrid, hybrid_blob = _loaded_exact_module(
+        "vdn_h3.hybrid", AUDITED_VDN_HYBRID_GIT_BLOBS
+    )
+    epilogue, epilogue_blob = _loaded_exact_module(
+        "vdn_h3.mixed_measure_epilogue", AUDITED_VDN_EPILOGUE_GIT_BLOBS
+    )
+    if hybrid is None or epilogue is None:
+        return None, "vdn_source_unreviewed"
+    required_hybrid = ("make_vdn_forward", "make_layout_wrapper")
+    required_epilogue = (
+        "ExternalSoftmaxEpilogueCapability",
+        "_config_identity",
+        "_weight_owner",
+        "_digest",
+    )
+    if any(not hasattr(hybrid, name) for name in required_hybrid) or any(
+        not hasattr(epilogue, name) for name in required_epilogue
+    ):
+        return None, "vdn_source_shape_changed"
+    expected_code = _core()._nested_code(hybrid.make_vdn_forward, "vdn_forward")
+    if expected_code is None:
+        return None, "vdn_forward_code_unproven"
+
+    external_digest = _external_digest(epilogue, external)
+    if external_digest is None:
+        return None, "vdn_external_digest_unproven"
+    external_counts = tuple(
+        (name, int(external[name])) for name in _EXTERNAL_COUNT_FIELDS
+    )
+
+    capabilities = []
+    owner_generations = []
+    config_digests = []
+    weight_owner_digests = []
+    gate_expected = []
+    expected_receipts = []
+    states = []
+    for index, (attention, forward) in enumerate(zip(attentions, forwards)):
+        if (
+            getattr(forward, "__module__", None) != "vdn_h3.hybrid"
+            or getattr(forward, "__qualname__", None)
+            != "make_vdn_forward.<locals>.vdn_forward"
+            or getattr(forward, "__code__", None) is not expected_code
+            or getattr(forward, VDN_EXTERNAL_SEQUENCE_API_ATTR, None)
+            != VDN_EXTERNAL_SEQUENCE_API
+        ):
+            return None, "vdn_forward_owner_unproven"
+        capability = getattr(forward, VDN_EPILOGUE_KEY, None)
+        if type(capability) is not epilogue.ExternalSoftmaxEpilogueCapability:
+            return None, "vdn_epilogue_capability_unproven"
+        active_layout = _state_layout_matches_external(
+            capability.state, external_counts
+        )
+        if not active_layout and not _deferred_layout_context_proven(
+            hybrid, capability.state, options
+        ):
+            return None, "vdn_execution_context_unproven"
+        fields = _current_capability_fields(
+            epilogue,
+            capability,
+            attention,
+            index,
+            external_digest,
+            external_counts,
+            require_active_layout=active_layout,
+        )
+        if fields is None:
+            return None, "vdn_epilogue_owner_unproven"
+        capabilities.append(capability)
+        states.append(capability.state)
+        owner_generations.append(dict(fields)["vdn_owner_generation"])
+        config_digests.append(dict(fields)["vdn_config_digest"])
+        weight_owner_digests.append(dict(fields)["vdn_weight_owner_digest"])
+        gate_expected.append(bool(dict(fields)["vdn_gate_expected"]))
+        expected_receipts.append(fields)
+    if states and any(state is not states[0] for state in states[1:]):
+        return None, "vdn_state_owner_inconsistent"
+
+    return VDNMeasureAudit(
+        active=True,
+        attentions=attentions,
+        forwards=forwards,
+        capabilities=tuple(capabilities),
+        owner_generations=tuple(owner_generations),
+        config_digests=tuple(config_digests),
+        weight_owner_digests=tuple(weight_owner_digests),
+        gate_expected=tuple(gate_expected),
+        external_digest=external_digest,
+        external_counts=external_counts,
+        expected_receipts=tuple(expected_receipts),
+        hybrid_blob=hybrid_blob,
+        epilogue_blob=epilogue_blob,
+        epilogue_module=epilogue,
+    ), None
+
+
+def identity(audit: VDNMeasureAudit):
+    if not audit.active:
+        return ("absent",)
+    return (
+        "reviewed_vdn_external_softmax_epilogue_v1",
+        ("sources", audit.hybrid_blob, audit.epilogue_blob),
+        ("external_digest", audit.external_digest),
+        (
+            "blocks",
+            tuple(
+                (
+                    index,
+                    audit.owner_generations[index],
+                    audit.config_digests[index],
+                    audit.weight_owner_digests[index],
+                    audit.gate_expected[index],
+                )
+                for index in range(len(audit.forwards))
+            ),
+        ),
+    )
+
+
+def _same_forward_owner(current: Any, expected: Any) -> bool:
+    """Compare a callable and its bound owner without relying on bound-method identity."""
+    current_func = getattr(current, "__func__", None)
+    expected_func = getattr(expected, "__func__", None)
+    if current_func is not None or expected_func is not None:
+        return (
+            current_func is expected_func
+            and getattr(current, "__self__", None) is getattr(expected, "__self__", None)
+        )
+    return current is expected
+
+
+def runtime_matches(audit: VDNMeasureAudit, index: int) -> bool:
+    if type(index) is not int or index < 0 or index >= len(audit.attentions):
+        return False
+    try:
+        forward = audit.attentions[index].forward
+    except Exception:  # noqa: BLE001
+        return False
+    if not _same_forward_owner(forward, audit.forwards[index]):
+        return False
+    if not audit.active:
+        return getattr(forward, VDN_FORWARD_MARKER, False) is not True
+    if (
+        getattr(forward, VDN_FORWARD_MARKER, False) is not True
+        or getattr(forward, VDN_EXTERNAL_SEQUENCE_API_ATTR, None)
+        != VDN_EXTERNAL_SEQUENCE_API
+        or getattr(forward, VDN_EPILOGUE_KEY, None) is not audit.capabilities[index]
+    ):
+        return False
+    fields = _current_capability_fields(
+        audit.epilogue_module,
+        audit.capabilities[index],
+        audit.attentions[index],
+        index,
+        audit.external_digest,
+        audit.external_counts,
+    )
+    return fields == audit.expected_receipts[index]
+
+
+def expected_receipt(audit: VDNMeasureAudit, index: int, route: str):
+    if not audit.active or route == "h3_dense":
+        return None
+    if type(index) is not int or index < 0 or index >= len(audit.expected_receipts):
+        return None
+    return audit.expected_receipts[index]
+
+
+def validate_receipt_delta(
+    audit: VDNMeasureAudit,
+    index: int,
+    route: str,
+    sink: Any,
+    before: int | None,
+):
+    """Validate exactly the receipt produced by this block invocation."""
+    expected = expected_receipt(audit, index, route)
+    if not audit.active:
+        return True, None
+    if not isinstance(sink, list) or type(before) is not int or before < 0:
+        return False, None
+    if expected is None:
+        return (len(sink) == before), None
+    if len(sink) != before + 1:
+        return False, None
+    item = sink[-1]
+    if (
+        not isinstance(item, tuple)
+        or len(item) != 2
+        or item[0] != index
+        or item[1] != expected
+    ):
+        return False, None
+    return True, item[1]
+
+
+def validate_final_receipts(
+    audit: VDNMeasureAudit,
+    route_specs: tuple[tuple[str, Any, Any], ...],
+    sink: Any,
+) -> bool:
+    if not audit.active:
+        return sink is None
+    if not isinstance(sink, list):
+        return False
+    expected = tuple(
+        (index, audit.expected_receipts[index])
+        for index, (route, _sink, _sink_q) in enumerate(route_specs)
+        if route != "h3_dense"
+    )
+    return tuple(sink) == expected
+
+
+__all__ = [
+    "AUDITED_VDN_EPILOGUE_GIT_BLOBS",
+    "AUDITED_VDN_HYBRID_GIT_BLOBS",
+    "VDN_EPILOGUE_KEY",
+    "VDN_EPILOGUE_RECEIPTS_KEY",
+    "VDNMeasureAudit",
+    "expected_receipt",
+    "identity",
+    "probe",
+    "runtime_matches",
+    "validate_final_receipts",
+    "validate_receipt_delta",
+]

--- a/tests/test_core_bsa_flow_compat.py
+++ b/tests/test_core_bsa_flow_compat.py
@@ -189,24 +189,30 @@ def _rebind(wrapper, **changes):
     )
 
 
-def _mixed_shared(model, mixed):
+def _mixed_shared(model, mixed, *, attention_measure=False, measure_profile=None):
     _attention, mixed_module = _flow_modules()
     from h3_flow_regenerate.metrics import H3FlowMetrics
     import comfy.ldm.minimax.model as native
 
+    plan_kwargs = {"attention_measure": attention_measure}
+    if measure_profile is not None:
+        plan_kwargs["measure_profile"] = measure_profile
     plan = mixed_module.MixedGridPlan(
         prefix=torch.zeros(1, 24, 1, 8, 8),
         temporal=8,
         source_h=4,
         source_w=4,
         prefix_noise=torch.zeros(1, 24, 1, 8, 8),
-        attention_measure=False,
+        **plan_kwargs,
+    )
+    measure_contract = mixed_module.mixed_attention_measure_contract(
+        plan, video_start=96, sequence_rows=140
     )
     return {
         "cached": {},
         "inner": model,
         "layout": _layout(),
-        "measure_contract": None,
+        "measure_contract": measure_contract,
         "metrics": H3FlowMetrics(),
         "mixed_layout": mixed,
         "native": native,
@@ -234,10 +240,17 @@ def _mixed_wrapper(previous, index, carrier, mixed, model, shared):
     return wrapper
 
 
-def _wrap_mixed(options, model, *, include_all=True):
+def _wrap_mixed(
+    options, model, *, include_all=True, attention_measure=False, measure_profile=None
+):
     carrier = _layout()
     mixed = _mixed_layout()
-    shared = _mixed_shared(model, mixed)
+    shared = _mixed_shared(
+        model,
+        mixed,
+        attention_measure=attention_measure,
+        measure_profile=measure_profile,
+    )
     out = dict(options)
     patches = dict(options["patches_replace"])
     dit = dict(patches["dit"])
@@ -289,6 +302,133 @@ def test_unknown_outer_block_wrapper_stays_fail_closed():
     audit, reason = core_bsa_flow_compat.probe(options, _layout(), model)
     assert audit is None
     assert reason == "flow_wrapper_unreviewed"
+
+
+def test_weighted_mixed_grid_preflight_synthesizes_block_local_contracts_without_mutation(monkeypatch):
+    _attention, mixed_module = _flow_modules()
+    if not hasattr(mixed_module, "MIXED_GRID_MEASURE_PROFILE_WEIGHTED"):
+        pytest.skip("Flow fixture predates the explicit weighted measure profile")
+
+    model, _patch, _override, options = _installation(sigma=0.5)
+    nodes = _audited_nodes()
+    # Match the production lifecycle: patch/ON_PREPARE_STATE registers the
+    # owner-bound measure capability before Spectrum probes the model call.
+    nodes.install_override(_patch, options)
+
+    # This CPU fixture cannot load the candidate GPU kernel. Expose only the
+    # provider ABI that Spectrum audits; the cross-repo workflow separately
+    # source-checks the pinned CUDA/HIP candidate for this key_bias parameter.
+    def key_bias_capable_chunked(*args, key_bias=None, **kwargs):
+        raise AssertionError("CPU compatibility audit must not execute the sparse kernel")
+
+    monkeypatch.setattr(nodes.ck, "sol_attn_chunked", key_bias_capable_chunked)
+    monkeypatch.setattr(core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True)
+    options, carrier, mixed = _wrap_mixed(
+        options,
+        model,
+        measure_profile=mixed_module.MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+    )
+    assert "attention_measure_v1" not in options
+    assert "vdn_h3_external_sequence_v1" not in options
+
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.measure is not None
+    assert audit.measure.q_rows == 140
+    assert audit.measure.kv_rows == 140
+    expected_measure = {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "q_rows": 140,
+        "kv_rows": 140,
+        "video_start": 96,
+        "temporal": 8,
+        "prefix_t": 1,
+        "source_grid": [2, 2],
+        "prefix_grid": [4, 4],
+        "segments": [
+            {"start": 0, "stop": 96, "mass_num": 1, "mass_den": 1},
+            {"start": 96, "stop": 112, "mass_num": 1, "mass_den": 4},
+            {"start": 112, "stop": 140, "mass_num": 1, "mass_den": 1},
+        ],
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+    }
+    assert audit.measure.normalized_request == core_bsa_compat._freeze(expected_measure)
+    expected_external = {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 128,
+        "sequence_rows": 140,
+        "video_start": 96,
+        "temporal": 8,
+        "prefix_t": 1,
+        "source_rows_per_frame": 4,
+        "prefix_rows_per_frame": 16,
+    }
+    assert dict(audit.measure.external_sequence) == expected_external
+    assert "attention_measure_v1" not in options
+    assert "vdn_h3_external_sequence_v1" not in options
+
+    actual = dict(options)
+    actual["minimax_h3_layout"] = mixed
+    actual["attention_measure_v1"] = expected_measure
+    actual["vdn_h3_external_sequence_v1"] = expected_external
+    assert core_bsa_compat._measure_runtime_matches(
+        audit, 0, actual, sparse_selected=True
+    )
+
+    missing = dict(actual)
+    missing.pop("attention_measure_v1")
+    assert not core_bsa_compat._measure_runtime_matches(
+        audit, 0, missing, sparse_selected=True
+    )
+    tampered = dict(actual)
+    tampered["vdn_h3_external_sequence_v1"] = {**expected_external, "prefix_t": 2}
+    assert not core_bsa_compat._measure_runtime_matches(
+        audit, 0, tampered, sparse_selected=True
+    )
+
+
+def test_legacy_mixed_grid_measure_flag_is_not_reinterpreted_as_weighted(monkeypatch):
+    _attention, mixed_module = _flow_modules()
+    model, _patch, _override, options = _installation(sigma=0.5)
+    monkeypatch.setattr(core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True)
+    options, carrier, _mixed = _wrap_mixed(options, model, attention_measure=True)
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.measure is None
+    assert audit.flow_mixed is True
+    assert audit.flow_identity is not None
+    assert "attention_measure_v1" not in options
+    assert "vdn_h3_external_sequence_v1" not in options
+    plan = core_bsa_compat._closure_values(
+        options["patches_replace"]["dit"][("double_block", 0)]
+    )["plan"]
+    if hasattr(mixed_module, "mixed_attention_measure_profile"):
+        assert (
+            mixed_module.mixed_attention_measure_profile(plan)
+            == mixed_module.MIXED_GRID_MEASURE_PROFILE_LEGACY
+        )
+
+
+def test_weighted_mixed_grid_rejects_preowned_block_local_contracts(monkeypatch):
+    _attention, mixed_module = _flow_modules()
+    if not hasattr(mixed_module, "MIXED_GRID_MEASURE_PROFILE_WEIGHTED"):
+        pytest.skip("Flow fixture predates the explicit weighted measure profile")
+    model, _patch, _override, options = _installation(sigma=0.5)
+    monkeypatch.setattr(core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True)
+    options, carrier, _mixed = _wrap_mixed(
+        options,
+        model,
+        measure_profile=mixed_module.MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+    )
+    options["attention_measure_v1"] = {"foreign": True}
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert audit is None
+    assert reason == "flow_weighted_measure_ownership_conflict"
 
 
 def test_reviewed_mixed_grid_wrapper_uses_propagated_layout_and_exact_kv_sinks(monkeypatch):
@@ -455,3 +595,105 @@ def test_untwist_plus_flow_wrapper_reaches_core_bsa_audit():
     assert reason is None and audit is not None and audit.safe
     assert audit.current_override is outer
     assert hasattr(audit, "flow_wrapper_specs")
+
+
+
+def test_measure_profile_semantics_follow_reviewed_flow_source_revision():
+    old_blob = "51b5bb068018f3336d1a036bd0065344788c3e6c"
+    new_blob = "41586100e74e43e2efbfc3ef30a9540647f1c8f6"
+
+    assert core_bsa_flow_compat._normalize_measure_profile(
+        True,
+        core_bsa_flow_compat._FLOW_MEASURE_PROFILE_OFF,
+        source_blob=old_blob,
+    ) == core_bsa_flow_compat._FLOW_MEASURE_PROFILE_LEGACY
+    assert (
+        core_bsa_flow_compat._normalize_measure_profile(
+            False,
+            core_bsa_flow_compat._FLOW_MEASURE_PROFILE_LEGACY,
+            source_blob=old_blob,
+        )
+        is None
+    )
+
+    assert core_bsa_flow_compat._normalize_measure_profile(
+        True, None, source_blob=new_blob
+    ) == core_bsa_flow_compat._FLOW_MEASURE_PROFILE_LEGACY
+    assert core_bsa_flow_compat._normalize_measure_profile(
+        False, None, source_blob=new_blob
+    ) == core_bsa_flow_compat._FLOW_MEASURE_PROFILE_OFF
+    assert core_bsa_flow_compat._normalize_measure_profile(
+        True,
+        core_bsa_flow_compat._FLOW_MEASURE_PROFILE_OFF,
+        source_blob=new_blob,
+    ) == core_bsa_flow_compat._FLOW_MEASURE_PROFILE_OFF
+    assert core_bsa_flow_compat._normalize_measure_profile(
+        False,
+        core_bsa_flow_compat._FLOW_MEASURE_PROFILE_LEGACY,
+        source_blob=new_blob,
+    ) == core_bsa_flow_compat._FLOW_MEASURE_PROFILE_LEGACY
+    assert core_bsa_flow_compat._normalize_measure_profile(
+        False,
+        core_bsa_flow_compat._FLOW_MEASURE_PROFILE_WEIGHTED,
+        source_blob=new_blob,
+    ) == core_bsa_flow_compat._FLOW_MEASURE_PROFILE_WEIGHTED
+
+
+def test_explicit_off_profile_is_authoritative_over_legacy_flag(monkeypatch):
+    _attention, mixed_module = _flow_modules()
+    if (
+        core_bsa_compat._module_blob_sha(mixed_module)
+        not in core_bsa_flow_compat._FLOW_EXPLICIT_PROFILE_AUTHORITATIVE_BLOBS
+    ):
+        pytest.skip("Flow fixture predates authoritative optional profile semantics")
+
+    model, _patch, _override, options = _installation(sigma=0.5)
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    options, carrier, _mixed = _wrap_mixed(
+        options,
+        model,
+        attention_measure=True,
+        measure_profile=mixed_module.MIXED_GRID_MEASURE_PROFILE_OFF,
+    )
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.measure is None
+    plan = core_bsa_compat._closure_values(
+        options["patches_replace"]["dit"][("double_block", 0)]
+    )["plan"]
+    assert (
+        mixed_module.mixed_attention_measure_profile(plan)
+        == mixed_module.MIXED_GRID_MEASURE_PROFILE_OFF
+    )
+
+
+def test_explicit_legacy_profile_is_authoritative_without_legacy_flag(monkeypatch):
+    _attention, mixed_module = _flow_modules()
+    if (
+        core_bsa_compat._module_blob_sha(mixed_module)
+        not in core_bsa_flow_compat._FLOW_EXPLICIT_PROFILE_AUTHORITATIVE_BLOBS
+    ):
+        pytest.skip("Flow fixture predates authoritative optional profile semantics")
+
+    model, _patch, _override, options = _installation(sigma=0.5)
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    options, carrier, _mixed = _wrap_mixed(
+        options,
+        model,
+        attention_measure=False,
+        measure_profile=mixed_module.MIXED_GRID_MEASURE_PROFILE_LEGACY,
+    )
+    audit, reason = core_bsa_flow_compat.probe(options, carrier, model)
+    assert reason is None and audit is not None and audit.safe
+    assert audit.measure is None
+    plan = core_bsa_compat._closure_values(
+        options["patches_replace"]["dit"][("double_block", 0)]
+    )["plan"]
+    assert (
+        mixed_module.mixed_attention_measure_profile(plan)
+        == mixed_module.MIXED_GRID_MEASURE_PROFILE_LEGACY
+    )

--- a/tests/test_core_bsa_measure_history.py
+++ b/tests/test_core_bsa_measure_history.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import core_bsa_compat
+
+
+def _measure_nodes():
+    required = os.getenv("SPECTRUM_REQUIRE_REVIEWED_BSA_MEASURE_FIXTURE") == "1"
+    try:
+        import comfy_extras.nodes_sparse_attention as nodes
+    except Exception as exc:  # noqa: BLE001
+        if required:
+            pytest.fail(f"required measure-capable core BSA fixture failed to import: {exc}")
+        pytest.skip(f"measure-capable core BSA fixture unavailable: {exc}")
+    blob = core_bsa_compat._module_blob_sha(nodes)
+    if blob not in core_bsa_compat.MEASURE_CAPABLE_BSA_GIT_BLOBS:
+        if required:
+            pytest.fail(f"required measure-capable core BSA blob not loaded: {blob}")
+        pytest.skip("this ComfyUI fixture is not the reviewed measure-capable BSA source")
+    return nodes
+
+
+class _Attention:
+    def __init__(self):
+        self.heads = 2
+        self.head_dim = 128
+        self.qkv_proj = SimpleNamespace(
+            weight=torch.empty(1, dtype=torch.bfloat16, device="cpu")
+        )
+
+    def forward(self, x, rope_freqs=None, transformer_options=None):
+        return x
+
+
+class _Block:
+    def __init__(self):
+        self.attn = _Attention()
+
+
+class _Model:
+    def __init__(self, count=2):
+        self.blocks = [_Block() for _ in range(count)]
+        self.dtype = torch.bfloat16
+
+
+def _layout():
+    return SimpleNamespace(
+        seq_len=192,
+        signature=(64, 2, 16, 16, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, 192, "video"),
+        ],
+    )
+
+
+def _request(*, source_grid=(4, 8), prefix_grid=(8, 8)):
+    source_rows = source_grid[0] * source_grid[1]
+    prefix_rows = prefix_grid[0] * prefix_grid[1]
+    return {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+        "q_rows": 192,
+        "kv_rows": 192,
+        "video_start": 96,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_grid": list(source_grid),
+        "prefix_grid": list(prefix_grid),
+        "segments": [
+            {"start": 0, "stop": 96, "mass_num": 1, "mass_den": 1},
+            {
+                "start": 96,
+                "stop": 96 + prefix_rows,
+                "mass_num": source_rows,
+                "mass_den": prefix_rows,
+            },
+            {
+                "start": 96 + prefix_rows,
+                "stop": 192,
+                "mass_num": 1,
+                "mass_den": 1,
+            },
+        ],
+    }
+
+
+def _installation(monkeypatch, *, count=2):
+    nodes = _measure_nodes()
+    model = _Model(count)
+    patch = nodes.SparseAttnPatch(
+        tau=1.0,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=0,
+        verbose=False,
+    )
+    override = nodes.make_attention_override(patch, None)
+    patch.installed.add(override)
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {
+            "dit": {
+                ("double_block", index): nodes.make_h3_block_patch(block, index, patch)
+                for index, block in enumerate(model.blocks)
+            }
+        },
+        "sigmas": torch.tensor([0.5]),
+        "uuids": ("positive",),
+        "minimax_h3_layout": _layout(),
+        core_bsa_compat.ATTENTION_MEASURE_KEY: _request(),
+    }
+    nodes.measure.register(patch, options)
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    monkeypatch.setattr(nodes.measure, "supports_key_bias", lambda _provider: True)
+    return nodes, model, patch, options
+
+
+def test_measure_fixture_is_source_pinned_when_required():
+    nodes = _measure_nodes()
+    assert core_bsa_compat._module_blob_sha(nodes) in core_bsa_compat.MEASURE_CAPABLE_BSA_GIT_BLOBS
+    assert core_bsa_compat._module_blob_sha(nodes.measure) in core_bsa_compat.AUDITED_BSA_MEASURE_GIT_BLOBS
+    import comfy.attention_measure as core_measure
+    assert core_bsa_compat._module_blob_sha(core_measure) in core_bsa_compat.AUDITED_ATTENTION_MEASURE_GIT_BLOBS
+
+
+def test_weighted_measure_changes_exact_sink_and_uses_measure_bound_pool(monkeypatch):
+    _nodes, model, patch, options = _installation(monkeypatch)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None
+    assert audit is not None and audit.safe and audit.measure is not None
+    assert audit.measure.semantic_digest
+    assert audit.measure.exact_k_block_range == (0, 3)
+    assert {spec[0] for spec in audit.route_specs} == {"h3_chunked_sparse_cold"}
+    assert {spec[1] for spec in audit.route_specs} == {(0, 3)}
+    assert len(audit.expected_receipts[0]) == 9
+    measure_receipt = audit.expected_receipts[0][8]
+    assert measure_receipt[0] == core_bsa_compat.ATTENTION_MEASURE_KEY
+    assert measure_receipt[2] == 0
+    assert measure_receipt[5] == core_bsa_compat.SPARSE_MEASURE_PROFILE
+    assert measure_receipt[6] == core_bsa_compat.SPARSE_MEASURE_ROUTE
+    assert measure_receipt[-1] is True
+
+    shape = (model.blocks[0].attn.heads, model.blocks[0].attn.head_dim)
+    for index in range(len(model.blocks)):
+        key = audit.measure.pool_keys[index]
+        assert key != (index, audit.seq_len, audit.uuids)
+        patch.pooled[key] = (
+            torch.zeros(shape, dtype=torch.float32),
+            torch.zeros(shape, dtype=torch.float32),
+        )
+
+    primed, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and primed is not None and primed.safe
+    assert {spec[0] for spec in primed.route_specs} == {"h3_chunked_sparse_primed"}
+
+
+def test_measure_digest_and_pool_key_change_for_anisotropic_grid_identity(monkeypatch):
+    _nodes, model, _patch, options = _installation(monkeypatch)
+    first, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and first is not None and first.measure is not None
+
+    changed = dict(options)
+    changed[core_bsa_compat.ATTENTION_MEASURE_KEY] = _request(
+        source_grid=(8, 4), prefix_grid=(8, 8)
+    )
+    second, reason = core_bsa_compat.probe(changed, _layout(), model)
+    assert reason is None and second is not None and second.measure is not None
+    assert first.measure.semantic_digest != second.measure.semantic_digest
+    assert first.measure.pool_keys != second.measure.pool_keys
+    assert first.identity != second.identity
+
+
+def test_foreign_measure_capability_fails_closed(monkeypatch):
+    _nodes, model, _patch, options = _installation(monkeypatch)
+    registry = dict(options[core_bsa_compat.ATTENTION_MEASURE_CAPABILITIES_KEY])
+    registry[core_bsa_compat.CORE_BSA_MEASURE_PROVIDER] = object()
+    options[core_bsa_compat.ATTENTION_MEASURE_CAPABILITIES_KEY] = registry
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "measure_capability_unproven"
+
+
+def test_missing_chunked_key_bias_is_actual_only_for_sparse_route(monkeypatch):
+    nodes, model, _patch, options = _installation(monkeypatch)
+    monkeypatch.setattr(nodes.measure, "supports_key_bias", lambda _provider: False)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None
+    assert not audit.safe
+    assert {spec[0] for spec in audit.route_specs} == {"h3_sparse_unproven"}
+
+
+def test_measure_disappearance_between_preflight_and_actual_is_rejected(monkeypatch):
+    _nodes, model, _patch, options = _installation(monkeypatch, count=1)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+    call_options = dict(options)
+    call_options.pop(core_bsa_compat.ATTENTION_MEASURE_KEY)
+    assert not core_bsa_compat._measure_runtime_matches(
+        audit,
+        0,
+        call_options,
+        sparse_selected=True,
+    )
+
+
+def test_unweighted_fixture_keeps_legacy_eight_field_receipt(monkeypatch):
+    nodes = _measure_nodes()
+    model = _Model(1)
+    patch = nodes.SparseAttnPatch(
+        tau=1.0,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=0,
+        verbose=False,
+    )
+    override = nodes.make_attention_override(patch, None)
+    patch.installed.add(override)
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {
+            "dit": {("double_block", 0): nodes.make_h3_block_patch(model.blocks[0], 0, patch)}
+        },
+        "sigmas": torch.tensor([0.5]),
+        "uuids": ("positive",),
+    }
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is None
+    assert len(audit.expected_receipts[0]) == 8

--- a/tests/test_core_bsa_measure_receipt_identity.py
+++ b/tests/test_core_bsa_measure_receipt_identity.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from comfyui_spectrum_h3 import backend_history, core_bsa_compat, core_bsa_forecast_recovery
+
+
+def _audit():
+    core = SimpleNamespace(ATTENTION_MEASURE_KEY=core_bsa_compat.ATTENTION_MEASURE_KEY)
+    return SimpleNamespace(measure=SimpleNamespace(core=core))
+
+
+def _receipt(*, call_generation=1, route="h3_chunked_sparse_primed", digest="measure-a"):
+    block = 0
+    measure = (
+        core_bsa_compat.ATTENTION_MEASURE_KEY,
+        (call_generation, block),
+        block,
+        "owner-generation",
+        digest,
+        core_bsa_compat.SPARSE_MEASURE_PROFILE,
+        core_bsa_compat.SPARSE_MEASURE_ROUTE,
+        192,
+        192,
+        "exact-range-digest",
+        core_bsa_compat.SPARSE_MEASURE_PREPROCESS,
+        True,
+    )
+    return (
+        core_bsa_compat.ADAPTER_KEY,
+        core_bsa_compat.ADAPTER_VERSION,
+        7,
+        block,
+        route,
+        192,
+        (0, 3),
+        (0, 0),
+        measure,
+    )
+
+
+def test_weighted_bsa_call_token_is_not_numerical_receipt_identity():
+    audit = _audit()
+    first = backend_history._core_bsa_numerical_receipts(
+        audit, (_receipt(call_generation=11),)
+    )
+    second = backend_history._core_bsa_numerical_receipts(
+        audit, (_receipt(call_generation=12),)
+    )
+
+    assert first == second
+    normalized_measure = first[0][8]
+    assert normalized_measure[0] == core_bsa_compat.ATTENTION_MEASURE_KEY
+    assert (11, 0) not in normalized_measure
+    assert normalized_measure[1] == 0
+
+
+def test_weighted_bsa_numerical_receipt_keeps_route_and_measure_identity():
+    audit = _audit()
+    baseline = backend_history._core_bsa_numerical_receipts(
+        audit, (_receipt(call_generation=11),)
+    )
+    changed_route = backend_history._core_bsa_numerical_receipts(
+        audit, (_receipt(call_generation=12, route="h3_chunked_sparse_cold"),)
+    )
+    changed_measure = backend_history._core_bsa_numerical_receipts(
+        audit, (_receipt(call_generation=12, digest="measure-b"),)
+    )
+
+    assert changed_route != baseline
+    assert changed_measure != baseline
+
+
+def test_unweighted_bsa_receipts_remain_byte_for_byte_compatible():
+    receipt = (
+        core_bsa_compat.ADAPTER_KEY,
+        core_bsa_compat.ADAPTER_VERSION,
+        7,
+        0,
+        "h3_chunked_sparse_primed",
+        192,
+        (0, 1),
+        (0, 0),
+    )
+    audit = SimpleNamespace(measure=None)
+    receipts = (receipt,)
+    assert backend_history._core_bsa_numerical_receipts(audit, receipts) is receipts
+
+
+def test_observe_verifies_raw_receipt_but_stores_token_free_identity(monkeypatch):
+    audit = _audit()
+    raw = (_receipt(call_generation=31),)
+    accepted = []
+
+    def accepts_actual(observed_audit, receipts):
+        accepted.append((observed_audit, receipts))
+        return True
+
+    monkeypatch.setattr(core_bsa_compat, "accepts_actual", accepts_actual)
+
+    class Runtime:
+        config = SimpleNamespace(debug=False)
+
+        def __init__(self):
+            self.observed = None
+
+        def observe_backend_history(self, run_id, step_id, identity, receipts, safe):
+            self.observed = (run_id, step_id, identity, receipts, safe)
+
+    runtime = Runtime()
+    options = {
+        core_bsa_compat.PRIVATE_AUDIT_KEY: audit,
+        backend_history.RECEIPTS: list(raw),
+    }
+    original_observe = core_bsa_forecast_recovery._ORIGINAL_OBSERVE
+    assert original_observe is not None
+    original_observe(runtime, 4, 9, options, ("policy", True))
+
+    assert accepted == [(audit, raw)]
+    assert runtime.observed[:3] == (4, 9, "policy")
+    assert runtime.observed[4] is True
+    assert runtime.observed[3] == backend_history._core_bsa_numerical_receipts(audit, raw)
+    assert runtime.observed[3] != raw

--- a/tests/test_core_bsa_vdn_measure_compat.py
+++ b/tests/test_core_bsa_vdn_measure_compat.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfyui_spectrum_h3 import core_bsa_compat, vdn_measure_compat
+from comfyui_spectrum_h3.minimax_h3 import diffusion_model_wrapper
+
+
+def _measure_nodes():
+    required = os.getenv("SPECTRUM_REQUIRE_REVIEWED_BSA_MEASURE_FIXTURE") == "1"
+    try:
+        import comfy_extras.nodes_sparse_attention as nodes
+    except Exception as exc:  # noqa: BLE001
+        if required:
+            pytest.fail(f"required measure-capable core BSA fixture failed to import: {exc}")
+        pytest.skip(f"measure-capable core BSA fixture unavailable: {exc}")
+    if core_bsa_compat._module_blob_sha(nodes) not in core_bsa_compat.MEASURE_CAPABLE_BSA_GIT_BLOBS:
+        if required:
+            pytest.fail("required measure-capable core BSA source is not loaded")
+        pytest.skip("this ComfyUI fixture is not the reviewed measure-capable BSA source")
+    if core_bsa_compat._module_blob_sha(nodes.measure) not in core_bsa_compat.AUDITED_BSA_MEASURE_GIT_BLOBS:
+        if required:
+            pytest.fail("required optional-VDN-correct measure adapter is not loaded")
+        pytest.skip("this ComfyUI fixture predates the optional-VDN measure adapter")
+    return nodes
+
+
+def _vdn_modules():
+    required = os.getenv("SPECTRUM_REQUIRE_REVIEWED_BSA_MEASURE_FIXTURE") == "1"
+    try:
+        from vdn_h3 import hybrid
+        import vdn_h3.mixed_measure_epilogue as epilogue
+    except Exception as exc:  # noqa: BLE001
+        if required:
+            pytest.fail(f"required reviewed VDN fixture failed to import: {exc}")
+        pytest.skip(f"reviewed VDN fixture unavailable: {exc}")
+    if (
+        core_bsa_compat._module_blob_sha(hybrid)
+        not in vdn_measure_compat.AUDITED_VDN_HYBRID_GIT_BLOBS
+        or core_bsa_compat._module_blob_sha(epilogue)
+        not in vdn_measure_compat.AUDITED_VDN_EPILOGUE_GIT_BLOBS
+    ):
+        if required:
+            pytest.fail("required reviewed VDN epilogue source is not loaded")
+        pytest.skip("this VDN fixture is not the reviewed epilogue source")
+    return hybrid, epilogue
+
+
+class _Attention:
+    def __init__(self):
+        self.heads = 2
+        self.head_dim = 128
+        self.qkv_proj = SimpleNamespace(
+            weight=torch.empty(1, dtype=torch.bfloat16, device="cpu")
+        )
+        norm_weight = torch.ones(128, dtype=torch.bfloat16, device="cpu")
+        self.q_norm = SimpleNamespace(weight=norm_weight, eps=1e-6)
+        self.k_norm = SimpleNamespace(weight=norm_weight.clone(), eps=1e-6)
+        self.out_proj = torch.nn.Identity()
+
+    def forward(self, x, rope_freqs=None, transformer_options=None):
+        return x
+
+
+class _Block:
+    def __init__(self):
+        self.attn = _Attention()
+
+
+class _Model:
+    def __init__(self, count=2):
+        self.blocks = [_Block() for _ in range(count)]
+        self.dtype = torch.bfloat16
+
+
+def _layout():
+    return SimpleNamespace(
+        seq_len=192,
+        signature=(64, 2, 16, 16, 16),
+        segments=[
+            (0, 64, "text"),
+            (64, 96, "audio"),
+            (96, 192, "video"),
+        ],
+    )
+
+
+def _request():
+    return {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+        "q_rows": 192,
+        "kv_rows": 192,
+        "video_start": 96,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_grid": [4, 8],
+        "prefix_grid": [8, 8],
+        "segments": [
+            {"start": 0, "stop": 96, "mass_num": 1, "mass_den": 1},
+            {"start": 96, "stop": 160, "mass_num": 1, "mass_den": 2},
+            {"start": 160, "stop": 192, "mass_num": 1, "mass_den": 1},
+        ],
+    }
+
+
+def _external():
+    return {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 160,
+        "sequence_rows": 192,
+        "video_start": 96,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 32,
+        "prefix_rows_per_frame": 64,
+    }
+
+
+def _install(monkeypatch, *, count=2, with_vdn=False):
+    nodes = _measure_nodes()
+    model = _Model(count)
+    state = None
+    if with_vdn:
+        hybrid, _epilogue = _vdn_modules()
+        branches = [SimpleNamespace() for _ in range(count)]
+        state = SimpleNamespace(
+            name="spectrum-vdn-fixture",
+            cfg={"enable_softmax_gate": True},
+            branches=branches,
+            managed_weights=None,
+            layout=SimpleNamespace(
+                seq_len=160,
+                video_start=96,
+                num_frames=2,
+                tokens_per_frame=32,
+            ),
+        )
+        for index, block in enumerate(model.blocks):
+            block.attn.forward = hybrid.make_vdn_forward(block.attn, state, index)
+
+    patch = nodes.SparseAttnPatch(
+        tau=1.0,
+        topk_ratio=0.0,
+        vsa=False,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=1,
+        dense_blocks=set(),
+        sink_conditioning="exact_kv",
+        extra_tokens=0,
+        verbose=False,
+    )
+    override = nodes.make_attention_override(patch, None)
+    patch.installed.add(override)
+    options = {
+        "callbacks": {"on_prepare_state": {"block_sparse_attention": []}},
+        "optimized_attention_override": override,
+        "patches_replace": {
+            "dit": {
+                ("double_block", index): nodes.make_h3_block_patch(block, index, patch)
+                for index, block in enumerate(model.blocks)
+            }
+        },
+        "sigmas": torch.tensor([0.5]),
+        "uuids": ("positive",),
+        "minimax_h3_layout": _layout(),
+        core_bsa_compat.ATTENTION_MEASURE_KEY: _request(),
+        "vdn_h3_external_sequence_v1": _external(),
+    }
+    nodes.measure.register(patch, options)
+    monkeypatch.setattr(
+        core_bsa_compat, "_sparse_runtime_eligible", lambda _model, _module: True
+    )
+    monkeypatch.setattr(nodes.measure, "supports_key_bias", lambda _provider: True)
+    return model, state, patch, options
+
+
+def test_api2_mixed_geometry_without_vdn_remains_forecast_safe(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, with_vdn=False)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+
+    assert reason is None
+    assert audit is not None and audit.safe and audit.measure is not None
+    assert audit.measure.vdn.active is False
+    assert vdn_measure_compat.identity(audit.measure.vdn) == ("absent",)
+    assert all(
+        vdn_measure_compat.VDN_EPILOGUE_KEY not in receipt[8]
+        for receipt in audit.expected_receipts
+    )
+
+    prepared = core_bsa_compat.instrument_actual_options(
+        {**options, "attention_backend_receipts_v1": []},
+        audit,
+        "attention_backend_receipts_v1",
+    )
+    assert vdn_measure_compat.VDN_EPILOGUE_RECEIPTS_KEY not in prepared
+
+
+def test_absent_vdn_bound_forward_identity_is_stable_and_owner_sensitive(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, count=1, with_vdn=False)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+    vdn = audit.measure.vdn
+
+    # Re-reading a normal Python bound method creates a fresh bound-method object;
+    # that must not look like an attention-owner change.
+    assert vdn_measure_compat.runtime_matches(vdn, 0)
+
+    # Rebinding the same class function to another attention instance is a real
+    # owner change and must still invalidate the preflight.
+    other = _Attention()
+    model.blocks[0].attn.forward = other.forward
+    assert not vdn_measure_compat.runtime_matches(vdn, 0)
+
+
+def test_reviewed_vdn_owner_enters_identity_and_sparse_receipt(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, with_vdn=True)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+
+    assert reason is None
+    assert audit is not None and audit.safe and audit.measure is not None
+    vdn = audit.measure.vdn
+    assert vdn.active is True
+    assert vdn.hybrid_blob in vdn_measure_compat.AUDITED_VDN_HYBRID_GIT_BLOBS
+    assert vdn.epilogue_blob in vdn_measure_compat.AUDITED_VDN_EPILOGUE_GIT_BLOBS
+    assert all(vdn_measure_compat.runtime_matches(vdn, index) for index in range(2))
+    assert any(item[0] == "vdn_epilogue" for item in core_bsa_compat._measure_identity(audit.measure))
+
+    measure_receipt = audit.expected_receipts[0][8]
+    vdn_receipt = measure_receipt[-2]
+    assert vdn_receipt[0] == vdn_measure_compat.VDN_EPILOGUE_KEY
+    assert dict(vdn_receipt[1:])["vdn_completed"] is True
+    assert measure_receipt[-1] is True
+
+    prepared = core_bsa_compat.instrument_actual_options(
+        {**options, "attention_backend_receipts_v1": []},
+        audit,
+        "attention_backend_receipts_v1",
+    )
+    sink = prepared[vdn_measure_compat.VDN_EPILOGUE_RECEIPTS_KEY]
+    assert sink is audit.vdn_receipts
+    assert sink == []
+
+    for index, (route, _sink, _sink_q) in enumerate(audit.route_specs):
+        before = core_bsa_compat._vdn_receipt_before(audit)
+        expected = vdn_measure_compat.expected_receipt(vdn, index, route)
+        assert expected is not None
+        sink.append((index, expected))
+        ok, fields = core_bsa_compat._vdn_receipt_after(audit, index, route, before)
+        assert ok and fields == expected
+    receipts = tuple(
+        core_bsa_compat._receipt(
+            audit,
+            index,
+            route,
+            completed=True,
+            vdn_fields=vdn_measure_compat.expected_receipt(vdn, index, route),
+        )
+        for index, (route, _sink, _sink_q) in enumerate(audit.route_specs)
+    )
+    assert core_bsa_compat.accepts_actual(audit, receipts)
+
+
+def test_vdn_config_change_after_preflight_invalidates_runtime_owner(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+
+    state.cfg["enable_softmax_gate"] = False
+    assert not vdn_measure_compat.runtime_matches(audit.measure.vdn, 0)
+    assert not core_bsa_compat._measure_runtime_matches(
+        audit, 0, options, sparse_selected=True
+    )
+
+
+def test_vdn_execution_context_must_be_active_at_preflight(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    state.layout = None
+
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+
+    assert audit is None
+    assert reason == "vdn_execution_context_unproven"
+
+
+def _deferred_wrapper_options(options, hybrid, state, *, vdn_first=False):
+    spectrum = ("spectrum_minimax_h3", [diffusion_model_wrapper])
+    vdn = ("vdn_h3", [hybrid.make_layout_wrapper(state)])
+    ordered = (vdn, spectrum) if vdn_first else (spectrum, vdn)
+    options["wrappers"] = {"diffusion_model": dict(ordered)}
+
+
+def test_vdn_context_may_be_proven_by_exact_downstream_layout_wrapper(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    hybrid, _epilogue = _vdn_modules()
+    state.layout = None
+    _deferred_wrapper_options(options, hybrid, state)
+
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+
+    assert reason is None
+    assert audit is not None and audit.safe and audit.measure is not None
+    assert audit.measure.vdn.active
+    # Before the downstream wrapper actually runs, runtime acceptance is still
+    # forbidden. The deferred proof applies only to preflight scheduling.
+    assert not vdn_measure_compat.runtime_matches(audit.measure.vdn, 0)
+
+    state.layout = SimpleNamespace(
+        seq_len=160, video_start=96, num_frames=2, tokens_per_frame=32
+    )
+    assert vdn_measure_compat.runtime_matches(audit.measure.vdn, 0)
+
+
+def test_missing_vdn_context_rejects_wrapper_that_is_not_downstream(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    hybrid, _epilogue = _vdn_modules()
+    state.layout = None
+    _deferred_wrapper_options(options, hybrid, state, vdn_first=True)
+
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+
+    assert audit is None
+    assert reason == "vdn_execution_context_unproven"
+
+
+def test_missing_vdn_context_rejects_downstream_wrapper_for_another_state(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    hybrid, _epilogue = _vdn_modules()
+    state.layout = None
+    other = SimpleNamespace()
+    _deferred_wrapper_options(options, hybrid, other)
+
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+
+    assert audit is None
+    assert reason == "vdn_execution_context_unproven"
+
+
+def test_vdn_execution_context_loss_after_preflight_invalidates_runtime(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+
+    state.layout = None
+    assert not vdn_measure_compat.runtime_matches(audit.measure.vdn, 0)
+    assert not core_bsa_compat._measure_runtime_matches(
+        audit, 0, options, sparse_selected=True
+    )
+
+
+def test_vdn_execution_context_geometry_change_invalidates_runtime(monkeypatch):
+    model, state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+
+    state.layout.tokens_per_frame = 31
+    assert not vdn_measure_compat.runtime_matches(audit.measure.vdn, 0)
+
+
+def test_partial_vdn_owner_is_fail_closed(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, count=2, with_vdn=True)
+    model.blocks[1].attn.forward = _Attention().forward
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "vdn_owner_incomplete"
+
+
+def test_vdn_receipt_sink_conflict_is_fail_closed(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    options[vdn_measure_compat.VDN_EPILOGUE_RECEIPTS_KEY] = []
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert audit is None
+    assert reason == "vdn_receipt_ownership_conflict"
+
+
+def test_missing_duplicate_and_wrong_vdn_completion_receipts_are_rejected(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+    vdn = audit.measure.vdn
+    route = audit.route_specs[0][0]
+    expected = vdn_measure_compat.expected_receipt(vdn, 0, route)
+    assert expected is not None
+
+    provider_receipt = core_bsa_compat._receipt(
+        audit, 0, route, completed=True, vdn_fields=expected
+    )
+    audit.vdn_receipts = []
+    assert not core_bsa_compat.accepts_actual(audit, (provider_receipt,))
+
+    audit.vdn_receipts[:] = [(0, expected), (0, expected)]
+    assert not core_bsa_compat.accepts_actual(audit, (provider_receipt,))
+
+    tampered = tuple(
+        (name, False if name == "vdn_completed" else value)
+        for name, value in expected
+    )
+    audit.vdn_receipts[:] = [(0, tampered)]
+    assert not core_bsa_compat.accepts_actual(audit, (provider_receipt,))
+
+
+def test_dense_vdn_route_requires_no_external_epilogue_receipt(monkeypatch):
+    model, _state, _patch, options = _install(monkeypatch, count=1, with_vdn=True)
+    options["sigmas"] = torch.tensor([1.0])
+    audit, reason = core_bsa_compat.probe(options, _layout(), model)
+    assert reason is None and audit is not None and audit.measure is not None
+    assert audit.route_specs[0][0] == "h3_dense"
+    assert vdn_measure_compat.expected_receipt(
+        audit.measure.vdn, 0, "h3_dense"
+    ) is None
+
+    prepared = core_bsa_compat.instrument_actual_options(
+        {**options, "attention_backend_receipts_v1": []},
+        audit,
+        "attention_backend_receipts_v1",
+    )
+    assert prepared[vdn_measure_compat.VDN_EPILOGUE_RECEIPTS_KEY] == []
+    assert vdn_measure_compat.validate_final_receipts(
+        audit.measure.vdn, audit.route_specs, audit.vdn_receipts
+    )


### PR DESCRIPTION
Companion for the Progressive Mixed-Grid attention-measure architecture. This PR extends Spectrum's existing reviewed ComfyUI BlockSparseAttention history path so the explicit weighted key-measure route can forecast only after completed, owner-matched execution evidence.

## What this adds

- source-gated reconstruction of the reviewed Flow Mixed-Grid request instead of trusting opaque wrapper state;
- explicit separation of legacy representative-K/V semantics from `weighted_measure_v1`; legacy serialized workflows are not reinterpreted as weighted;
- source-revision-aware Flow profile semantics: the earlier reviewed Flow blob keeps its historical boolean/profile rules, while current Flow PR #30 blob `41586100e74e43e2efbfc3ef30a9540647f1c8f6` treats an explicit profile as authoritative and uses the legacy boolean only when `measure_profile` is absent/`None`;
- weighted history identity covering the key-measure semantic digest, concrete provider/owner generation, numerical route/profile, exact K-block range and preprocessing identity;
- exact verification of the current actual's raw weighted receipts while excluding the dispatch-local `call_token` from stored numerical history identity, so equivalent successive actuals do not invalidate forecast history solely because preflight allocated a new call token;
- preservation of exact `kmean` / `vscale` object ownership across the accepted sparse-cold -> sparse-primed transition without contaminating their calibration values with the measure;
- preservation of the existing unweighted BSA pool key and the production behavior accepted in #106;
- owner-bound VDN integration: API-2 geometry alone does not imply VDN is installed, while a concrete reviewed VDN owner contributes owner/config/weight/external identity and must produce a completed gate/projection receipt;
- deferred VDN-layout proof for legitimate Spectrum -> VDN wrapper ordering, with live API-2 layout validation still required at actual execution;
- fail-closed handling for partial, stale, foreign or changed VDN ownership;
- no-VDN weighted execution remains legal and forecast-safe when the concrete attention owner is native;
- bound-method identity checks use function + bound owner rather than transient bound-method wrapper identity;
- the weighted Core-BSA source gate accepts the cache-hardened Core adapter only. The earlier adapter that could reuse a cached plan without revalidating live H3/API-2 geometry and capability ownership is not forecast-audited.

The authoritative weighted route retains all mixed Q/K/V rows. Spectrum does not implement key deletion or representative subsampling for this route, does not alter the unweighted calibration identity, and does not add a corrective H3 transformer evaluation.

## Flow profile synchronization

Flow PR #30 advanced from `a6bf395133c8ce496217ca9194f3ab3f2b9181ef` to `8dfb7a2e570458b5078734755b897c7e89ddac8c`. That changed the reviewed `mixed_grid.py` blob from `51b5bb068018f3336d1a036bd0065344788c3e6c` to `41586100e74e43e2efbfc3ef30a9540647f1c8f6` and changed profile authority semantics.

Spectrum now audits both source revisions explicitly instead of applying one interpretation to both:

- old reviewed blob: preserves the old compatibility rule (`attention_measure=True` can upgrade an `off` profile to legacy; incompatible legacy/boolean combinations still fail closed);
- current reviewed blob: `measure_profile=None` preserves legacy boolean semantics, while explicit `off`, `legacy_representative_v1`, or `weighted_measure_v1` is authoritative regardless of the legacy boolean.

Regression coverage proves both generations and directly exercises explicit `off` over `attention_measure=True` and explicit legacy over `attention_measure=False` using the current Flow source.

## Structural validation

The current clean head `78a9a5b36c185a55af59a44c073bc7f8e534bc97` is exactly one implementation commit over Spectrum `main` `455bd357cb45637c8e852f7f448dc57b52de94f8`; no temporary validation workflow files are present in the PR tree.

A targeted synchronization run against current Flow PR #30 head `8dfb7a2e570458b5078734755b897c7e89ddac8c`, Core `8406da920f9df19cbc14b76aef1bcd3dc4cf1119`, and VDN `d5f158a1c1750d79b37cb6ef22b0f14e6a8cbad6` completed **46 passed, 1 skipped** in run `34581322295`. The single skip is the separate Untwist-composition fixture because Untwist was intentionally not installed in that targeted harness.

The exact final one-commit PR head also passes normal CI run `34581917615` successfully across the full matrix, including forecaster smoke, Ruff/compile, focused external compatibility suites, and native MiniMax-H3 tests.

The weighted-receipt identity regression separately proves that changing only the actual dispatch call token does not change stored numerical receipt identity, while route and measure changes still do.

These are structural/CPU test evidence only. They do not establish weighted CUDA numerical correctness, decoded-media parity, or performance.

## Release gates still open

- **CUDA numerical behavior:** post-fix real weighted SM120 execution still required.
- **Compiled Kitchen `chunked_key_bias`:** real CUDA/HIP validation still required.
- **Decoded-media parity:** unvalidated.
- **Weighted performance:** unvalidated.
- Real weighted production execution must still prove the applicable `18 logical / 14 actual / 4 forecast` schedule with no hidden correction NFE.
- VDN and no-VDN production routes both require CUDA receipt/history validation.
- Audio, framing/composition, motion, boundary continuity and reference fidelity still require matched decoded-media A/B validation.

Authoritative architecture: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/blob/3afc6c63063f410afec756c42811a8cf1ad2ed77/docs/MIXED_GRID_MEASURE_ARCHITECTURE.md

Design PR: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/29

Companions:
- Flow implementation: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/30
- ComfyUI core: https://github.com/Comfy-Org/ComfyUI/pull/16239
- comfy-kitchen key bias: https://github.com/Comfy-Org/comfy-kitchen/pull/171
- Sol-H3 provider: https://github.com/xmarre/ComfyUI-Sol-H3/pull/9
- VDN epilogue: https://github.com/xmarre/ComfyUI-VDN-H3-Plus/pull/14